### PR TITLE
docs: link feature cards to their documentation pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,13 @@ features:
   - icon: 🔗
     title: TORCH Integration
     details: Extract patient data from TORCH servers using CRTDL queries
+    link: /guides/torch-integration
   - icon: 🔐
     title: DIMP Pseudonymization
     details: Protect patient privacy by pseudonymizing FHIR data
+    link: /guides/dimp-pseudonymization
   - icon: ⚙️
     title: Simple Configuration
     details: One YAML file to configure everything
+    link: /getting-started/configuration
 ---


### PR DESCRIPTION
## Summary
- Add links to the three feature cards on the documentation landing page
- TORCH Integration links to `/guides/torch-integration`
- DIMP Pseudonymization links to `/guides/dimp-pseudonymization`
- Simple Configuration links to `/getting-started/configuration`

Closes #76