### PR TITLE
refactor: simplify Renovate config to minimal setup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,53 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    ":enableVulnerabilityAlerts"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "docker:pinDigests"
   ],
-  "go": {
-    "enabled": true
-  },
-  "postUpdateOptions": [
-    "gomodTidy"
-  ],
-  "semanticCommits": "enabled",
-  "vulnerabilityAlerts": {
-    "labels": [
-      "security"
-    ]
-  },
-  "packageRules": [
-    {
-      "description": "Automatically merge minor and patch updates for Go dependencies",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
-    },
-    {
-      "description": "Require manual review for major version updates",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "automerge": false
-    },
-    {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "GitHub Actions",
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
-    }
-  ],
-  "schedule": [
-    "after 10pm every weekday",
-    "before 5am every weekday",
-    "every weekend"
-  ]
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 3
 }


### PR DESCRIPTION
## Summary
Replace complex custom Renovate configuration with minimal blazectl-style setup.

**Before**: 53 lines with custom automerge rules, schedules, semantic commits
**After**: 10 lines using recommended defaults

## What's included in `config:recommended`
- Dependency Dashboard
- Sensible update grouping
- Security vulnerability alerts
- Go module support (auto-detected)

## Changes
- Use `config:recommended` preset instead of `config:best-practices`
- Pin GitHub Actions digests for security
- Pin Docker digests for reproducibility
- Add "dependencies" label to all Renovate PRs
- Limit to 3 concurrent PRs

## What's removed
- Custom automerge rules (use Renovate defaults)
- Custom schedules (updates anytime)
- Semantic commits config (use Renovate default)
- Explicit Go enablement (auto-detected)
- Custom vulnerability alert labels

## Test plan
- [ ] Renovate processes repo without errors
- [ ] Dependency PRs are created with "dependencies" label