### PR TITLE
fix: Disable anchore auto-upload to prevent SBOM artifact name conflicts

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -100,13 +100,7 @@ jobs:
           path: bin/release/
           format: spdx-json
           output-file: sbom-${{ matrix.arch }}.spdx.json
-
-      - name: Rename SBOM for upload
-        if: always()
-        run: |
-          if [ -f "aether-attestation.spdx.json" ]; then
-            mv aether-attestation.spdx.json sbom-${{ matrix.arch }}.spdx.json
-          fi
+          upload-artifact: false
 
       - name: Upload SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Problem
The SBOM generation job runs in a matrix for multiple architectures, and all jobs were uploading artifacts with the same name, causing a 409 Conflict error:
```
Error: Failed to CreateArtifact: an artifact with this name already exists on the workflow run
```

## Root Cause
The `anchore/sbom-action` was auto-uploading artifacts after generating them, all with the name `aether-attestation.spdx.json`.

## Solution
Disable anchore's auto-upload with `upload-artifact: false` and rely on the manual `actions/upload-artifact@` step that already includes the architecture suffix in the artifact name.

This ensures:
- anchore only generates the SBOM file with the correct name
- Anchore doesn't auto-upload (preventing conflicts)
- Manual upload step handles the upload with unique artifact names per architecture

## Files Changed
- `.github/workflows/_release.yaml` - Added `upload-artifact: false` to anchore action, removed unnecessary rename step