### PR TITLE
fix: Apply least privilege principle to workflow permissions

### DIFF
--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -3,6 +3,8 @@ name: Lint
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -3,6 +3,8 @@ name: Release
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   build:
     name: Build Release

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -8,6 +8,8 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 jobs:
   detect-changes:
     name: Detect Changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ permissions:
   contents: read
   pull-requests: read
   actions: read
-  security-events: write
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Add explicit `permissions: {}` to reusable workflows to ensure they start with no default permissions
- Remove `security-events: write` from ci.yaml top-level (already set at job-level for codeql)
- Improves OpenSSF Scorecard Token-Permissions check

## Changes
| File | Change |
|------|--------|
| `_lint.yaml` | Added `permissions: {}` |
| `_tests.yaml` | Added `permissions: {}` |
| `_release.yaml` | Added `permissions: {}` |
| `ci.yaml` | Removed top-level `security-events: write` |

## Test plan
- [ ] CI workflows still pass
- [ ] Re-run OpenSSF Scorecard to verify improved Token-Permissions score