### PR TITLE
fix: update Renovate config to fix invalid org references

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":enableVulnerabilityAlerts"
   ],
   "go": {
@@ -14,9 +14,6 @@
   "vulnerabilityAlerts": {
     "labels": [
       "security"
-    ],
-    "assignees": [
-      "@medizininformatik-initiative"
     ]
   },
   "packageRules": [
@@ -35,10 +32,7 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "automerge": false,
-      "reviewers": [
-        "@medizininformatik-initiative"
-      ]
+      "automerge": false
     },
     {
       "description": "Group GitHub Actions updates",


### PR DESCRIPTION
## Summary
- Update deprecated `config:base` preset to `config:best-practices`
- Remove invalid `assignees` field (GitHub org cannot be assignee)
- Remove invalid `reviewers` field (GitHub org cannot be reviewer)

## Test plan
- [ ] Renovate should re-process the repository after merge
- [ ] Issue #28 should auto-close via "Closes #28" in commit message

Closes #28