### PR TITLE
fix: Rename SBOM file to include architecture suffix to avoid artifact name conflicts

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -101,6 +101,13 @@ jobs:
           format: spdx-json
           output-file: sbom-${{ matrix.arch }}.spdx.json
 
+      - name: Rename SBOM for upload
+        if: always()
+        run: |
+          if [ -f "aether-attestation.spdx.json" ]; then
+            mv aether-attestation.spdx.json sbom-${{ matrix.arch }}.spdx.json
+          fi
+
       - name: Upload SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Problem
The attestation job runs in a matrix for multiple architectures. All matrix jobs were trying to upload SBOM artifacts with the same name (`aether-attestation.spdx.json`), causing:
```
Error: Failed to CreateArtifact: (409) Conflict: an artifact with this name already exists
```

## Root Cause
The `anchore/sbom-action` generates a default filename (`aether-attestation.spdx.json`) regardless of the `output-file` parameter, and all matrix jobs try to upload with the same name.

## Solution
Added a rename step that:
1. Checks for the default SBOM file generated by anchore
2. Renames it to include the architecture suffix: `sbom-${{ matrix.arch }}.spdx.json`
3. Ensures each matrix job uploads a uniquely named artifact

## Files Changed
- `.github/workflows/_release.yaml` - Added rename step before artifact upload