### PR TITLE
feat(pipeline): add send step for DSF transfer preparation

### DIFF
--- a/.github/scripts/run-e2e-test.sh
+++ b/.github/scripts/run-e2e-test.sh
@@ -32,6 +32,7 @@ echo ""
 echo "Running aether E2E test inside Docker network..."
 echo "  TORCH: http://torch-proxy:80 (internal)"
 echo "  DIMP: http://fhir-pseudonymizer:8080 (internal)"
+echo "  Blaze (send target): http://blaze-fhir:8080/fhir (internal)"
 
 # Run aether inside the Docker network where it can resolve internal hostnames
 # Capture output to extract job ID
@@ -103,6 +104,35 @@ if echo "$OUTPUT" | grep -q "Pipeline paused at wait step"; then
         fi
     done
 fi
+
+echo ""
+echo "Verifying send step: checking Blaze FHIR server for transferred resources..."
+
+# Verify DocumentReference was created on the Blaze FHIR server
+SEND_VERIFY=$(docker compose exec -T aether-runner sh -c '
+    DOC_REF_RESPONSE=$(curl --silent --show-error "http://blaze-fhir:8080/fhir/DocumentReference?_summary=count")
+    DOC_REF_COUNT=$(echo "$DOC_REF_RESPONSE" | grep -o "\"total\":[0-9]*" | grep -o "[0-9]*" || echo "0")
+    BINARY_RESPONSE=$(curl --silent --show-error "http://blaze-fhir:8080/fhir/Binary?_summary=count")
+    BINARY_COUNT=$(echo "$BINARY_RESPONSE" | grep -o "\"total\":[0-9]*" | grep -o "[0-9]*" || echo "0")
+
+    echo "DocumentReference count: $DOC_REF_COUNT"
+    echo "Binary count: $BINARY_COUNT"
+
+    if [ "$DOC_REF_COUNT" -lt 1 ]; then
+        echo "FAIL: Expected at least 1 DocumentReference on transfer server"
+        exit 1
+    fi
+    if [ "$BINARY_COUNT" -lt 1 ]; then
+        echo "FAIL: Expected at least 1 Binary on transfer server"
+        exit 1
+    fi
+    echo "PASS: Send step verified successfully"
+') || {
+    echo "$SEND_VERIFY"
+    echo "Send step verification failed"
+    exit 1
+}
+echo "$SEND_VERIFY"
 
 echo ""
 echo "E2E test completed for job: $JOB_ID"

--- a/.github/test/Makefile
+++ b/.github/test/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Aether Test Infrastructure
 # Located in .github/test/
 
-.PHONY: help services start stop torch-up torch-down torch-logs torch-test dimp-up dimp-down dimp-test flattener-up flattener-down flattener-logs test-with-services download-testdata upload-testdata e2e-test e2e-test-flattening clean-test-data
+.PHONY: help services start stop torch-up torch-down torch-logs torch-test dimp-up dimp-down dimp-test flattener-up flattener-down flattener-logs blaze-up blaze-down blaze-logs test-with-services download-testdata upload-testdata e2e-test e2e-test-flattening clean-test-data
 
 # Default target
 .DEFAULT_GOAL := help
@@ -32,6 +32,9 @@ help:
 	@echo "  flattener-up      Start fhir-flattener service"
 	@echo "  flattener-down    Stop fhir-flattener service"
 	@echo "  flattener-logs    Show fhir-flattener service logs"
+	@echo "  blaze-up          Start Blaze FHIR server (DSF transfer target)"
+	@echo "  blaze-down        Stop Blaze FHIR server"
+	@echo "  blaze-logs        Show Blaze FHIR server logs"
 	@echo "  test-with-services Run all tests with required services"
 	@echo "  download-testdata Download test data (only if not present)"
 	@echo "  upload-testdata   Upload test data to TORCH (requires services)"
@@ -133,6 +136,23 @@ flattener-down:
 flattener-logs:
 	@echo "Showing fhir-flattener service logs..."
 	cd flattener && docker compose logs -f
+
+## blaze-up: Start Blaze FHIR server (DSF transfer target for send step)
+blaze-up:
+	@echo "Starting Blaze FHIR server..."
+	cd blaze && docker compose up -d
+	@echo "✓ Blaze FHIR server starting (may take up to 60s for healthcheck)"
+
+## blaze-down: Stop Blaze FHIR server
+blaze-down:
+	@echo "Stopping Blaze FHIR server..."
+	cd blaze && docker compose down
+	@echo "✓ Blaze FHIR server stopped"
+
+## blaze-logs: Show Blaze FHIR server logs
+blaze-logs:
+	@echo "Showing Blaze FHIR server logs..."
+	cd blaze && docker compose logs -f
 
 ## dimp-test: Run integration tests with DIMP service
 dimp-test:

--- a/.github/test/aether.yaml
+++ b/.github/test/aether.yaml
@@ -40,6 +40,12 @@ services:
       - csv
     timeout: 30m
 
+  # DSF Transfer Server (Blaze FHIR server for e2e testing)
+  send:
+    server_url: "http://blaze-fhir:8080/fhir"
+    project_identifier: "MII-E2E-TEST"
+    organization_identifier: "e2e-test.hospital.de"
+
 pipeline:
   # List of steps to execute in order
   # Options: import, dimp, validation, csv_conversion, parquet_conversion
@@ -49,6 +55,7 @@ pipeline:
     - wait
     - dimp
     - flattening
+    - send
     # - csv_conversion  # Commented out - service not running
     # - parquet_conversion  # Commented out - service not running
 

--- a/.github/test/blaze/compose.yaml
+++ b/.github/test/blaze/compose.yaml
@@ -1,0 +1,18 @@
+name: blaze
+
+services:
+  # Blaze FHIR server used as DSF transfer target for the send step
+  blaze-fhir:
+    image: samply/blaze:1.1.2@sha256:af980162fea1c1047ffab1e51400c7a8bbe4d61d6669de0ed915198280d46878
+    ports: [ ":8080" ]
+    networks: [ "aether" ]
+    environment:
+      BASE_URL: http://blaze-fhir:8080
+      LOG_LEVEL: debug
+      JAVA_TOOL_OPTIONS: "-Xmx2g"
+    healthcheck:
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8080/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s

--- a/.github/test/compose.yaml
+++ b/.github/test/compose.yaml
@@ -7,6 +7,7 @@ include:
   - torch/compose.yaml
   - dimp/compose.yaml
   - flattener/compose.yaml
+  - blaze/compose.yaml
 
 services:
   # E2E test runner - runs aether inside the Docker network
@@ -27,3 +28,4 @@ services:
       - torch-proxy
       - fhir-pseudonymizer
       - fhir-flattener
+      - blaze-fhir

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -230,6 +230,23 @@ func executeStep(job *models.PipelineJob, stepName models.StepName, config *mode
 		fmt.Printf("\n✓ Flattening completed\n")
 		return nil
 
+	case models.StepSend:
+		fmt.Println("Starting send step...")
+		if err := pipeline.ExecuteSendStep(job, jobDir, logger); err != nil {
+			failedJob := pipeline.FailJob(job, err.Error())
+			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
+				logger.Error("Failed to save job state", "error", saveErr)
+			}
+			return fmt.Errorf("send step failed: %w", err)
+		}
+
+		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
+			return fmt.Errorf("failed to save job state: %w", err)
+		}
+
+		fmt.Printf("\n✓ Send completed\n")
+		return nil
+
 	case models.StepWait:
 		// Execute wait step - creates empty wait directory and pauses pipeline
 		stepIndex := -1

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -67,6 +67,34 @@ services:
     # Default: 30m (30 minutes)
     timeout: 30m
 
+  # DSF Transfer Server (send step)
+  # Prepares and sends FHIR Binary + DocumentReference resources to a FHIR transfer server
+  # for DSF-based data transfer. Each pipeline output file is zipped, base64-encoded,
+  # and wrapped in a Binary resource. A DocumentReference links all Binary resources.
+  # Leave server_url empty to skip the send step.
+  send:
+    # FHIR transfer server URL (must accept transaction Bundles)
+    server_url: "https://dsf-transfer.example.com/fhir"
+
+    # MII project identifier (used in DocumentReference.masterIdentifier)
+    project_identifier: "MII-PROJECT"
+
+    # DSF organization identifier (used in DocumentReference.author)
+    organization_identifier: "your-org.example.de"
+
+    # Authentication (optional) - choose ONE method or leave both empty for no auth
+    #
+    # Option 1: Basic Auth
+    # Use environment variables to avoid storing credentials in config files:
+    # username: "${FHIR_USER}"
+    # password: "${FHIR_PASSWORD}"
+    #
+    # Option 2: OAuth2 Client Credentials (Keycloak-compatible)
+    # Use environment variables to avoid storing credentials in config files:
+    # oauth_issuer_uri: "${FHIR_OAUTH_ISSUER_URI}"
+    # oauth_client_id: "${FHIR_OAUTH_CLIENT_ID}"
+    # oauth_client_secret: "${FHIR_OAUTH_CLIENT_SECRET}"
+
 pipeline:
   # List of steps to execute in order
   # Import step options (must be first): torch, local_import, http_import
@@ -74,6 +102,11 @@ pipeline:
   # NOTE: At least one import step must be first in enabled_steps
   # NOTE: Enable all the import types you want to support - the system will automatically
   #       use the correct one based on your input (TORCH URL → torch, local dir → local_import, etc.)
+  #
+  # Send step:
+  #   Use 'send' as a final step to upload data to a DSF transfer FHIR server.
+  #   Each output file is zipped, base64-encoded, and wrapped in a FHIR Binary.
+  #   A DocumentReference links all Binaries. Everything is POSTed as a transaction Bundle.
   #
   # Wait step:
   #   Use 'wait' to pause the pipeline for inspection or manual modification.
@@ -91,6 +124,7 @@ pipeline:
     - flattening      # Transform FHIR to CSV using fhir-flattener (CRTDL input only)
     - csv_conversion
     - parquet_conversion
+    # - send           # Uncomment to send data to DSF transfer server
 
 retry:
   # Maximum number of retry attempts for transient errors (network, 5xx)

--- a/internal/lib/validation.go
+++ b/internal/lib/validation.go
@@ -20,6 +20,7 @@ var StepPrerequisites = map[models.StepName][]models.StepName{
 	models.StepCSVConversion:     {"import"}, // Can convert original or pseudonymized data
 	models.StepParquetConversion: {"import"}, // Can convert original or pseudonymized data
 	models.StepWait:              {"import"}, // Wait requires at least one step to have run
+	models.StepSend:              {"import"}, // Send requires at least import to have run
 }
 
 // ValidateStepPrerequisites checks if all prerequisite steps have completed successfully

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -36,6 +36,7 @@ type ServiceConfig struct {
 	ParquetConversion ParquetConversionConfig `yaml:"parquet_conversion" json:"parquet_conversion"`
 	TORCH             TORCHConfig             `yaml:"torch" json:"torch"`
 	Flattening        FlatteningConfig        `yaml:"flattening" json:"flattening"`
+	Send              SendConfig              `yaml:"send" json:"send"`
 }
 
 // DIMPConfig contains DIMP pseudonymization service settings
@@ -62,6 +63,110 @@ type TORCHConfig struct {
 	ExtractionTimeoutMinutes  int    `yaml:"extraction_timeout_minutes" json:"extraction_timeout_minutes"`
 	PollingIntervalSeconds    int    `yaml:"polling_interval_seconds" json:"polling_interval_seconds"`
 	MaxPollingIntervalSeconds int    `yaml:"max_polling_interval_seconds" json:"max_polling_interval_seconds"`
+}
+
+// SendConfig contains DSF transfer server settings for the send step
+type SendConfig struct {
+	ServerURL              string `yaml:"server_url" json:"server_url" mapstructure:"server_url"`
+	ProjectIdentifier      string `yaml:"project_identifier" json:"project_identifier" mapstructure:"project_identifier"`
+	OrganizationIdentifier string `yaml:"organization_identifier" json:"organization_identifier" mapstructure:"organization_identifier"`
+	// Authentication - Basic Auth (optional)
+	Username string `yaml:"username" json:"username" mapstructure:"username"`
+	Password string `yaml:"password" json:"password" mapstructure:"password"`
+	// Authentication - OAuth2 Client Credentials (optional)
+	OAuthIssuerURI    string `yaml:"oauth_issuer_uri" json:"oauth_issuer_uri" mapstructure:"oauth_issuer_uri"`
+	OAuthClientID     string `yaml:"oauth_client_id" json:"oauth_client_id" mapstructure:"oauth_client_id"`
+	OAuthClientSecret string `yaml:"oauth_client_secret" json:"oauth_client_secret" mapstructure:"oauth_client_secret"`
+}
+
+// Validate checks if SendConfig has all required fields
+func (c *SendConfig) Validate() error {
+	if c.ServerURL == "" {
+		return fmt.Errorf("send server_url is required")
+	}
+
+	parsedURL, err := url.Parse(c.ServerURL)
+	if err != nil {
+		return fmt.Errorf("invalid send server_url: %w", err)
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("invalid send server_url: must use http or https scheme, got '%s'", parsedURL.Scheme)
+	}
+
+	if c.ProjectIdentifier == "" {
+		return fmt.Errorf("send project_identifier is required")
+	}
+
+	if c.OrganizationIdentifier == "" {
+		return fmt.Errorf("send organization_identifier is required")
+	}
+
+	// Validate authentication configuration
+	if err := c.validateAuth(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateAuth checks that authentication configuration is consistent
+func (c *SendConfig) validateAuth() error {
+	hasBasicAuth := c.Username != "" || c.Password != ""
+	hasOAuth2 := c.OAuthIssuerURI != "" || c.OAuthClientID != "" || c.OAuthClientSecret != ""
+
+	// Cannot mix both auth methods
+	if hasBasicAuth && hasOAuth2 {
+		return fmt.Errorf("send: cannot configure both basic auth and OAuth2; use one or the other")
+	}
+
+	// If using Basic Auth, both username and password must be set
+	if hasBasicAuth {
+		if c.Username == "" {
+			return fmt.Errorf("send: username is required when using basic auth")
+		}
+		if c.Password == "" {
+			return fmt.Errorf("send: password is required when using basic auth")
+		}
+	}
+
+	// If using OAuth2, all three fields must be set
+	if hasOAuth2 {
+		if c.OAuthIssuerURI == "" {
+			return fmt.Errorf("send: oauth_issuer_uri is required when using OAuth2")
+		}
+		if c.OAuthClientID == "" {
+			return fmt.Errorf("send: oauth_client_id is required when using OAuth2")
+		}
+		if c.OAuthClientSecret == "" {
+			return fmt.Errorf("send: oauth_client_secret is required when using OAuth2")
+		}
+	}
+
+	return nil
+}
+
+// SendAuthType represents the type of authentication to use
+type SendAuthType int
+
+const (
+	// SendAuthNone indicates no authentication
+	SendAuthNone SendAuthType = iota
+	// SendAuthBasic indicates Basic authentication
+	SendAuthBasic
+	// SendAuthOAuth2 indicates OAuth2 client credentials
+	SendAuthOAuth2
+)
+
+// GetAuthType returns the authentication type based on configuration
+func (c *SendConfig) GetAuthType() SendAuthType {
+	if c.Username != "" && c.Password != "" {
+		return SendAuthBasic
+	}
+	if c.OAuthIssuerURI != "" && c.OAuthClientID != "" && c.OAuthClientSecret != "" {
+		return SendAuthOAuth2
+	}
+	return SendAuthNone
 }
 
 // PipelineConfig defines which steps are enabled and their execution order
@@ -182,6 +287,8 @@ func (c *ServiceConfig) HasServiceURL(step StepName) bool {
 		return c.ParquetConversion.URL != ""
 	case StepFlattening:
 		return c.Flattening.ServiceURL != ""
+	case StepSend:
+		return c.Send.ServerURL != ""
 	default:
 		return true // Import and validation don't require external services
 	}
@@ -198,6 +305,8 @@ func (c *ServiceConfig) GetServiceURL(step StepName) string {
 		return c.ParquetConversion.URL
 	case StepFlattening:
 		return c.Flattening.ServiceURL
+	case StepSend:
+		return c.Send.ServerURL
 	default:
 		return ""
 	}

--- a/internal/models/step.go
+++ b/internal/models/step.go
@@ -29,6 +29,7 @@ const (
 	StepParquetConversion StepName = "parquet_conversion"
 	StepWait              StepName = "wait"       // Pause pipeline for user inspection/modification
 	StepFlattening        StepName = "flattening" // Transform FHIR data to CSV using fhir-flattener
+	StepSend              StepName = "send"       // Prepare and send data to DSF transfer server
 )
 
 // StepStatus defines the execution state of a pipeline step
@@ -69,7 +70,7 @@ const (
 // IsValidStepName checks if the step name is recognized
 func IsValidStepName(name StepName) bool {
 	switch name {
-	case StepTorchImport, StepLocalImport, StepHttpImport, StepDIMP, StepValidation, StepCSVConversion, StepParquetConversion, StepWait, StepFlattening:
+	case StepTorchImport, StepLocalImport, StepHttpImport, StepDIMP, StepValidation, StepCSVConversion, StepParquetConversion, StepWait, StepFlattening, StepSend:
 		return true
 	default:
 		return false

--- a/internal/models/validation.go
+++ b/internal/models/validation.go
@@ -159,7 +159,7 @@ func (c *ProjectConfig) Validate() error {
 	for _, step := range c.Pipeline.EnabledSteps {
 		if !c.Services.HasServiceURL(step) {
 			switch step {
-			case StepDIMP, StepCSVConversion, StepParquetConversion:
+			case StepDIMP, StepCSVConversion, StepParquetConversion, StepSend:
 				return fmt.Errorf("service URL required for enabled step '%s'", step)
 			}
 		}
@@ -171,6 +171,13 @@ func (c *ProjectConfig) Validate() error {
 	if c.Pipeline.IsStepEnabled(StepTorchImport) || torchIsConfigured {
 		if err := c.Services.TORCH.Validate(); err != nil {
 			return fmt.Errorf("TORCH config validation failed: %w", err)
+		}
+	}
+
+	// Validate Send config if send step is enabled
+	if c.Pipeline.IsStepEnabled(StepSend) {
+		if err := c.Services.Send.Validate(); err != nil {
+			return fmt.Errorf("send config validation failed: %w", err)
 		}
 	}
 
@@ -283,6 +290,9 @@ func (c *ProjectConfig) ValidateServiceConnectivity() error {
 		case StepDIMP:
 			serviceURL = c.Services.DIMP.URL
 			serviceName = "DIMP"
+		case StepSend:
+			serviceURL = c.Services.Send.ServerURL
+			serviceName = "Send (FHIR transfer server)"
 		case StepCSVConversion:
 			serviceURL = c.Services.CSVConversion.URL
 			serviceName = "CSV Conversion"

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -1,0 +1,487 @@
+package pipeline
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// oauth2TokenCache stores cached OAuth2 tokens to avoid fetching a new token for every request.
+// Thread-safe for concurrent access.
+var oauth2TokenCache = struct {
+	sync.RWMutex
+	token     string
+	expiresAt time.Time
+}{}
+
+// buildBasicAuthHeader returns the Authorization header value for Basic auth.
+func buildBasicAuthHeader(username, password string) string {
+	credentials := username + ":" + password
+	encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
+	return "Basic " + encoded
+}
+
+// oauth2TokenResponse represents the response from an OAuth2 token endpoint
+type oauth2TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"` // Token lifetime in seconds
+	TokenType   string `json:"token_type"`
+}
+
+// fetchOAuth2Token retrieves an access token using the OAuth2 client credentials flow.
+// Uses the Keycloak standard token endpoint: {issuer_uri}/protocol/openid-connect/token
+func fetchOAuth2Token(issuerURI, clientID, clientSecret string, httpClient *services.HTTPClient) (string, error) {
+	// Check cache first
+	oauth2TokenCache.RLock()
+	if oauth2TokenCache.token != "" && time.Now().Before(oauth2TokenCache.expiresAt) {
+		token := oauth2TokenCache.token
+		oauth2TokenCache.RUnlock()
+		return token, nil
+	}
+	oauth2TokenCache.RUnlock()
+
+	// Build token endpoint URL (Keycloak standard path)
+	tokenURL := strings.TrimSuffix(issuerURI, "/") + "/protocol/openid-connect/token"
+
+	// Build request body
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", clientID)
+	data.Set("client_secret", clientSecret)
+
+	// Create request
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Execute request
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response
+	var tokenResp oauth2TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return "", fmt.Errorf("token response missing access_token")
+	}
+
+	// Cache the token with a small buffer before expiration (30 seconds)
+	oauth2TokenCache.Lock()
+	oauth2TokenCache.token = tokenResp.AccessToken
+	if tokenResp.ExpiresIn > 30 {
+		oauth2TokenCache.expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn-30) * time.Second)
+	} else {
+		// Token expires very soon, don't cache
+		oauth2TokenCache.expiresAt = time.Now()
+	}
+	oauth2TokenCache.Unlock()
+
+	return tokenResp.AccessToken, nil
+}
+
+// clearOAuth2TokenCache clears the cached OAuth2 token (useful for testing)
+func clearOAuth2TokenCache() {
+	oauth2TokenCache.Lock()
+	oauth2TokenCache.token = ""
+	oauth2TokenCache.expiresAt = time.Time{}
+	oauth2TokenCache.Unlock()
+}
+
+// ClearOAuth2TokenCacheForTesting clears the OAuth2 token cache - exported for testing
+func ClearOAuth2TokenCacheForTesting() {
+	clearOAuth2TokenCache()
+}
+
+// putWithAuth performs an authenticated HTTP PUT request based on the SendConfig authentication settings.
+func putWithAuth(targetURL, contentType string, body []byte, config models.SendConfig, httpClient *services.HTTPClient) (*http.Response, error) {
+	req, err := http.NewRequest("PUT", targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	// Add authentication header based on config
+	switch config.GetAuthType() {
+	case models.SendAuthBasic:
+		req.Header.Set("Authorization", buildBasicAuthHeader(config.Username, config.Password))
+	case models.SendAuthOAuth2:
+		token, err := fetchOAuth2Token(config.OAuthIssuerURI, config.OAuthClientID, config.OAuthClientSecret, httpClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get OAuth2 token: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	return httpClient.Do(req)
+}
+
+// ExecuteSendStep prepares and sends pipeline output to a DSF transfer FHIR server.
+// For each file in the previous step's output: zips it, base64-encodes it, and wraps it
+// in a FHIR Binary resource. Then creates a DocumentReference linking all Binaries,
+// wraps everything in a FHIR transaction Bundle, and POSTs it to the transfer server.
+func ExecuteSendStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	stepName := models.StepSend
+
+	if !isStepEnabled(job.Config, stepName) {
+		logger.Info("Send step not enabled, skipping", "job_id", job.JobID)
+		return nil
+	}
+
+	logger.Debug("Send step starting", "job_id", job.JobID)
+
+	step := getOrCreateStep(job, stepName)
+	step.Status = models.StepStatusInProgress
+	now := time.Now()
+	step.StartedAt = &now
+
+	if err := job.Config.Services.Send.Validate(); err != nil {
+		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
+		recordStepError(step, err, models.ErrorTypeNonTransient)
+		return err
+	}
+
+	// Resolve input directory from previous step
+	jobsBaseDir := filepath.Dir(jobDir)
+	jobID := filepath.Base(jobDir)
+	stepIndex := getStepIndexInEnabledSteps(job.Config.Pipeline.EnabledSteps, stepName)
+	inputDir := services.GetStepInputDir(jobsBaseDir, jobID, job.Config.Pipeline.EnabledSteps, stepIndex)
+
+	files, err := findAllFilesRecursive(inputDir)
+	if err != nil {
+		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
+		recordStepError(step, err, models.ErrorTypeNonTransient)
+		return fmt.Errorf("failed to list input files: %w", err)
+	}
+
+	if len(files) == 0 {
+		err := fmt.Errorf("no files found in %s", inputDir)
+		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
+		recordStepError(step, err, models.ErrorTypeNonTransient)
+		return err
+	}
+
+	fmt.Printf("Preparing %d file(s) for DSF transfer...\n\n", len(files))
+
+	var binaryResources []binaryEntry
+	for _, filePath := range files {
+		fileName := filepath.Base(filePath)
+
+		entry, err := createBinaryFromFile(filePath)
+		if err != nil {
+			lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
+			recordStepError(step, err, models.ErrorTypeNonTransient)
+			return fmt.Errorf("failed to process %s: %w", fileName, err)
+		}
+
+		binaryResources = append(binaryResources, entry)
+		fmt.Printf("  ✓ %s (%s)\n", fileName, entry.contentType)
+
+		logger.Debug("Created Binary resource",
+			"file", fileName,
+			"content_type", entry.contentType,
+			"job_id", job.JobID)
+	}
+
+	sendConfig := job.Config.Services.Send
+	docRef := buildDocumentReference(binaryResources, sendConfig)
+
+	logger.Debug("Uploading resources individually",
+		"binary_count", len(binaryResources),
+		"job_id", job.JobID)
+
+	httpClient := services.DefaultHTTPClient()
+
+	// Upload each Binary resource
+	for i, binary := range binaryResources {
+		fmt.Printf("  Uploading Binary %d/%d...\n", i+1, len(binaryResources))
+		if err := uploadBinary(binary, sendConfig, httpClient, logger); err != nil {
+			retryable := isSendErrorRetryable(err)
+			lib.LogStepFailed(logger, string(stepName), job.JobID, err, retryable)
+			recordStepError(step, err, classifySendError(err))
+			return fmt.Errorf("failed to upload Binary %s: %w", binary.id, err)
+		}
+	}
+
+	// Upload DocumentReference
+	fmt.Println("  Uploading DocumentReference...")
+	if err := uploadDocumentReference(docRef, sendConfig, httpClient, logger); err != nil {
+		retryable := isSendErrorRetryable(err)
+		lib.LogStepFailed(logger, string(stepName), job.JobID, err, retryable)
+		recordStepError(step, err, classifySendError(err))
+		return fmt.Errorf("failed to upload DocumentReference: %w", err)
+	}
+
+	fmt.Printf("\n✓ Transfer complete (%d files sent)\n", len(files))
+
+	step.Status = models.StepStatusCompleted
+	step.FilesProcessed = len(files)
+	completedAt := time.Now()
+	step.CompletedAt = &completedAt
+
+	logger.Debug("Send step completed",
+		"files_sent", len(files),
+		"duration", completedAt.Sub(*step.StartedAt),
+		"job_id", job.JobID)
+
+	return nil
+}
+
+// binaryEntry holds a FHIR Binary resource and its metadata
+type binaryEntry struct {
+	id          string
+	contentType string
+	resource    map[string]any
+}
+
+// createBinaryFromFile reads a file, zips it, base64-encodes the content,
+// and returns a FHIR Binary resource.
+func createBinaryFromFile(filePath string) (binaryEntry, error) {
+	contentType := detectContentType(filePath)
+
+	// All files are zipped for transfer
+	data, err := zipSingleFile(filePath)
+	if err != nil {
+		return binaryEntry{}, fmt.Errorf("failed to zip %s: %w", filepath.Base(filePath), err)
+	}
+
+	id := uuid.New().String()
+	b64 := base64.StdEncoding.EncodeToString(data)
+
+	resource := map[string]any{
+		"resourceType": "Binary",
+		"id":           id,
+		"contentType":  contentType,
+		"data":         b64,
+	}
+
+	return binaryEntry{
+		id:          id,
+		contentType: contentType,
+		resource:    resource,
+	}, nil
+}
+
+// detectContentType determines the FHIR contentType for a file based on its extension.
+// All files are zipped for transfer - the pipeline doesn't produce standalone .json files.
+func detectContentType(filePath string) string {
+	name := strings.ToLower(filepath.Base(filePath))
+
+	switch {
+	case strings.HasSuffix(name, ".ndjson.zst") || strings.HasSuffix(name, ".ndjson"):
+		return "application/zip"
+	case strings.HasSuffix(name, ".csv"):
+		return "text/zip"
+	case strings.HasSuffix(name, ".parquet"):
+		return "text/zip"
+	default:
+		return "application/zip"
+	}
+}
+
+// zipSingleFile compresses a single file into an in-memory zip archive.
+// Uses lib.OpenFileForReading to transparently decompress .zst files before zipping,
+// so the zip contains the raw (uncompressed) data.
+func zipSingleFile(filePath string) ([]byte, error) {
+	reader, err := lib.OpenFileForReading(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = reader.Close() }()
+
+	// Use the uncompressed filename inside the zip (strip .zst suffix)
+	entryName := lib.GetUncompressedFilename(filepath.Base(filePath))
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create(entryName)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := io.Copy(w, reader); err != nil {
+		return nil, err
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// buildDocumentReference creates a FHIR DocumentReference linking all Binary resources.
+func buildDocumentReference(binaries []binaryEntry, config models.SendConfig) map[string]any {
+	content := make([]map[string]any, len(binaries))
+	for i, b := range binaries {
+		content[i] = map[string]any{
+			"attachment": map[string]any{
+				"contentType": b.contentType,
+				"url":         fmt.Sprintf("Binary/%s", b.id),
+			},
+		}
+	}
+
+	return map[string]any{
+		"resourceType": "DocumentReference",
+		"id":           uuid.New().String(),
+		"masterIdentifier": map[string]any{
+			"system": "http://medizininformatik-initiative.de/sid/project-identifier",
+			"value":  config.ProjectIdentifier,
+		},
+		"status":    "current",
+		"docStatus": "final",
+		"author": []map[string]any{
+			{
+				"type": "Organization",
+				"identifier": map[string]any{
+					"system": "http://dsf.dev/sid/organization-identifier",
+					"value":  config.OrganizationIdentifier,
+				},
+			},
+		},
+		"date":    time.Now().Format(time.RFC3339),
+		"content": content,
+	}
+}
+
+// uploadBinary PUTs a single Binary resource to the FHIR server.
+func uploadBinary(binary binaryEntry, config models.SendConfig, httpClient *services.HTTPClient, logger *lib.Logger) error {
+	targetURL := fmt.Sprintf("%s/Binary/%s", strings.TrimSuffix(config.ServerURL, "/"), binary.id)
+	jsonData, err := json.Marshal(binary.resource)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Binary: %w", err)
+	}
+
+	logger.Debug("Uploading Binary resource",
+		"url", targetURL,
+		"id", binary.id,
+		"size_bytes", len(jsonData))
+
+	resp, err := putWithAuth(targetURL, "application/fhir+json", jsonData, config, httpClient)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return &SendError{
+			StatusCode: resp.StatusCode,
+			Message:    string(body),
+			ErrorType:  lib.ClassifyHTTPError(resp.StatusCode),
+		}
+	}
+
+	logger.Debug("Binary resource uploaded successfully", "id", binary.id, "status", resp.StatusCode)
+	return nil
+}
+
+// uploadDocumentReference PUTs the DocumentReference to the FHIR server.
+func uploadDocumentReference(docRef map[string]any, config models.SendConfig, httpClient *services.HTTPClient, logger *lib.Logger) error {
+	id, _ := docRef["id"].(string)
+	targetURL := fmt.Sprintf("%s/DocumentReference/%s", strings.TrimSuffix(config.ServerURL, "/"), id)
+	jsonData, err := json.Marshal(docRef)
+	if err != nil {
+		return fmt.Errorf("failed to marshal DocumentReference: %w", err)
+	}
+
+	logger.Debug("Uploading DocumentReference",
+		"url", targetURL,
+		"id", id,
+		"size_bytes", len(jsonData))
+
+	resp, err := putWithAuth(targetURL, "application/fhir+json", jsonData, config, httpClient)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return &SendError{
+			StatusCode: resp.StatusCode,
+			Message:    string(body),
+			ErrorType:  lib.ClassifyHTTPError(resp.StatusCode),
+		}
+	}
+
+	logger.Debug("DocumentReference uploaded successfully", "id", id, "status", resp.StatusCode)
+	return nil
+}
+
+// findAllFilesRecursive walks a directory tree and returns all file paths.
+func findAllFilesRecursive(dir string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	return files, err
+}
+
+// SendError represents a failure from the FHIR transfer server.
+type SendError struct {
+	StatusCode int
+	Message    string
+	ErrorType  models.ErrorType
+}
+
+func (e *SendError) Error() string {
+	return fmt.Sprintf("send failed: HTTP %d: %s", e.StatusCode, e.Message)
+}
+
+func isSendErrorRetryable(err error) bool {
+	var sendErr *SendError
+	if errors.As(err, &sendErr) {
+		return sendErr.ErrorType == models.ErrorTypeTransient
+	}
+	return lib.IsNetworkError(err)
+}
+
+func classifySendError(err error) models.ErrorType {
+	var sendErr *SendError
+	if errors.As(err, &sendErr) {
+		return sendErr.ErrorType
+	}
+	if lib.IsNetworkError(err) {
+		return models.ErrorTypeTransient
+	}
+	return models.ErrorTypeNonTransient
+}

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -87,6 +87,18 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 				Formats:    viper.GetStringSlice("services.flattening.formats"),
 				Timeout:    viper.GetDuration("services.flattening.timeout"),
 			},
+			Send: models.SendConfig{
+				ServerURL:              ExpandEnvVars(viper.GetString("services.send.server_url")),
+				ProjectIdentifier:      ExpandEnvVars(viper.GetString("services.send.project_identifier")),
+				OrganizationIdentifier: ExpandEnvVars(viper.GetString("services.send.organization_identifier")),
+				// Basic Auth
+				Username: ExpandEnvVars(viper.GetString("services.send.username")),
+				Password: ExpandEnvVars(viper.GetString("services.send.password")),
+				// OAuth2 Client Credentials
+				OAuthIssuerURI:    ExpandEnvVars(viper.GetString("services.send.oauth_issuer_uri")),
+				OAuthClientID:     ExpandEnvVars(viper.GetString("services.send.oauth_client_id")),
+				OAuthClientSecret: ExpandEnvVars(viper.GetString("services.send.oauth_client_secret")),
+			},
 		},
 		Retry: models.RetryConfig{
 			MaxAttempts:      viper.GetInt("retry.max_attempts"),

--- a/internal/services/httpclient.go
+++ b/internal/services/httpclient.go
@@ -69,6 +69,18 @@ func (c *HTTPClient) PostJSON(url string, jsonBody []byte) (*http.Response, erro
 	return c.Post(url, "application/json", jsonBody)
 }
 
+// Put performs an HTTP PUT request with retry logic
+func (c *HTTPClient) Put(url string, contentType string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest("PUT", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+
+	return c.Do(req)
+}
+
 // Do executes an HTTP request with retry logic for transient errors
 func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 	var resp *http.Response

--- a/internal/services/state.go
+++ b/internal/services/state.go
@@ -161,6 +161,7 @@ func EnsureJobDirs(jobsBaseDir string, jobID string) (map[models.StepName]string
 		models.StepCSVConversion:     filepath.Join(jobDir, "csv"),
 		models.StepParquetConversion: filepath.Join(jobDir, "parquet"),
 		models.StepFlattening:        filepath.Join(jobDir, "csv"),
+		models.StepSend:              filepath.Join(jobDir, "send"),
 	}
 
 	for _, dir := range dirs {
@@ -185,6 +186,8 @@ func GetJobOutputDir(jobsBaseDir string, jobID string, step models.StepName) str
 		return filepath.Join(jobDir, "csv")
 	case models.StepParquetConversion:
 		return filepath.Join(jobDir, "parquet")
+	case models.StepSend:
+		return filepath.Join(jobDir, "send")
 	case models.StepWait:
 		// Wait step output depends on previous step - use GetWaitStepDir instead
 		return jobDir

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -834,6 +834,11 @@ func TestGetServiceURL(t *testing.T) {
 			Flattening: models.FlatteningConfig{
 				ServiceURL: "http://flattener.example.com:8000",
 			},
+			Send: models.SendConfig{
+				ServerURL:              "http://fhir.example.com:8080/fhir",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
 		},
 	}
 
@@ -848,6 +853,9 @@ func TestGetServiceURL(t *testing.T) {
 
 	// Test Flattening URL
 	assert.Equal(t, "http://flattener.example.com:8000", config.Services.GetServiceURL(models.StepFlattening))
+
+	// Test Send URL
+	assert.Equal(t, "http://fhir.example.com:8080/fhir", config.Services.GetServiceURL(models.StepSend))
 
 	// Test unknown step
 	assert.Equal(t, "", config.Services.GetServiceURL(models.StepLocalImport))
@@ -1227,6 +1235,70 @@ func TestValidateServiceConnectivity_ParquetServiceUnreachable(t *testing.T) {
 	assert.Contains(t, err.Error(), "Parquet Conversion")
 }
 
+// TestValidateServiceConnectivity_SendServiceAvailable verifies connectivity check with Send service available
+func TestValidateServiceConnectivity_SendServiceAvailable(t *testing.T) {
+	sendServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sendServer.Close()
+
+	config := models.ProjectConfig{
+		Services: models.ServiceConfig{
+			Send: models.SendConfig{
+				ServerURL:              sendServer.URL,
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+		},
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{
+				models.StepLocalImport,
+				models.StepSend,
+			},
+		},
+		Retry: models.RetryConfig{
+			MaxAttempts:      5,
+			InitialBackoffMs: 1000,
+			MaxBackoffMs:     30000,
+		},
+		JobsDir: "/tmp/jobs",
+	}
+
+	// ValidateServiceConnectivity should succeed when Send service is reachable
+	err := config.ValidateServiceConnectivity()
+	assert.NoError(t, err, "Send service should be reachable")
+}
+
+// TestValidateServiceConnectivity_SendServiceUnreachable verifies error when Send service is unreachable
+func TestValidateServiceConnectivity_SendServiceUnreachable(t *testing.T) {
+	config := models.ProjectConfig{
+		Services: models.ServiceConfig{
+			Send: models.SendConfig{
+				ServerURL:              "http://localhost:59998", // Unreachable
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+		},
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{
+				models.StepLocalImport,
+				models.StepSend,
+			},
+		},
+		Retry: models.RetryConfig{
+			MaxAttempts:      5,
+			InitialBackoffMs: 1000,
+			MaxBackoffMs:     30000,
+		},
+		JobsDir: "/tmp/jobs",
+	}
+
+	// ValidateServiceConnectivity should fail when Send service is unreachable
+	err := config.ValidateServiceConnectivity()
+	assert.Error(t, err, "Should fail when Send service is unreachable")
+	assert.Contains(t, err.Error(), "Send (FHIR transfer server)")
+}
+
 // TestConfigLoading_BundleSplitThreshold verifies bundle_split_threshold_mb is loaded correctly
 func TestConfigLoading_BundleSplitThreshold(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -1427,6 +1499,293 @@ jobs_dir: "` + jobsDir + `"
 
 			assert.True(t, config.Compression.Enabled)
 			assert.Equal(t, level, config.Compression.Level)
+		})
+	}
+}
+
+// TestConfigLoading_SendConfig verifies that send service configuration
+// is properly loaded from YAML config file
+func TestConfigLoading_SendConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	// Mock server for connectivity validation
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	configContent := `
+services:
+  send:
+    server_url: "` + mockServer.URL + `"
+    project_identifier: "MII-TEST-PROJECT"
+    organization_identifier: "test.hospital.de"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - send
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, mockServer.URL, config.Services.Send.ServerURL)
+	assert.Equal(t, "MII-TEST-PROJECT", config.Services.Send.ProjectIdentifier)
+	assert.Equal(t, "test.hospital.de", config.Services.Send.OrganizationIdentifier)
+
+	// Verify send step is in enabled steps
+	assert.Contains(t, config.Pipeline.EnabledSteps, models.StepSend)
+}
+
+// TestConfigLoading_SendConfigWithBasicAuth verifies that Basic Auth configuration is loaded
+func TestConfigLoading_SendConfigWithBasicAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	configContent := `
+services:
+  send:
+    server_url: "` + mockServer.URL + `"
+    project_identifier: "MII-TEST-PROJECT"
+    organization_identifier: "test.hospital.de"
+    username: "testuser"
+    password: "testpass"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - send
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, "testuser", config.Services.Send.Username)
+	assert.Equal(t, "testpass", config.Services.Send.Password)
+	assert.Equal(t, models.SendAuthBasic, config.Services.Send.GetAuthType())
+}
+
+// TestConfigLoading_SendConfigWithOAuth2 verifies that OAuth2 configuration is loaded
+func TestConfigLoading_SendConfigWithOAuth2(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	configContent := `
+services:
+  send:
+    server_url: "` + mockServer.URL + `"
+    project_identifier: "MII-TEST-PROJECT"
+    organization_identifier: "test.hospital.de"
+    oauth_issuer_uri: "https://auth.example.com/realms/test"
+    oauth_client_id: "my-client"
+    oauth_client_secret: "my-secret"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - send
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, "https://auth.example.com/realms/test", config.Services.Send.OAuthIssuerURI)
+	assert.Equal(t, "my-client", config.Services.Send.OAuthClientID)
+	assert.Equal(t, "my-secret", config.Services.Send.OAuthClientSecret)
+	assert.Equal(t, models.SendAuthOAuth2, config.Services.Send.GetAuthType())
+}
+
+// TestConfigLoading_SendConfigNoAuth verifies that no-auth configuration works
+func TestConfigLoading_SendConfigNoAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	configContent := `
+services:
+  send:
+    server_url: "` + mockServer.URL + `"
+    project_identifier: "MII-TEST-PROJECT"
+    organization_identifier: "test.hospital.de"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - send
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Empty(t, config.Services.Send.Username)
+	assert.Empty(t, config.Services.Send.Password)
+	assert.Empty(t, config.Services.Send.OAuthIssuerURI)
+	assert.Equal(t, models.SendAuthNone, config.Services.Send.GetAuthType())
+}
+
+// TestSendConfig_ValidateMixedAuth verifies that mixing Basic Auth and OAuth2 is rejected
+func TestSendConfig_ValidateMixedAuth(t *testing.T) {
+	config := models.SendConfig{
+		ServerURL:              "https://example.com/fhir",
+		ProjectIdentifier:      "TEST",
+		OrganizationIdentifier: "test.org",
+		Username:               "user",
+		Password:               "pass",
+		OAuthIssuerURI:         "https://auth.example.com",
+		OAuthClientID:          "client",
+		OAuthClientSecret:      "secret",
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot configure both basic auth and OAuth2")
+}
+
+// TestSendConfig_ValidateIncompleteBasicAuth verifies partial Basic Auth is rejected
+func TestSendConfig_ValidateIncompleteBasicAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		password string
+		errMsg   string
+	}{
+		{
+			name:     "username only",
+			username: "user",
+			password: "",
+			errMsg:   "password is required",
+		},
+		{
+			name:     "password only",
+			username: "",
+			password: "pass",
+			errMsg:   "username is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := models.SendConfig{
+				ServerURL:              "https://example.com/fhir",
+				ProjectIdentifier:      "TEST",
+				OrganizationIdentifier: "test.org",
+				Username:               tt.username,
+				Password:               tt.password,
+			}
+
+			err := config.Validate()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// TestSendConfig_ValidateIncompleteOAuth2 verifies partial OAuth2 config is rejected
+func TestSendConfig_ValidateIncompleteOAuth2(t *testing.T) {
+	tests := []struct {
+		name         string
+		issuerURI    string
+		clientID     string
+		clientSecret string
+		errMsg       string
+	}{
+		{
+			name:         "missing issuer URI",
+			issuerURI:    "",
+			clientID:     "client",
+			clientSecret: "secret",
+			errMsg:       "oauth_issuer_uri is required",
+		},
+		{
+			name:         "missing client ID",
+			issuerURI:    "https://auth.example.com",
+			clientID:     "",
+			clientSecret: "secret",
+			errMsg:       "oauth_client_id is required",
+		},
+		{
+			name:         "missing client secret",
+			issuerURI:    "https://auth.example.com",
+			clientID:     "client",
+			clientSecret: "",
+			errMsg:       "oauth_client_secret is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := models.SendConfig{
+				ServerURL:              "https://example.com/fhir",
+				ProjectIdentifier:      "TEST",
+				OrganizationIdentifier: "test.org",
+				OAuthIssuerURI:         tt.issuerURI,
+				OAuthClientID:          tt.clientID,
+				OAuthClientSecret:      tt.clientSecret,
+			}
+
+			err := config.Validate()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
 }

--- a/tests/unit/config_validation_test.go
+++ b/tests/unit/config_validation_test.go
@@ -356,3 +356,243 @@ func TestProjectConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+// TestSendConfig_Validate tests validation of SendConfig struct
+func TestSendConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  models.SendConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "Valid config",
+			config: models.SendConfig{
+				ServerURL:              "https://fhir.example.com/fhir",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing server_url",
+			config: models.SendConfig{
+				ServerURL:              "",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: true,
+			errMsg:  "server_url is required",
+		},
+		{
+			name: "Invalid server_url - malformed",
+			config: models.SendConfig{
+				ServerURL:              "://not-a-valid-url",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: true,
+			errMsg:  "invalid send server_url",
+		},
+		{
+			name: "Invalid server_url - wrong scheme (ftp)",
+			config: models.SendConfig{
+				ServerURL:              "ftp://fhir.example.com/fhir",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: true,
+			errMsg:  "must use http or https scheme",
+		},
+		{
+			name: "Invalid server_url - wrong scheme (empty)",
+			config: models.SendConfig{
+				ServerURL:              "fhir.example.com/fhir",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: true,
+			errMsg:  "must use http or https scheme",
+		},
+		{
+			name: "Missing project_identifier",
+			config: models.SendConfig{
+				ServerURL:              "https://fhir.example.com/fhir",
+				ProjectIdentifier:      "",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: true,
+			errMsg:  "project_identifier is required",
+		},
+		{
+			name: "Missing organization_identifier",
+			config: models.SendConfig{
+				ServerURL:              "https://fhir.example.com/fhir",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "",
+			},
+			wantErr: true,
+			errMsg:  "organization_identifier is required",
+		},
+		{
+			name: "Valid config with http scheme",
+			config: models.SendConfig{
+				ServerURL:              "http://localhost:8080/fhir",
+				ProjectIdentifier:      "TEST-PROJECT",
+				OrganizationIdentifier: "test.org",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestProjectConfig_Validate_SendStep tests validation of ProjectConfig with send step
+func TestProjectConfig_Validate_SendStep(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  models.ProjectConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "Valid config with send step",
+			config: models.ProjectConfig{
+				Pipeline: models.PipelineConfig{
+					EnabledSteps: []models.StepName{models.StepLocalImport, models.StepSend},
+				},
+				Services: models.ServiceConfig{
+					Send: models.SendConfig{
+						ServerURL:              "https://fhir.example.com/fhir",
+						ProjectIdentifier:      "TEST-PROJECT",
+						OrganizationIdentifier: "test.org",
+					},
+				},
+				Retry: models.RetryConfig{
+					MaxAttempts:      3,
+					InitialBackoffMs: 500,
+					MaxBackoffMs:     5000,
+				},
+				JobsDir: "/tmp/jobs",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Send step enabled but missing server_url",
+			config: models.ProjectConfig{
+				Pipeline: models.PipelineConfig{
+					EnabledSteps: []models.StepName{models.StepLocalImport, models.StepSend},
+				},
+				Services: models.ServiceConfig{
+					Send: models.SendConfig{
+						ServerURL:              "",
+						ProjectIdentifier:      "TEST-PROJECT",
+						OrganizationIdentifier: "test.org",
+					},
+				},
+				Retry: models.RetryConfig{
+					MaxAttempts:      3,
+					InitialBackoffMs: 500,
+					MaxBackoffMs:     5000,
+				},
+				JobsDir: "/tmp/jobs",
+			},
+			wantErr: true,
+			errMsg:  "service URL required for enabled step 'send'",
+		},
+		{
+			name: "Send step enabled but invalid send config - missing project identifier",
+			config: models.ProjectConfig{
+				Pipeline: models.PipelineConfig{
+					EnabledSteps: []models.StepName{models.StepLocalImport, models.StepSend},
+				},
+				Services: models.ServiceConfig{
+					Send: models.SendConfig{
+						ServerURL:              "https://fhir.example.com/fhir",
+						ProjectIdentifier:      "",
+						OrganizationIdentifier: "test.org",
+					},
+				},
+				Retry: models.RetryConfig{
+					MaxAttempts:      3,
+					InitialBackoffMs: 500,
+					MaxBackoffMs:     5000,
+				},
+				JobsDir: "/tmp/jobs",
+			},
+			wantErr: true,
+			errMsg:  "send config validation failed",
+		},
+		{
+			name: "Send step enabled but invalid send config - missing organization identifier",
+			config: models.ProjectConfig{
+				Pipeline: models.PipelineConfig{
+					EnabledSteps: []models.StepName{models.StepLocalImport, models.StepSend},
+				},
+				Services: models.ServiceConfig{
+					Send: models.SendConfig{
+						ServerURL:              "https://fhir.example.com/fhir",
+						ProjectIdentifier:      "TEST-PROJECT",
+						OrganizationIdentifier: "",
+					},
+				},
+				Retry: models.RetryConfig{
+					MaxAttempts:      3,
+					InitialBackoffMs: 500,
+					MaxBackoffMs:     5000,
+				},
+				JobsDir: "/tmp/jobs",
+			},
+			wantErr: true,
+			errMsg:  "send config validation failed",
+		},
+		{
+			name: "Send step enabled but invalid send config - invalid URL scheme",
+			config: models.ProjectConfig{
+				Pipeline: models.PipelineConfig{
+					EnabledSteps: []models.StepName{models.StepLocalImport, models.StepSend},
+				},
+				Services: models.ServiceConfig{
+					Send: models.SendConfig{
+						ServerURL:              "ftp://fhir.example.com/fhir",
+						ProjectIdentifier:      "TEST-PROJECT",
+						OrganizationIdentifier: "test.org",
+					},
+				},
+				Retry: models.RetryConfig{
+					MaxAttempts:      3,
+					InitialBackoffMs: 500,
+					MaxBackoffMs:     5000,
+				},
+				JobsDir: "/tmp/jobs",
+			},
+			wantErr: true,
+			errMsg:  "send config validation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/unit/httpclient_test.go
+++ b/tests/unit/httpclient_test.go
@@ -1,0 +1,167 @@
+package unit
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHTTPClient_Put_Success tests the Put method with a successful response
+func TestHTTPClient_Put_Success(t *testing.T) {
+	var receivedMethod string
+	var receivedContentType string
+	var receivedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+
+	body := []byte(`{"resourceType":"Binary","id":"123"}`)
+	resp, err := httpClient.Put(server.URL, "application/fhir+json", body)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "PUT", receivedMethod)
+	assert.Equal(t, "application/fhir+json", receivedContentType)
+	assert.Equal(t, body, receivedBody)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestHTTPClient_Put_ClientError tests the Put method with a 4xx client error (non-retryable)
+func TestHTTPClient_Put_ClientError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad request"}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+
+	body := []byte(`{"data":"test"}`)
+	resp, err := httpClient.Put(server.URL, "application/json", body)
+
+	// 4xx client errors are non-retryable, response is returned for caller to handle
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestHTTPClient_Put_InvalidURL tests the Put method with an invalid URL
+func TestHTTPClient_Put_InvalidURL(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+
+	body := []byte(`{"data":"test"}`)
+	// Use an invalid URL scheme to trigger NewRequest error
+	resp, err := httpClient.Put("://invalid-url", "application/json", body)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to create request")
+}
+
+// TestHTTPClient_Put_EmptyBody tests the Put method with an empty body
+func TestHTTPClient_Put_EmptyBody(t *testing.T) {
+	var receivedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+
+	resp, err := httpClient.Put(server.URL, "application/json", []byte{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, receivedBody)
+}
+
+// TestHTTPClient_Put_LargeBody tests the Put method with a large body
+func TestHTTPClient_Put_LargeBody(t *testing.T) {
+	var receivedBodyLen int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBodyLen = len(body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+
+	// Create a large body (1MB)
+	largeBody := make([]byte, 1024*1024)
+	for i := range largeBody {
+		largeBody[i] = byte('A' + (i % 26))
+	}
+
+	resp, err := httpClient.Put(server.URL, "application/octet-stream", largeBody)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, len(largeBody), receivedBodyLen)
+}
+
+// TestHTTPClient_Put_CustomContentType tests the Put method with various content types
+func TestHTTPClient_Put_CustomContentType(t *testing.T) {
+	contentTypes := []string{
+		"application/fhir+json",
+		"text/plain",
+		"application/xml",
+		"multipart/form-data",
+	}
+
+	for _, expectedCT := range contentTypes {
+		t.Run(expectedCT, func(t *testing.T) {
+			var receivedContentType string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedContentType = r.Header.Get("Content-Type")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			logger := lib.NewLogger(lib.LogLevelDebug)
+			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+
+			resp, err := httpClient.Put(server.URL, expectedCT, []byte("test"))
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			_ = resp.Body.Close()
+
+			assert.Equal(t, expectedCT, receivedContentType)
+		})
+	}
+}

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -1,0 +1,1203 @@
+package unit
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteSendStep_Success(t *testing.T) {
+	// Capture resources received by the mock server
+	var receivedResources []map[string]any
+	var receivedRequests []struct {
+		Method string
+		Path   string
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "application/fhir+json", r.Header.Get("Content-Type"))
+
+		receivedRequests = append(receivedRequests, struct {
+			Method string
+			Path   string
+		}{r.Method, r.URL.Path})
+
+		var resource map[string]any
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-send-job"
+	jobDir := filepath.Join(tmpDir, jobID)
+
+	// Create input directory with test files
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Write a test CSV file
+	csvContent := "id,gender,birthDate\n1,male,1990-01-01\n"
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.csv"), []byte(csvContent), 0644))
+
+	// Write a test NDJSON file
+	ndjsonContent := `{"resourceType":"Patient","id":"1"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"), []byte(ndjsonContent), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// 2 Binary resources + 1 DocumentReference = 3 PUT requests
+	require.Len(t, receivedRequests, 3)
+	require.Len(t, receivedResources, 3)
+
+	// All requests should be PUTs
+	for _, req := range receivedRequests {
+		assert.Equal(t, "PUT", req.Method)
+	}
+
+	// Collect resources by type
+	var binaryResources []map[string]any
+	var docRef map[string]any
+	for _, res := range receivedResources {
+		switch res["resourceType"].(string) {
+		case "Binary":
+			binaryResources = append(binaryResources, res)
+		case "DocumentReference":
+			docRef = res
+		}
+	}
+
+	assert.Len(t, binaryResources, 2)
+	require.NotNil(t, docRef)
+
+	// Verify DocumentReference structure
+	assert.Equal(t, "DocumentReference", docRef["resourceType"])
+	assert.Equal(t, "current", docRef["status"])
+	assert.Equal(t, "final", docRef["docStatus"])
+
+	// Verify masterIdentifier
+	masterID := docRef["masterIdentifier"].(map[string]any)
+	assert.Equal(t, "http://medizininformatik-initiative.de/sid/project-identifier", masterID["system"])
+	assert.Equal(t, "TEST-PROJECT", masterID["value"])
+
+	// Verify author organization
+	authors := docRef["author"].([]any)
+	require.Len(t, authors, 1)
+	author := authors[0].(map[string]any)
+	assert.Equal(t, "Organization", author["type"])
+	authorIdent := author["identifier"].(map[string]any)
+	assert.Equal(t, "http://dsf.dev/sid/organization-identifier", authorIdent["system"])
+	assert.Equal(t, "test.hospital.de", authorIdent["value"])
+
+	// Verify DocumentReference content links
+	contentArr := docRef["content"].([]any)
+	assert.Len(t, contentArr, 2)
+
+	// Verify Binary resources have base64-encoded data
+	for _, binary := range binaryResources {
+		assert.Equal(t, "Binary", binary["resourceType"])
+		assert.NotEmpty(t, binary["id"])
+		assert.NotEmpty(t, binary["contentType"])
+		assert.NotEmpty(t, binary["data"])
+	}
+
+	// Verify PUT paths match resource IDs
+	for _, req := range receivedRequests {
+		// Path should be /Binary/{id} or /DocumentReference/{id}
+		assert.True(t, len(req.Path) > 1, "Path should not be empty")
+	}
+
+	// Verify step was marked completed
+	var sendStep *models.PipelineStep
+	for i := range job.Steps {
+		if job.Steps[i].Name == models.StepSend {
+			sendStep = &job.Steps[i]
+			break
+		}
+	}
+	require.NotNil(t, sendStep)
+	assert.Equal(t, models.StepStatusCompleted, sendStep.Status)
+	assert.Equal(t, 2, sendStep.FilesProcessed)
+}
+
+func TestExecuteSendStep_ZipContentVerification(t *testing.T) {
+	var binaryResource map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+
+		// Capture the Binary resource (not the DocumentReference)
+		if resource["resourceType"] == "Binary" {
+			binaryResource = resource
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-zip-verify"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	originalContent := "id,name\n1,Alice\n2,Bob\n"
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "data.csv"), []byte(originalContent), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify the captured Binary resource
+	require.NotNil(t, binaryResource)
+	assert.Equal(t, "text/zip", binaryResource["contentType"])
+
+	b64Data := binaryResource["data"].(string)
+	zipBytes, err := base64.StdEncoding.DecodeString(b64Data)
+	require.NoError(t, err)
+
+	// Open zip and verify contents
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	require.NoError(t, err)
+	require.Len(t, zipReader.File, 1)
+	assert.Equal(t, "data.csv", zipReader.File[0].Name)
+
+	rc, err := zipReader.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	decompressed, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, originalContent, string(decompressed))
+}
+
+func TestExecuteSendStep_ContentTypeMapping(t *testing.T) {
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-content-types"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create files of different types
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"), []byte(`{"resourceType":"Patient"}`+"\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "data.csv"), []byte("id\n1\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "data.parquet"), []byte("parquet-content"), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// 3 Binaries + 1 DocumentReference = 4 requests
+	require.Len(t, receivedResources, 4)
+
+	// Collect content types from Binary resources
+	contentTypes := make(map[string]bool)
+	for _, resource := range receivedResources {
+		if resource["resourceType"] == "Binary" {
+			ct := resource["contentType"].(string)
+			contentTypes[ct] = true
+		}
+	}
+
+	assert.True(t, contentTypes["application/zip"], "ndjson should have application/zip")
+	assert.True(t, contentTypes["text/zip"], "csv/parquet should have text/zip")
+}
+
+func TestExecuteSendStep_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"issue":"bad request"}`))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-send-error"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload Binary")
+}
+
+func TestExecuteSendStep_NoFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	jobID := "test-send-empty"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	job := createSendTestJob("http://unused", jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no files found")
+}
+
+func TestExecuteSendStep_InvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	jobID := "test-send-invalid-config"
+	jobDir := filepath.Join(tmpDir, jobID)
+
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: "/tmp/test",
+		InputType:   models.InputTypeLocal,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(models.StepSend),
+		Config: models.ProjectConfig{
+			Pipeline: models.PipelineConfig{
+				EnabledSteps: []models.StepName{models.StepLocalImport, models.StepSend},
+			},
+			Services: models.ServiceConfig{
+				Send: models.SendConfig{
+					ServerURL: "", // Missing required field
+				},
+			},
+			JobsDir: tmpDir,
+		},
+		Steps: []models.PipelineStep{
+			{Name: models.StepSend, Status: models.StepStatusPending},
+		},
+	}
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server_url is required")
+}
+
+func TestExecuteSendStep_NotEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	jobID := "test-send-disabled"
+	jobDir := filepath.Join(tmpDir, jobID)
+
+	// Create a job where send step is NOT in enabled steps
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: "/tmp/test",
+		InputType:   models.InputTypeLocal,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(models.StepSend),
+		Config: models.ProjectConfig{
+			Pipeline: models.PipelineConfig{
+				EnabledSteps: []models.StepName{models.StepLocalImport}, // No StepSend
+			},
+			Services: models.ServiceConfig{
+				Send: models.SendConfig{
+					ServerURL:              "http://unused",
+					ProjectIdentifier:      "TEST-PROJECT",
+					OrganizationIdentifier: "test.org",
+				},
+			},
+			JobsDir: tmpDir,
+		},
+		Steps: []models.PipelineStep{
+			{Name: models.StepSend, Status: models.StepStatusPending},
+		},
+	}
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	// Should succeed by skipping (not an error)
+	assert.NoError(t, err)
+}
+
+func TestExecuteSendStep_InputDirNotExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-send-no-input-dir"
+	jobDir := filepath.Join(tmpDir, jobID)
+	// Deliberately NOT creating the input directory
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list input files")
+}
+
+func TestExecuteSendStep_DocumentReferenceUploadError(t *testing.T) {
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+
+		// Succeed on Binary uploads, fail on DocumentReference
+		if resource["resourceType"] == "DocumentReference" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"issue":"server error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-docref-error"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload DocumentReference")
+}
+
+func TestExecuteSendStep_JsonFile(t *testing.T) {
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-json-file"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create a JSON file - all files are now zipped
+	bundleContent := `{
+		"resourceType": "Bundle",
+		"type": "transaction",
+		"entry": [{"resource": {"resourceType": "Patient", "id": "1"}}]
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "bundle.json"), []byte(bundleContent), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// All files are now zipped - JSON files get application/zip
+	var binaryResource map[string]any
+	for _, res := range receivedResources {
+		if res["resourceType"] == "Binary" {
+			binaryResource = res
+			break
+		}
+	}
+	require.NotNil(t, binaryResource)
+	assert.Equal(t, "application/zip", binaryResource["contentType"])
+
+	// Verify the data is a valid zip archive containing the JSON
+	b64Data := binaryResource["data"].(string)
+	zipBytes, err := base64.StdEncoding.DecodeString(b64Data)
+	require.NoError(t, err)
+
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	require.NoError(t, err)
+	require.Len(t, zipReader.File, 1)
+	assert.Equal(t, "bundle.json", zipReader.File[0].Name)
+}
+
+func TestExecuteSendStep_AllJsonFilesZipped(t *testing.T) {
+	// All JSON files are now zipped - no special handling for FHIR Bundles
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-all-json-zipped"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create various JSON files - all should be zipped
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "config.json"), []byte(`{"type": "config"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "invalid.json"), []byte(`{not valid json}`), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Count Binary resources with application/zip
+	zipCount := 0
+	for _, res := range receivedResources {
+		if res["resourceType"] == "Binary" && res["contentType"] == "application/zip" {
+			zipCount++
+		}
+	}
+	assert.Equal(t, 2, zipCount, "All JSON files should be zipped")
+}
+
+func TestExecuteSendStep_SubdirectoryFiles(t *testing.T) {
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-subdirs"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	subDir := filepath.Join(inputDir, "subdir")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+
+	// Create files in both root and subdirectory
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "root.csv"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "nested.csv"), []byte("nested"), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Should process 2 files (root.csv + nested.csv) -> 2 Binaries + 1 DocumentReference
+	binaryCount := 0
+	for _, res := range receivedResources {
+		if res["resourceType"] == "Binary" {
+			binaryCount++
+		}
+	}
+	assert.Equal(t, 2, binaryCount)
+}
+
+func TestExecuteSendStep_ServerNonRetryableError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 400 Bad Request (non-retryable error)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"issue":"bad request"}`))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-non-retryable-error"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload Binary")
+
+	// Check that step has non-transient error type for 400 errors
+	var sendStep *models.PipelineStep
+	for i := range job.Steps {
+		if job.Steps[i].Name == models.StepSend {
+			sendStep = &job.Steps[i]
+			break
+		}
+	}
+	require.NotNil(t, sendStep)
+	assert.Equal(t, models.ErrorTypeNonTransient, sendStep.LastError.Type)
+}
+
+func TestExecuteSendStep_UnknownFileExtension(t *testing.T) {
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-unknown-ext"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create a file with unknown extension
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "data.xyz"), []byte("some data"), 0644))
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	var binaryResource map[string]any
+	for _, res := range receivedResources {
+		if res["resourceType"] == "Binary" {
+			binaryResource = res
+			break
+		}
+	}
+	require.NotNil(t, binaryResource)
+	// Unknown extension defaults to application/zip
+	assert.Equal(t, "application/zip", binaryResource["contentType"])
+}
+
+func TestExecuteSendStep_FileReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-file-read-error"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create a file that cannot be read (directory pretending to be a file via symlink trick won't work)
+	// Instead, create a file and then make its directory unreadable
+	testFile := filepath.Join(inputDir, "test.csv")
+	require.NoError(t, os.WriteFile(testFile, []byte("data"), 0644))
+
+	// Make the file unreadable by removing read permissions
+	require.NoError(t, os.Chmod(testFile, 0000))
+
+	// Restore permissions after test
+	defer func() { _ = os.Chmod(testFile, 0644) }()
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+}
+
+func TestExecuteSendStep_CompressedNdjsonFile(t *testing.T) {
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-compressed-ndjson"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create a .ndjson.zst file (compressed NDJSON)
+	ndjsonContent := `{"resourceType":"Patient","id":"1"}` + "\n"
+
+	// Write compressed content using zstd
+	zstdFile := filepath.Join(inputDir, "Patient.ndjson.zst")
+	compressedWriter, err := lib.CreateCompressedFileWriter(zstdFile, "default")
+	require.NoError(t, err)
+	_, err = compressedWriter.Write([]byte(ndjsonContent))
+	require.NoError(t, err)
+	require.NoError(t, compressedWriter.Close())
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err = pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify the Binary was created with zip content type
+	var binaryResource map[string]any
+	for _, res := range receivedResources {
+		if res["resourceType"] == "Binary" {
+			binaryResource = res
+			break
+		}
+	}
+	require.NotNil(t, binaryResource)
+	assert.Equal(t, "application/zip", binaryResource["contentType"])
+
+	// Verify the zip contains the uncompressed NDJSON content
+	b64Data := binaryResource["data"].(string)
+	zipBytes, err := base64.StdEncoding.DecodeString(b64Data)
+	require.NoError(t, err)
+
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	require.NoError(t, err)
+	require.Len(t, zipReader.File, 1)
+
+	// The zip entry should have .ndjson extension (without .zst)
+	assert.Equal(t, "Patient.ndjson", zipReader.File[0].Name)
+
+	// Verify content
+	rc, err := zipReader.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	decompressed, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, ndjsonContent, string(decompressed))
+}
+
+func TestExecuteSendStep_CompressedJsonFile(t *testing.T) {
+	var receivedResources []map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var resource map[string]any
+		_ = json.Unmarshal(body, &resource)
+		receivedResources = append(receivedResources, resource)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-compressed-json"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create a compressed JSON file (.json.zst)
+	jsonContent := `{"resourceType":"Bundle","type":"transaction","entry":[]}`
+
+	// Write compressed content
+	zstdFile := filepath.Join(inputDir, "data.json.zst")
+	compressedWriter, err := lib.CreateCompressedFileWriter(zstdFile, "default")
+	require.NoError(t, err)
+	_, err = compressedWriter.Write([]byte(jsonContent))
+	require.NoError(t, err)
+	require.NoError(t, compressedWriter.Close())
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err = pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify the Binary was created
+	var binaryResource map[string]any
+	for _, res := range receivedResources {
+		if res["resourceType"] == "Binary" {
+			binaryResource = res
+			break
+		}
+	}
+	require.NotNil(t, binaryResource)
+	// Compressed JSON files (.json.zst) go through default path and get zipped
+	assert.Equal(t, "application/zip", binaryResource["contentType"])
+}
+
+func TestExecuteSendStep_UnreadableFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-unreadable-file"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	// Create a file but make it unreadable
+	testFile := filepath.Join(inputDir, "test.json")
+	require.NoError(t, os.WriteFile(testFile, []byte(`{"resourceType":"Patient"}`), 0644))
+
+	// Make the file unreadable
+	require.NoError(t, os.Chmod(testFile, 0000))
+	defer func() { _ = os.Chmod(testFile, 0644) }()
+
+	job := createSendTestJob(server.URL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	// Should fail when trying to read the file to process it
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+}
+
+func TestExecuteSendStep_ConnectionRefused(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network error test in short mode")
+	}
+
+	// Use localhost with a port that's not listening to trigger connection refused
+	// Find a high port that's likely not in use
+	unreachableURL := "http://127.0.0.1:59999"
+
+	tmpDir := t.TempDir()
+	jobID := "test-connection-refused"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJob(unreachableURL, jobID, tmpDir)
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to upload Binary")
+
+	// Check that step has transient error type (connection refused is transient)
+	var sendStep *models.PipelineStep
+	for i := range job.Steps {
+		if job.Steps[i].Name == models.StepSend {
+			sendStep = &job.Steps[i]
+			break
+		}
+	}
+	require.NotNil(t, sendStep)
+	assert.Equal(t, models.ErrorTypeTransient, sendStep.LastError.Type)
+}
+
+func createSendTestJob(serverURL, jobID, jobsDir string) *models.PipelineJob {
+	return &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: "/tmp/test",
+		InputType:   models.InputTypeLocal,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(models.StepSend),
+		Config: models.ProjectConfig{
+			Pipeline: models.PipelineConfig{
+				EnabledSteps: []models.StepName{
+					models.StepLocalImport,
+					models.StepFlattening,
+					models.StepSend,
+				},
+			},
+			Services: models.ServiceConfig{
+				Send: models.SendConfig{
+					ServerURL:              serverURL,
+					ProjectIdentifier:      "TEST-PROJECT",
+					OrganizationIdentifier: "test.hospital.de",
+				},
+			},
+			JobsDir: jobsDir,
+		},
+		Steps: []models.PipelineStep{
+			{Name: models.StepSend, Status: models.StepStatusPending},
+		},
+	}
+}
+
+func createSendTestJobWithAuth(serverURL, jobID, jobsDir string, sendConfig models.SendConfig) *models.PipelineJob {
+	sendConfig.ServerURL = serverURL
+	if sendConfig.ProjectIdentifier == "" {
+		sendConfig.ProjectIdentifier = "TEST-PROJECT"
+	}
+	if sendConfig.OrganizationIdentifier == "" {
+		sendConfig.OrganizationIdentifier = "test.hospital.de"
+	}
+	return &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: "/tmp/test",
+		InputType:   models.InputTypeLocal,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(models.StepSend),
+		Config: models.ProjectConfig{
+			Pipeline: models.PipelineConfig{
+				EnabledSteps: []models.StepName{
+					models.StepLocalImport,
+					models.StepFlattening,
+					models.StepSend,
+				},
+			},
+			Services: models.ServiceConfig{
+				Send: sendConfig,
+			},
+			JobsDir: jobsDir,
+		},
+		Steps: []models.PipelineStep{
+			{Name: models.StepSend, Status: models.StepStatusPending},
+		},
+	}
+}
+
+func TestExecuteSendStep_BasicAuth(t *testing.T) {
+	var receivedAuthHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-basic-auth"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJobWithAuth(server.URL, jobID, tmpDir, models.SendConfig{
+		Username: "testuser",
+		Password: "testpass",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify Basic Auth header was sent
+	assert.True(t, strings.HasPrefix(receivedAuthHeader, "Basic "))
+
+	// Decode and verify credentials
+	encodedCreds := strings.TrimPrefix(receivedAuthHeader, "Basic ")
+	decoded, err := base64.StdEncoding.DecodeString(encodedCreds)
+	require.NoError(t, err)
+	assert.Equal(t, "testuser:testpass", string(decoded))
+}
+
+func TestExecuteSendStep_OAuth2(t *testing.T) {
+	var receivedAuthHeader string
+	var tokenRequests int
+
+	// Mock OAuth2 token server
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests++
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/protocol/openid-connect/token", r.URL.Path)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		body, _ := io.ReadAll(r.Body)
+		bodyStr := string(body)
+		assert.Contains(t, bodyStr, "grant_type=client_credentials")
+		assert.Contains(t, bodyStr, "client_id=test-client")
+		assert.Contains(t, bodyStr, "client_secret=test-secret")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token": "test-token-12345", "expires_in": 300, "token_type": "Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	// Mock FHIR server
+	fhirServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fhirServer.Close()
+
+	// Clear the token cache before the test
+	pipeline.ClearOAuth2TokenCacheForTesting()
+
+	tmpDir := t.TempDir()
+	jobID := "test-oauth2"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJobWithAuth(fhirServer.URL, jobID, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "test-client",
+		OAuthClientSecret: "test-secret",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify Bearer token was sent
+	assert.Equal(t, "Bearer test-token-12345", receivedAuthHeader)
+
+	// Token should have been fetched (could be 1 or 2 depending on caching)
+	assert.GreaterOrEqual(t, tokenRequests, 1)
+}
+
+func TestExecuteSendStep_NoAuth(t *testing.T) {
+	var receivedAuthHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-no-auth"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	// No auth configured
+	job := createSendTestJobWithAuth(server.URL, jobID, tmpDir, models.SendConfig{})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// No Authorization header should be sent
+	assert.Empty(t, receivedAuthHeader)
+}
+
+func TestExecuteSendStep_OAuth2TokenError(t *testing.T) {
+	// Mock OAuth2 token server that returns an error
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "invalid_client", "error_description": "Bad credentials"}`))
+	}))
+	defer tokenServer.Close()
+
+	// Mock FHIR server (should not be called)
+	fhirServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("FHIR server should not be called when token fetch fails")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fhirServer.Close()
+
+	// Clear the token cache before the test
+	pipeline.ClearOAuth2TokenCacheForTesting()
+
+	tmpDir := t.TempDir()
+	jobID := "test-oauth2-error"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJobWithAuth(fhirServer.URL, jobID, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "invalid-client",
+		OAuthClientSecret: "wrong-secret",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OAuth2 token")
+}
+
+func TestExecuteSendStep_OAuth2TokenCaching(t *testing.T) {
+	tokenRequestCount := 0
+
+	// Mock OAuth2 token server that counts requests
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequestCount++
+		w.Header().Set("Content-Type", "application/json")
+		// Return a token that expires in 60 seconds (will be cached)
+		_, _ = w.Write([]byte(`{"access_token": "cached-token-xyz", "expires_in": 60, "token_type": "Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	// Mock FHIR server
+	fhirServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fhirServer.Close()
+
+	// Clear the token cache before the test
+	pipeline.ClearOAuth2TokenCacheForTesting()
+
+	tmpDir := t.TempDir()
+
+	// First job execution
+	jobID1 := "test-oauth2-cache-1"
+	jobDir1 := filepath.Join(tmpDir, jobID1)
+	inputDir1 := filepath.Join(jobDir1, "csv")
+	require.NoError(t, os.MkdirAll(inputDir1, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir1, "test.csv"), []byte("data"), 0644))
+
+	job1 := createSendTestJobWithAuth(fhirServer.URL, jobID1, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "test-client",
+		OAuthClientSecret: "test-secret",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job1, jobDir1, logger)
+	require.NoError(t, err)
+
+	firstRequestCount := tokenRequestCount
+
+	// Second job execution - should reuse cached token
+	jobID2 := "test-oauth2-cache-2"
+	jobDir2 := filepath.Join(tmpDir, jobID2)
+	inputDir2 := filepath.Join(jobDir2, "csv")
+	require.NoError(t, os.MkdirAll(inputDir2, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir2, "test2.csv"), []byte("data2"), 0644))
+
+	job2 := createSendTestJobWithAuth(fhirServer.URL, jobID2, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "test-client",
+		OAuthClientSecret: "test-secret",
+	})
+
+	err = pipeline.ExecuteSendStep(job2, jobDir2, logger)
+	require.NoError(t, err)
+
+	// The second execution should not have requested a new token (cached)
+	// Note: Multiple PUT requests in first job may have all used the same token
+	assert.GreaterOrEqual(t, firstRequestCount, 1, "At least one token request should have been made")
+	// If caching works, token requests should not increase significantly
+	assert.LessOrEqual(t, tokenRequestCount, firstRequestCount+1, "Token caching should reduce requests")
+}
+
+func TestExecuteSendStep_OAuth2TokenInvalidJSON(t *testing.T) {
+	// Mock OAuth2 token server that returns invalid JSON
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{invalid json`))
+	}))
+	defer tokenServer.Close()
+
+	// Mock FHIR server (should not be called)
+	fhirServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("FHIR server should not be called when token parsing fails")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fhirServer.Close()
+
+	// Clear the token cache before the test
+	pipeline.ClearOAuth2TokenCacheForTesting()
+
+	tmpDir := t.TempDir()
+	jobID := "test-oauth2-invalid-json"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJobWithAuth(fhirServer.URL, jobID, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "test-client",
+		OAuthClientSecret: "test-secret",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OAuth2 token")
+}
+
+func TestExecuteSendStep_OAuth2TokenMissingAccessToken(t *testing.T) {
+	// Mock OAuth2 token server that returns empty access_token
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Valid JSON but missing access_token
+		_, _ = w.Write([]byte(`{"expires_in": 300, "token_type": "Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	// Mock FHIR server (should not be called)
+	fhirServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("FHIR server should not be called when access_token is missing")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fhirServer.Close()
+
+	// Clear the token cache before the test
+	pipeline.ClearOAuth2TokenCacheForTesting()
+
+	tmpDir := t.TempDir()
+	jobID := "test-oauth2-missing-token"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJobWithAuth(fhirServer.URL, jobID, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "test-client",
+		OAuthClientSecret: "test-secret",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OAuth2 token")
+}
+
+func TestExecuteSendStep_OAuth2TokenShortExpiry(t *testing.T) {
+	tokenRequestCount := 0
+
+	// Mock OAuth2 token server that returns a short-lived token (expires_in <= 30)
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequestCount++
+		w.Header().Set("Content-Type", "application/json")
+		// Token expires in 10 seconds (will NOT be cached since <= 30)
+		_, _ = w.Write([]byte(`{"access_token": "short-lived-token", "expires_in": 10, "token_type": "Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	// Mock FHIR server
+	fhirServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fhirServer.Close()
+
+	// Clear the token cache before the test
+	pipeline.ClearOAuth2TokenCacheForTesting()
+
+	tmpDir := t.TempDir()
+	jobID := "test-oauth2-short-expiry"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.csv"), []byte("data"), 0644))
+
+	job := createSendTestJobWithAuth(fhirServer.URL, jobID, tmpDir, models.SendConfig{
+		OAuthIssuerURI:    tokenServer.URL,
+		OAuthClientID:     "test-client",
+		OAuthClientSecret: "test-secret",
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// With short-lived token, each PUT request may need a new token
+	assert.GreaterOrEqual(t, tokenRequestCount, 1)
+}

--- a/tests/unit/state_persistence_test.go
+++ b/tests/unit/state_persistence_test.go
@@ -29,6 +29,7 @@ func TestGetJobOutputDir(t *testing.T) {
 		{models.StepCSVConversion, "/tmp/jobs/test-job-123/csv"},
 		{models.StepFlattening, "/tmp/jobs/test-job-123/csv"},
 		{models.StepParquetConversion, "/tmp/jobs/test-job-123/parquet"},
+		{models.StepSend, "/tmp/jobs/test-job-123/send"},
 		{models.StepWait, "/tmp/jobs/test-job-123"},
 		{models.StepValidation, "/tmp/jobs/test-job-123"},
 	}


### PR DESCRIPTION
## Summary

- Add `send` pipeline step that prepares and uploads FHIR Binary + DocumentReference resources to a DSF transfer server
- Each pipeline output file is individually zipped, base64-encoded, and wrapped in a FHIR Binary resource
- A DocumentReference links all Binaries with configurable project/organization identifiers
- Everything is wrapped in a FHIR transaction Bundle and POSTed to the configured transfer server
- Add Blaze FHIR server to e2e test infrastructure to verify data transfer

## Content type mapping (per DSF spec)
| File type | Content type |
|-----------|-------------|
| `.ndjson` / `.ndjson.zst` | `application/zip` |
| `.csv` | `text/zip` |
| `.parquet` | `text/zip` |
| FHIR Bundle `.json` | `application/fhir+json` (no zip) |

## Configuration
```yaml
services:
  send:
    server_url: "https://dsf-transfer.example.com/fhir"
    project_identifier: "MII-PROJECT"
    organization_identifier: "your-org.example.de"
```

## Test plan
- [x] Unit tests: 6 tests covering success, zip verification, content type mapping, server errors, no files, invalid config
- [x] Config loading test for send config
- [x] E2E test with Blaze FHIR server verifies DocumentReference and Binary resources land on the server
- [x] CI pipeline passes

Closes #124