### PR TITLE
fix: Add id-token permission to attestation job for OIDC token requests

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -65,6 +65,7 @@ jobs:
     permissions:
       attestations: write
       contents: read
+      id-token: write
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,3 +54,4 @@ jobs:
     permissions:
       contents: write
       attestations: write
+      id-token: write


### PR DESCRIPTION
## Problem
Attestation generation was failing with:
```
Failed to get ID token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

## Solution
Added `id-token: write` permission to the `attestation` job in `_release.yaml`.

The `actions/attest-build-provenance@` action requires OIDC token access to generate build provenance attestations. Without this permission, GitHub Actions doesn't set the required environment variables.

## Changes
- Added `id-token: write` to attestation job permissions