### PR TITLE
docs: fix redundant DIMP Pseudonymization naming

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,7 +61,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'TORCH Integration', link: '/guides/torch-integration' },
-            { text: 'DIMP Pseudonymization', link: '/guides/dimp-pseudonymization' },
+            { text: 'DIMP', link: '/guides/dimp' },
             { text: 'Pipeline Steps', link: '/guides/pipeline-steps' }
           ]
         },

--- a/docs/guides/dimp.md
+++ b/docs/guides/dimp.md
@@ -1,6 +1,6 @@
-# DIMP Pseudonymization
+# DIMP
 
-DIMP provides de-identification and pseudonymization for FHIR data, protecting patient privacy while keeping the data useful for research.
+DIMP (**D**e-identify, **M**inimize, **P**seudonymize) provides de-identification, minimization, and pseudonymization for FHIR data, protecting patient privacy while keeping the data useful for research.
 
 ## What DIMP Does
 
@@ -33,7 +33,7 @@ aether pipeline start your-query.crtdl
 
 Aether will:
 1. Extract data from TORCH (or import from files)
-2. Send it to DIMP for pseudonymization
+2. Send it to DIMP for dimping
 3. Save the protected data in the jobs folder
 
 ## Output

--- a/docs/guides/pipeline-steps.md
+++ b/docs/guides/pipeline-steps.md
@@ -32,7 +32,7 @@ Removes or masks identifying information to protect patient privacy.
 
 **What it does:**
 - Sends FHIR data to the DIMP service
-- Receives pseudonymized data back
+- Receives dimped data back
 - Saves the protected data
 
 **Configuration:**
@@ -55,7 +55,7 @@ Most users will run both steps together:
 pipeline:
   enabled_steps:
     - torch   # First: get data from TORCH
-    - dimp    # Then: pseudonymize it
+    - dimp    # Then: dimp it
 ```
 
 Run with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Aether
   text: FHIR Data Processing Tool
-  tagline: Extract data from TORCH and pseudonymize it with DIMP
+  tagline: Extract, dimp, validate, and flatten FHIR data
   actions:
     - theme: brand
       text: Get Started
@@ -19,9 +19,9 @@ features:
     details: Extract patient data from TORCH servers using CRTDL queries
     link: /guides/torch-integration
   - icon: 🔐
-    title: DIMP Pseudonymization
-    details: Protect patient privacy by pseudonymizing FHIR data
-    link: /guides/dimp-pseudonymization
+    title: DIMP
+    details: De-identify, Minimize, Pseudonymize - Protect patient privacy by dimping FHIR data
+    link: /guides/dimp
   - icon: ⚙️
     title: Simple Configuration
     details: One YAML file to configure everything


### PR DESCRIPTION
## Summary
- Rename `dimp-pseudonymization.md` to `dimp.md` (DIMP already contains "Pseudonymization")
- Update navigation and landing page links
- Replace "pseudonymized/pseudonymizing" terminology with "dimped/dimping"
- Add DIMP acronym explanation: **D**e-identify, **M**inimize, **P**seudonymize

## Test plan
- [ ] Verify docs build successfully
- [ ] Check navigation links resolve correctly
- [ ] Confirm landing page card displays properly

Closes #83