### PR TITLE
feat(pipeline): store ViewDefinitions for debugging in job directory

### DIFF
--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"os"
+	"strings"
 	"time"
 )
 
@@ -38,4 +39,20 @@ func GetFileSize(path string) int64 {
 		return 0
 	}
 	return info.Size()
+}
+
+// SanitizeFilename removes or replaces characters that are invalid in filenames
+func SanitizeFilename(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+	)
+	return replacer.Replace(name)
 }

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -80,6 +80,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 	stepIndex := getStepIndexInEnabledSteps(job.Config.Pipeline.EnabledSteps, stepName)
 	inputDir := services.GetStepInputDir(jobsBaseDir, jobID, job.Config.Pipeline.EnabledSteps, stepIndex)
 	outputDir := filepath.Join(jobDir, "csv")
+	viewDefDir := filepath.Join(jobDir, "viewdefinitions")
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
@@ -123,6 +124,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 	flattenerClient := services.NewFlattenerClient(job.Config.Services.Flattening, logger)
 	viewDefBuilder := services.NewViewDefinitionBuilder(lookupTables)
 	csvWriter := services.NewCSVWriter(outputDir)
+	viewDefWriter := services.NewViewDefinitionWriter(viewDefDir)
 
 	attributeGroups := services.GetAttributeGroups(crtdl)
 	fmt.Printf("Processing %d attribute group(s)...\n\n", len(attributeGroups))
@@ -144,6 +146,15 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 				"error", err)
 			fmt.Printf("  ⚠ %s (skipped: %v)\n", group.Name, err)
 			continue
+		}
+
+		// Save ViewDefinition to disk for debugging/auditing (before flattener call)
+		viewDefFilename := services.BuildViewDefinitionFilename(group.Name)
+		if err := viewDefWriter.WriteViewDefinition(viewDefFilename, *viewDef); err != nil {
+			logger.Warn("Failed to save ViewDefinition, continuing",
+				"group_name", group.Name,
+				"filename", viewDefFilename,
+				"error", err)
 		}
 
 		// Filter resources by profile URL

--- a/internal/services/csv_writer.go
+++ b/internal/services/csv_writer.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
@@ -87,28 +88,9 @@ func (w *CSVWriter) WriteCSVDirect(filename string, data string) error {
 	return nil
 }
 
-// SanitizeFilename removes or replaces characters that are invalid in filenames
-func SanitizeFilename(name string) string {
-	// Replace characters that are typically problematic in filenames
-	replacer := strings.NewReplacer(
-		"/", "_",
-		"\\", "_",
-		":", "_",
-		"*", "_",
-		"?", "_",
-		"\"", "_",
-		"<", "_",
-		">", "_",
-		"|", "_",
-	)
-	return replacer.Replace(name)
-}
-
 // BuildCSVFilename creates a CSV filename from an attribute group name
 func BuildCSVFilename(groupName string) string {
-	// Sanitize the group name and add .csv extension
-	sanitized := SanitizeFilename(groupName)
-	return sanitized + ".csv"
+	return lib.SanitizeFilename(groupName) + ".csv"
 }
 
 // ExtractHeaderFromViewDefinition extracts column names from a ViewDefinition

--- a/internal/services/viewdefinition_writer.go
+++ b/internal/services/viewdefinition_writer.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// ViewDefinitionWriter handles writing ViewDefinition JSON files to disk for debugging and auditing
+type ViewDefinitionWriter struct {
+	outputDir string
+}
+
+// NewViewDefinitionWriter creates a new ViewDefinitionWriter with the given output directory
+func NewViewDefinitionWriter(outputDir string) *ViewDefinitionWriter {
+	return &ViewDefinitionWriter{
+		outputDir: outputDir,
+	}
+}
+
+// WriteViewDefinition writes a ViewDefinition to a JSON file
+func (w *ViewDefinitionWriter) WriteViewDefinition(filename string, viewDef models.ViewDefinition) error {
+	if err := os.MkdirAll(w.outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create viewdefinitions directory: %w", err)
+	}
+
+	outputPath := filepath.Join(w.outputDir, filename)
+
+	data, err := json.MarshalIndent(viewDef, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal ViewDefinition: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write ViewDefinition file: %w", err)
+	}
+
+	return nil
+}
+
+// BuildViewDefinitionFilename creates a filename from a group name
+// Format: <sanitized-group-name>_viewdefinition.json
+func BuildViewDefinitionFilename(groupName string) string {
+	sanitized := lib.SanitizeFilename(groupName)
+	return sanitized + "_viewdefinition.json"
+}

--- a/tests/unit/csv_writer_test.go
+++ b/tests/unit/csv_writer_test.go
@@ -143,32 +143,6 @@ func TestValidateCSVHeaderError(t *testing.T) {
 	})
 }
 
-func TestSanitizeFilename(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"normal_name", "normal_name"},
-		{"name with spaces", "name with spaces"},
-		{"name/with/slashes", "name_with_slashes"},
-		{"name\\with\\backslashes", "name_with_backslashes"},
-		{"name:with:colons", "name_with_colons"},
-		{"name*with*asterisks", "name_with_asterisks"},
-		{"name?with?question", "name_with_question"},
-		{`name"with"quotes`, "name_with_quotes"},
-		{"name<with>angles", "name_with_angles"},
-		{"name|with|pipes", "name_with_pipes"},
-		{"complex/path:name*?", "complex_path_name__"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := services.SanitizeFilename(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestBuildCSVFilename(t *testing.T) {
 	tests := []struct {
 		groupName string

--- a/tests/unit/lib/utils_test.go
+++ b/tests/unit/lib/utils_test.go
@@ -1,0 +1,89 @@
+package lib_test
+
+import (
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple name",
+			input:    "Patient",
+			expected: "Patient",
+		},
+		{
+			name:     "name with spaces",
+			input:    "standard pat",
+			expected: "standard pat",
+		},
+		{
+			name:     "forward slash",
+			input:    "Condition/Diagnosis",
+			expected: "Condition_Diagnosis",
+		},
+		{
+			name:     "backslash",
+			input:    "path\\name",
+			expected: "path_name",
+		},
+		{
+			name:     "colon",
+			input:    "name:value",
+			expected: "name_value",
+		},
+		{
+			name:     "asterisk",
+			input:    "name*pattern",
+			expected: "name_pattern",
+		},
+		{
+			name:     "question mark",
+			input:    "name?query",
+			expected: "name_query",
+		},
+		{
+			name:     "double quotes",
+			input:    "name\"quoted\"",
+			expected: "name_quoted_",
+		},
+		{
+			name:     "angle brackets",
+			input:    "name<Test>",
+			expected: "name_Test_",
+		},
+		{
+			name:     "pipe",
+			input:    "name|value",
+			expected: "name_value",
+		},
+		{
+			name:     "complex combination",
+			input:    "MII_PR_Person:Patient<Test>",
+			expected: "MII_PR_Person_Patient_Test_",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only special characters",
+			input:    "/:*?\"<>|",
+			expected: "________",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := lib.SanitizeFilename(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -756,6 +756,62 @@ func TestLoadResourcesFromFile_ScannerError(t *testing.T) {
 	assert.Len(t, result, 1)
 }
 
+// TestExecuteFlatteningStep_ViewDefinitionWriteError tests line 153-158
+// When ViewDefinition write fails, it should log warning and continue
+func TestExecuteFlatteningStep_ViewDefinitionWriteError(t *testing.T) {
+	// Skip on systems where we can't reliably test permission errors
+	if os.Getuid() == 0 {
+		t.Skip("Cannot test permission errors as root")
+	}
+
+	// Create mock flattener server that returns valid CSV data
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("1\n"))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-viewdef-write-error"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	viewDefDir := filepath.Join(jobDir, "viewdefinitions")
+	csvDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.MkdirAll(csvDir, 0755))
+
+	// Create viewdefinitions as a file instead of directory to cause MkdirAll to fail
+	require.NoError(t, os.WriteFile(viewDefDir, []byte("not a directory"), 0644))
+
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", "https://example.com/Patient")
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
+
+	// Create input NDJSON file with matching profile
+	ndjsonContent := `{"resourceType":"Patient","id":"1","meta":{"profile":["https://example.com/Patient"]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte(ndjsonContent), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	// Should complete successfully even though ViewDefinition write fails
+	// (non-fatal error, logged as warning and continues)
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify CSV file was created despite ViewDefinition write failure
+	csvFiles, err := filepath.Glob(filepath.Join(csvDir, "*.csv"))
+	require.NoError(t, err)
+	assert.Len(t, csvFiles, 1)
+}
+
 // TestExecuteFlatteningStep_CSVWriteError tests line 176-180
 // When CSV writing fails, the step should return an error
 func TestExecuteFlatteningStep_CSVWriteError(t *testing.T) {

--- a/tests/unit/viewdefinition_writer_test.go
+++ b/tests/unit/viewdefinition_writer_test.go
@@ -1,0 +1,223 @@
+package unit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildViewDefinitionFilename(t *testing.T) {
+	tests := []struct {
+		name      string
+		groupName string
+		expected  string
+	}{
+		{
+			name:      "simple name",
+			groupName: "Patient",
+			expected:  "Patient_viewdefinition.json",
+		},
+		{
+			name:      "name with spaces",
+			groupName: "standard pat",
+			expected:  "standard pat_viewdefinition.json",
+		},
+		{
+			name:      "name with special characters",
+			groupName: "Condition/Diagnosis",
+			expected:  "Condition_Diagnosis_viewdefinition.json",
+		},
+		{
+			name:      "complex name",
+			groupName: "MII_PR_Person:Patient<Test>",
+			expected:  "MII_PR_Person_Patient_Test__viewdefinition.json",
+		},
+		{
+			name:      "empty name",
+			groupName: "",
+			expected:  "_viewdefinition.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := services.BuildViewDefinitionFilename(tc.groupName)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestWriteViewDefinition_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	writer := services.NewViewDefinitionWriter(tmpDir)
+
+	viewDef := models.NewBaseViewDefinition("TestGroup", "Patient")
+	viewDef.Select = []models.SelectClause{
+		{
+			Column: []models.ColumnDefinition{
+				{Name: "id", Path: "id"},
+				{Name: "gender", Path: "gender"},
+			},
+		},
+	}
+
+	filename := services.BuildViewDefinitionFilename("TestGroup")
+	err := writer.WriteViewDefinition(filename, viewDef)
+	require.NoError(t, err)
+
+	// Verify file exists
+	outputPath := filepath.Join(tmpDir, filename)
+	assert.FileExists(t, outputPath)
+
+	// Verify content is valid JSON
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var parsed models.ViewDefinition
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, "TestGroup", parsed.Name)
+	assert.Equal(t, "Patient", parsed.Resource)
+	assert.Equal(t, "draft", parsed.Status)
+	assert.Len(t, parsed.Select, 1)
+	assert.Len(t, parsed.Select[0].Column, 2)
+}
+
+func TestWriteViewDefinition_CreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	nestedDir := filepath.Join(tmpDir, "nested", "viewdefinitions")
+	writer := services.NewViewDefinitionWriter(nestedDir)
+
+	viewDef := models.NewBaseViewDefinition("Test", "Patient")
+	filename := services.BuildViewDefinitionFilename("Test")
+	err := writer.WriteViewDefinition(filename, viewDef)
+	require.NoError(t, err)
+
+	// Verify directory was created
+	assert.DirExists(t, nestedDir)
+	assert.FileExists(t, filepath.Join(nestedDir, filename))
+}
+
+func TestWriteViewDefinition_PrettyPrintedJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	writer := services.NewViewDefinitionWriter(tmpDir)
+
+	viewDef := models.NewBaseViewDefinition("Test", "Patient")
+	viewDef.Select = []models.SelectClause{
+		{Column: []models.ColumnDefinition{{Name: "id", Path: "id"}}},
+	}
+
+	filename := services.BuildViewDefinitionFilename("Test")
+	err := writer.WriteViewDefinition(filename, viewDef)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, filename))
+	require.NoError(t, err)
+
+	// Check that JSON is indented (not minified)
+	content := string(data)
+	assert.Contains(t, content, "\n")
+	assert.Contains(t, content, "  ") // 2-space indentation
+}
+
+func TestWriteViewDefinition_OverwritesExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	writer := services.NewViewDefinitionWriter(tmpDir)
+
+	// Write first version
+	viewDef1 := models.NewBaseViewDefinition("Test", "Patient")
+	filename := services.BuildViewDefinitionFilename("Test")
+	err := writer.WriteViewDefinition(filename, viewDef1)
+	require.NoError(t, err)
+
+	// Write second version (different resource type)
+	viewDef2 := models.NewBaseViewDefinition("Test", "Observation")
+	err = writer.WriteViewDefinition(filename, viewDef2)
+	require.NoError(t, err)
+
+	// Verify it's the second version
+	data, err := os.ReadFile(filepath.Join(tmpDir, filename))
+	require.NoError(t, err)
+
+	var parsed models.ViewDefinition
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Observation", parsed.Resource)
+}
+
+func TestWriteViewDefinition_MultipleGroups(t *testing.T) {
+	tmpDir := t.TempDir()
+	writer := services.NewViewDefinitionWriter(tmpDir)
+
+	groups := []string{"Patient", "Condition", "Observation"}
+
+	for _, group := range groups {
+		viewDef := models.NewBaseViewDefinition(group, group)
+		filename := services.BuildViewDefinitionFilename(group)
+		err := writer.WriteViewDefinition(filename, viewDef)
+		require.NoError(t, err, "Failed to write ViewDefinition for group: %s", group)
+	}
+
+	// Verify all files exist
+	for _, group := range groups {
+		filename := services.BuildViewDefinitionFilename(group)
+		assert.FileExists(t, filepath.Join(tmpDir, filename))
+	}
+}
+
+func TestWriteViewDefinition_DirectoryCreationError(t *testing.T) {
+	// Use a path that can't be created (file as parent directory)
+	tmpDir := t.TempDir()
+
+	// Create a file where we need a directory
+	blockingFile := filepath.Join(tmpDir, "blocking_file")
+	err := os.WriteFile(blockingFile, []byte("content"), 0644)
+	require.NoError(t, err)
+
+	// Try to write ViewDefinition to a path that requires creating dir inside the file
+	invalidDir := filepath.Join(blockingFile, "viewdefinitions")
+	writer := services.NewViewDefinitionWriter(invalidDir)
+
+	viewDef := models.NewBaseViewDefinition("Test", "Patient")
+	filename := services.BuildViewDefinitionFilename("Test")
+	err = writer.WriteViewDefinition(filename, viewDef)
+
+	// Should fail because can't create directory inside a file
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create viewdefinitions directory")
+}
+
+func TestWriteViewDefinition_WriteFileError(t *testing.T) {
+	// Create a read-only directory
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	err := os.MkdirAll(readOnlyDir, 0755)
+	require.NoError(t, err)
+
+	// Make directory read-only (no write permission)
+	err = os.Chmod(readOnlyDir, 0555)
+	require.NoError(t, err)
+
+	// Ensure we restore permissions after test for cleanup
+	t.Cleanup(func() {
+		_ = os.Chmod(readOnlyDir, 0755)
+	})
+
+	writer := services.NewViewDefinitionWriter(readOnlyDir)
+
+	viewDef := models.NewBaseViewDefinition("Test", "Patient")
+	filename := services.BuildViewDefinitionFilename("Test")
+	err = writer.WriteViewDefinition(filename, viewDef)
+
+	// Should fail because can't write to read-only directory
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write ViewDefinition file")
+}


### PR DESCRIPTION
## Summary
- Save generated ViewDefinitions to `jobs/<job-id>/viewdefinitions/` directory before sending to fhir-flattener service
- Enables debugging and auditing when flattening produces unexpected results
- ViewDefinition files are stored with format `<group-name>_viewdefinition.json`

## Changes
- Add `ViewDefinitionWriter` service following the existing `CSVWriter` pattern
- Integrate ViewDefinition saving into flattening step (before flattener call)
- Move `SanitizeFilename` to `lib` package for shared use
- Non-fatal error handling: pipeline continues if ViewDefinition save fails

Closes #139