### PR TITLE
feat: Add cosign signing for release artifacts

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -30,6 +30,39 @@ jobs:
           path: bin/release/
           retention-days: 1
 
+  sign:
+    name: Sign Release Artifacts
+    runs-on: ubuntu-24.04
+    needs: [build]
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-artifacts
+          path: release/
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+      - name: Sign release artifacts
+        run: |
+          for file in release/*; do
+            if [ -f "$file" ]; then
+              echo "Signing $file..."
+              cosign sign-blob --yes "$file" --output-signature "${file}.sig"
+            fi
+          done
+
+      - name: Upload signatures
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: signatures
+          path: release/*.sig
+          retention-days: 1
+
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-24.04
@@ -57,7 +90,7 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-24.04
-    needs: [build, attestation, sbom]
+    needs: [build, attestation, sbom, sign]
     timeout-minutes: 30
     permissions:
       contents: write
@@ -75,6 +108,12 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: sbom
+          path: release/
+
+      - name: Download signatures
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: signatures
           path: release/
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Add cosign keyless signing for binary release artifacts
- Signature files (`.sig`) are now included in GitHub releases alongside binaries
- Uses GitHub OIDC for keyless signing (no key management required)

## Changes
- New `sign` job in release workflow that signs all binary artifacts with `cosign sign-blob`
- Updated `publish` job to include signature files in releases

## Verification
Users can verify downloaded artifacts with:
```bash
cosign verify-blob \
  --certificate-identity-regexp="https://github.com/medizininformatik-initiative/aether/.*" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
  --signature aether-v1.0.0-linux-amd64.tar.gz.sig \
  aether-v1.0.0-linux-amd64.tar.gz
```

## Test plan
- [ ] Create a test release tag to verify the workflow executes correctly
- [ ] Verify `.sig` files appear in the GitHub release assets
- [ ] Test signature verification with `cosign verify-blob`