### PR TITLE
fix: use correct type for semanticCommits in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "semanticCommits": true,
+  "semanticCommits": "enabled",
   "vulnerabilityAlerts": {
     "labels": [
       "security"


### PR DESCRIPTION
## Summary
- Change `semanticCommits: true` (boolean) to `semanticCommits: "enabled"` (string)

The Renovate schema requires `semanticCommits` to be one of: `"auto"`, `"enabled"`, `"disabled"` - not a boolean.

## Test plan
- [ ] Renovate should stop complaining after merge
- [ ] Issue #30 should auto-close

Closes #30