### PR TITLE
fix: prevent CI deadlock on docs-only changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,8 @@ on:
   push:
     tags: [ "v*.*.*" ]
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
   merge_group:
   branch_protection_rule:
   schedule:
@@ -24,9 +20,29 @@ permissions:
   pull-requests: read
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+
   test:
     name: Tests
     runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.code == 'true'
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -47,10 +63,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: medizininformatik-initiative/aether
 
-  e2e-test:
-    name: E2E Tests
+  e2e-test-run:
+    name: E2E Tests - Run
     runs-on: ubuntu-24.04
-    needs: [test]
+    needs: [detect-changes, test]
+    if: needs.detect-changes.outputs.code == 'true'
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -149,3 +166,24 @@ jobs:
       - name: Cleanup Docker services
         if: always()
         run: docker compose -f .github/test/compose.yaml down -v
+
+  e2e-test:
+    name: E2E Tests
+    runs-on: ubuntu-24.04
+    needs: [detect-changes, e2e-test-run]
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Check E2E test results
+        run: |
+          echo "E2E Tests Result: ${{ needs.e2e-test-run.result }}"
+          echo "Code Changed: ${{ needs.detect-changes.outputs.code }}"
+
+          # Pass if e2e-test-run succeeded or was skipped (docs-only changes)
+          if [[ "${{ needs.e2e-test-run.result }}" == "success" ]] || [[ "${{ needs.e2e-test-run.result }}" == "skipped" ]]; then
+            echo "✅ E2E Tests passed or were not required"
+            exit 0
+          else
+            echo "❌ E2E Tests failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Fixes #8 - CI no longer gets stuck when only documentation files are changed.

## Problem

Previously, when only `docs/` files were modified in a PR:
- The `tests.yml` workflow was skipped entirely due to `paths-ignore` filters
- The repository ruleset requires "E2E Tests" status check to pass
- The required check never appeared, causing PRs to get stuck

## Solution

Implemented conditional execution with an always-pass fallback:

1. **detect-changes job**: Determines if non-docs files changed using `dorny/paths-filter`
2. **Conditional execution**: `test` and `e2e-test-run` jobs only run when code changes
3. **Final status check**: New `e2e-test` job always runs and passes if either:
   - Real e2e tests passed (code changed), OR
   - Tests were skipped (docs-only changes)

## Result

- ✅ Docs-only PRs: Required check passes without running full test suite
- ✅ Code PRs: Full test suite runs normally
- ✅ No more CI deadlock
- ✅ Saves CI resources on docs-only changes

## Testing

- [ ] Verify on docs-only PR (e.g., PR #5)
- [ ] Verify on code-change PR
- [ ] Confirm "E2E Tests" check appears and passes in both cases