### PR TITLE
fix: Stop rewriting localhost URLs from TORCH responses

### DIFF
--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -575,16 +575,15 @@ func (c *TORCHClient) makeAbsoluteURL(rawURL string) string {
 	}
 
 	// Check if this is an internal hostname that should be rewritten to use our configured baseURL
-	// Internal hostnames include:
+	// Internal hostnames are Docker container names only:
 	// - torch: TORCH API service (container internal)
 	// - torch-proxy: reverse proxy service (container internal)
-	// - localhost/127.0.0.1: loopback addresses used internally
+	// Note: localhost/127.0.0.1 are NOT rewritten - TORCH returns correct external URLs
+	// that may use a different port than the configured baseURL
 	hostname := torchURL.Hostname()
 	internalHosts := map[string]bool{
 		"torch":       true,
 		"torch-proxy": true,
-		"localhost":   true,
-		"127.0.0.1":   true,
 	}
 
 	if internalHosts[hostname] {


### PR DESCRIPTION
## Summary

- Fix 404 errors when downloading TORCH extraction files
- TORCH `__status` responses return correct external URLs (e.g., `http://localhost/uuid/file.ndjson` served by nginx on port 80)
- `makeAbsoluteURL` was incorrectly rewriting these to use the configured base URL (e.g., `http://localhost:8086/...`)
- Remove `localhost` and `127.0.0.1` from internal hostname rewriting - only Docker container names (`torch`, `torch-proxy`) are now rewritten

## Test plan

- [x] All existing unit tests pass
- [ ] Manual test with actual TORCH deployment to verify file downloads work