### PR TITLE
docs: add releases section to documentation navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vitepress'
 
+const version = process.env.VITE_LATEST_RELEASE || 'v0.1.0'
+
 export default defineConfig({
   title: 'Aether',
   description: 'Healthcare Data Integration Platform',
@@ -19,6 +21,27 @@ export default defineConfig({
     // Logo and site branding
     logo: '/assets/logo.svg',
     siteTitle: 'Aether',
+
+    // Top navigation bar
+    nav: [
+      {
+        text: version,
+        items: [
+          {
+            text: 'Issues',
+            link: 'https://github.com/medizininformatik-initiative/aether/issues'
+          },
+          {
+            text: 'Discussions',
+            link: 'https://github.com/medizininformatik-initiative/aether/discussions'
+          },
+          {
+            text: 'Releases',
+            link: 'https://github.com/medizininformatik-initiative/aether/releases'
+          }
+        ]
+      }
+    ],
 
     // Navigation sidebar
     sidebar: {


### PR DESCRIPTION
## Summary
- Adds a version dropdown in the top navigation bar of the documentation site
- Links to GitHub Issues, Discussions, and Releases
- Follows the pattern used in [fts-next documentation](https://github.com/medizininformatik-initiative/fts-next)

## Test plan
- [ ] Verify docs build successfully (`npm run docs:build` in docs/)
- [ ] Check navigation dropdown appears in local dev server
- [ ] Confirm links point to correct GitHub pages

Closes #49