### PR TITLE
feat: Include SBOM attestations in GitHub release assets

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -33,7 +33,7 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-24.04
-    needs: [build]
+    needs: [build, attestation]
     timeout-minutes: 30
     permissions:
       contents: write
@@ -41,16 +41,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
-      - name: Download artifacts
+      - name: Download release artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-artifacts
           path: release/
 
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: sbom-*
+          path: release/sbom/
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
-          files: release/*
+          files: |
+            release/*
+            release/sbom/**/*.spdx.json
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary
Include SBOM (Software Bill of Materials) attestations as downloadable assets in GitHub releases for supply chain transparency and verification.

## Changes
- Make `publish` job depend on `attestation` job to ensure attestations are generated before release
- Download SBOM artifacts from all build architectures
- Include SBOM files in GitHub release assets alongside binaries

## Why
- **Provenance**: Provides build provenance for each binary
- **Supply chain security**: SBOM allows users to verify dependencies
- **Transparency**: Makes attestations easily accessible from the release page

## Artifacts Included in Release
- Binary releases (existing)
- SBOM files for each architecture (new):
  - sbom-linux-amd64.spdx.json
  - sbom-darwin-amd64.spdx.json
  - sbom-darwin-arm64.spdx.json
  - sbom-windows-amd64.spdx.json
  - sbom-windows-arm64.spdx.json