### PR TITLE
refactor(models): remove unused ResourceType field from FHIRDataFile

### DIFF
--- a/internal/models/file.go
+++ b/internal/models/file.go
@@ -9,13 +9,12 @@ import (
 
 // FHIRDataFile represents a single FHIR NDJSON file in the pipeline
 type FHIRDataFile struct {
-	FileName     string    `json:"file_name"`
-	FilePath     string    `json:"file_path"`     // Relative to job directory
-	ResourceType string    `json:"resource_type"` // e.g., "Patient", "Observation"
-	FileSize     int64     `json:"file_size"`     // Bytes
-	SourceStep   StepName  `json:"source_step"`   // Which step produced this file
-	LineCount    int       `json:"line_count"`    // Number of FHIR resources
-	CreatedAt    time.Time `json:"created_at"`
+	FileName   string    `json:"file_name"`
+	FilePath   string    `json:"file_path"`   // Relative to job directory
+	FileSize   int64     `json:"file_size"`   // Bytes
+	SourceStep StepName  `json:"source_step"` // Which step produced this file
+	LineCount  int       `json:"line_count"`  // Number of FHIR resources
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 // IsValidFHIRFile checks if the file has valid FHIR NDJSON format
@@ -39,24 +38,6 @@ func IsSafePath(path string) bool {
 	}
 
 	return true
-}
-
-// GetResourceTypeFromFilename attempts to extract resource type from filename
-// Example: "Patient_001.ndjson" -> "Patient"
-// Example: "Patient_001.ndjson.zst" -> "Patient"
-func GetResourceTypeFromFilename(filename string) string {
-	base := strings.TrimSuffix(filename, ".zst")
-	base = strings.TrimSuffix(base, ".ndjson")
-
-	parts := strings.FieldsFunc(base, func(r rune) bool {
-		return r == '_' || r == '-' || r == '.'
-	})
-
-	if len(parts) > 0 {
-		return parts[0]
-	}
-
-	return "Unknown"
 }
 
 // GetNormalizedBaseName returns the base filename without compression extension.

--- a/internal/services/downloader.go
+++ b/internal/services/downloader.go
@@ -93,18 +93,15 @@ func DownloadFromURL(url string, destinationDir string, httpClient *HTTPClient, 
 		lineCount = 0
 	}
 
-	resourceType := models.GetResourceTypeFromFilename(outputFileName)
-
 	logger.Info("File downloaded successfully", "file", outputFileName, "size", fileSize, "resources", lineCount, "compressed", compress)
 
 	downloadedFile := models.FHIRDataFile{
-		FileName:     outputFileName,
-		FilePath:     outputFileName, // Relative to job import directory
-		ResourceType: resourceType,
-		FileSize:     fileSize,
-		SourceStep:   models.StepHttpImport,
-		LineCount:    lineCount,
-		CreatedAt:    lib.GetFileModTime(destPath),
+		FileName:   outputFileName,
+		FilePath:   outputFileName, // Relative to job import directory
+		FileSize:   fileSize,
+		SourceStep: models.StepHttpImport,
+		LineCount:  lineCount,
+		CreatedAt:  lib.GetFileModTime(destPath),
 	}
 
 	return []models.FHIRDataFile{downloadedFile}, nil
@@ -179,18 +176,16 @@ func DownloadFromURLWithProgress(url string, destinationDir string, httpClient *
 	}
 
 	lineCount, _ := lib.CountResourcesInFile(destPath)
-	resourceType := models.GetResourceTypeFromFilename(outputFileName)
 
 	logger.Info("Download completed", "file", outputFileName, "size", fileSize, "resources", lineCount, "compressed", compress)
 
 	downloadedFile := models.FHIRDataFile{
-		FileName:     outputFileName,
-		FilePath:     outputFileName,
-		ResourceType: resourceType,
-		FileSize:     fileSize,
-		SourceStep:   models.StepHttpImport,
-		LineCount:    lineCount,
-		CreatedAt:    lib.GetFileModTime(destPath),
+		FileName:   outputFileName,
+		FilePath:   outputFileName,
+		FileSize:   fileSize,
+		SourceStep: models.StepHttpImport,
+		LineCount:  lineCount,
+		CreatedAt:  lib.GetFileModTime(destPath),
 	}
 
 	return []models.FHIRDataFile{downloadedFile}, nil

--- a/internal/services/importer.go
+++ b/internal/services/importer.go
@@ -161,18 +161,15 @@ func copyFile(sourcePath string, destDir string, logger *lib.Logger, compress bo
 		lineCount = 0
 	}
 
-	resourceType := models.GetResourceTypeFromFilename(outputFileName)
-
 	logger.Debug("File imported", "file", outputFileName, "size", fileSize, "resources", lineCount, "compressed", compress)
 
 	return models.FHIRDataFile{
-		FileName:     outputFileName,
-		FilePath:     outputFileName, // Relative to job import directory
-		ResourceType: resourceType,
-		FileSize:     fileSize,
-		SourceStep:   models.StepLocalImport,
-		LineCount:    lineCount,
-		CreatedAt:    srcInfo.ModTime(),
+		FileName:   outputFileName,
+		FilePath:   outputFileName, // Relative to job import directory
+		FileSize:   fileSize,
+		SourceStep: models.StepLocalImport,
+		LineCount:  lineCount,
+		CreatedAt:  srcInfo.ModTime(),
 	}, nil
 }
 

--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -395,16 +395,14 @@ func (c *TORCHClient) downloadFile(fileURL, destPath string, compress bool, comp
 	lineCount, _ := lib.CountResourcesInFile(destPath)
 
 	fileName := filepath.Base(destPath)
-	resourceType := models.GetResourceTypeFromFilename(fileName)
 
 	return models.FHIRDataFile{
-		FileName:     fileName,
-		FilePath:     fileName, // Relative to job directory
-		ResourceType: resourceType,
-		FileSize:     fileSize,
-		SourceStep:   models.StepTorchImport,
-		LineCount:    lineCount,
-		CreatedAt:    lib.GetFileModTime(destPath),
+		FileName:   fileName,
+		FilePath:   fileName, // Relative to job directory
+		FileSize:   fileSize,
+		SourceStep: models.StepTorchImport,
+		LineCount:  lineCount,
+		CreatedAt:  lib.GetFileModTime(destPath),
 	}, nil
 }
 

--- a/tests/unit/import_local_test.go
+++ b/tests/unit/import_local_test.go
@@ -56,15 +56,6 @@ func TestImportFromLocalDirectory_Success(t *testing.T) {
 		assert.Equal(t, models.StepLocalImport, imported.SourceStep, "SourceStep should be import")
 		assert.Equal(t, 1, imported.LineCount, "LineCount should be 1 for single-line files")
 	}
-
-	// Verify resource types are extracted correctly
-	resourceTypes := make(map[string]bool)
-	for _, file := range importedFiles {
-		resourceTypes[file.ResourceType] = true
-	}
-	assert.True(t, resourceTypes["Patient"], "Patient resource type should be identified")
-	assert.True(t, resourceTypes["Observation"], "Observation resource type should be identified")
-	assert.True(t, resourceTypes["Bundle"], "Bundle resource type should be identified")
 }
 
 // TestImportFromLocalDirectory_NonexistentDirectory verifies error handling for missing source directory

--- a/tests/unit/import_url_test.go
+++ b/tests/unit/import_url_test.go
@@ -49,7 +49,6 @@ func TestDownloadFromURL_Success(t *testing.T) {
 	assert.Equal(t, "Patient.ndjson", downloaded.FileName, "FileName should be extracted from URL")
 	assert.Greater(t, downloaded.FileSize, int64(0), "FileSize should be > 0")
 	assert.Equal(t, models.StepHttpImport, downloaded.SourceStep, "SourceStep should be import")
-	assert.Equal(t, "Patient", downloaded.ResourceType, "ResourceType should be extracted from filename")
 	assert.Equal(t, 3, downloaded.LineCount, "Should count 3 lines/resources")
 
 	// Verify file was saved
@@ -409,7 +408,6 @@ func TestDownloadFromURL_WithCompression(t *testing.T) {
 	assert.Equal(t, "Patient.ndjson.zst", downloaded.FileName, "FileName should have .zst extension")
 	assert.Greater(t, downloaded.FileSize, int64(0), "FileSize should be > 0")
 	assert.Equal(t, models.StepHttpImport, downloaded.SourceStep, "SourceStep should be import")
-	assert.Equal(t, "Patient", downloaded.ResourceType, "ResourceType should be extracted from filename")
 	assert.Equal(t, 3, downloaded.LineCount, "Should count 3 lines/resources")
 
 	// Verify compressed file was saved

--- a/tests/unit/models_validation_test.go
+++ b/tests/unit/models_validation_test.go
@@ -151,12 +151,11 @@ func TestFHIRDataFile_Validate(t *testing.T) {
 		{
 			name: "Valid NDJSON file",
 			file: models.FHIRDataFile{
-				FileName:     "Patient.ndjson",
-				FilePath:     "safe/path/Patient.ndjson",
-				FileSize:     1024,
-				LineCount:    100,
-				ResourceType: "Patient",
-				SourceStep:   models.StepLocalImport,
+				FileName:   "Patient.ndjson",
+				FilePath:   "safe/path/Patient.ndjson",
+				FileSize:   1024,
+				LineCount:  100,
+				SourceStep: models.StepLocalImport,
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Summary

- Remove unused `ResourceType` field from `FHIRDataFile` struct
- Remove `GetResourceTypeFromFilename` function (dead code)
- Clean up all usages in importer, downloader, and torch_client services
- Update tests to remove ResourceType assertions

## Context

The `ResourceType` field was populated during file import by extracting the resource type from the filename using heuristics, but this metadata was never read by any production code - only tests verified the extraction logic. Since extracting resource type from filename is unreliable (filename may not match actual content), and the field served no functional purpose, it has been removed.

Note: `GetNormalizedBaseName` was kept as it's still used by `DetectDuplicateFHIRFiles` for duplicate detection.

Closes #93

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass
- [x] All contract tests pass
- [x] Linter passes with 0 issues