### PR TITLE
feat(flattening): support column at viewDefinition level in lookup tables

### DIFF
--- a/internal/models/flattening.go
+++ b/internal/models/flattening.go
@@ -77,9 +77,10 @@ type LookupElement struct {
 // ViewDefSnippet represents the viewDefinition snippet within a lookup element
 // This contains partial ViewDefinition data that will be merged into the final ViewDefinition
 type ViewDefSnippet struct {
-	ForEach       string         `json:"forEach,omitempty"`       // ForEach expression at viewDefinition level
-	ForEachOrNull string         `json:"forEachOrNull,omitempty"` // ForEachOrNull expression at viewDefinition level
-	Select        []SelectClause `json:"select,omitempty"`        // Select clauses for this element
+	ForEach       string             `json:"forEach,omitempty"`       // ForEach expression at viewDefinition level
+	ForEachOrNull string             `json:"forEachOrNull,omitempty"` // ForEachOrNull expression at viewDefinition level
+	Column        []ColumnDefinition `json:"column,omitempty"`        // Column definitions at viewDefinition level (for leaf elements)
+	Select        []SelectClause     `json:"select,omitempty"`        // Select clauses for this element
 }
 
 // ViewDefinition represents a complete SQL-on-FHIR ViewDefinition

--- a/internal/services/viewdefinition_builder.go
+++ b/internal/services/viewdefinition_builder.go
@@ -125,10 +125,12 @@ func (b *ViewDefinitionBuilder) buildAttributeSelect(lookup *models.LookupTable,
 func (b *ViewDefinitionBuilder) resolveWithChildren(lookup *models.LookupTable, element *models.LookupElement) []models.SelectClause {
 	// Check if element has root-level forEach/forEachOrNull
 	hasRootForEach := element.ViewDefinition.ForEach != "" || element.ViewDefinition.ForEachOrNull != ""
+	// Check if element has Column at viewDefinition level (common for leaf elements)
+	hasRootColumn := len(element.ViewDefinition.Column) > 0
 
 	if len(element.Children) == 0 {
-		// No children - convert viewDefSnippet to SelectClause if it has root forEach
-		if hasRootForEach {
+		// No children - convert viewDefSnippet to SelectClause if it has root forEach or Column
+		if hasRootForEach || hasRootColumn {
 			return []models.SelectClause{viewDefSnippetToSelectClause(element.ViewDefinition)}
 		}
 		return element.ViewDefinition.Select
@@ -282,10 +284,12 @@ func cloneSelectClause(sel models.SelectClause) models.SelectClause {
 // viewDefSnippetToSelectClause converts a ViewDefSnippet into a SelectClause.
 // This handles the case where forEach/forEachOrNull is at the viewDefinition level
 // in the lookup JSON, rather than inside a select clause.
+// Also supports Column at the viewDefinition level (for leaf elements in hierarchies).
 func viewDefSnippetToSelectClause(snippet models.ViewDefSnippet) models.SelectClause {
 	return models.SelectClause{
 		ForEach:       snippet.ForEach,
 		ForEachOrNull: snippet.ForEachOrNull,
+		Column:        snippet.Column,
 		Select:        snippet.Select,
 	}
 }

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -1476,3 +1476,157 @@ func TestBuildViewDefinitionWithRealLookupStructure(t *testing.T) {
 		assert.Contains(t, columnNames, "recorded_date")
 	})
 }
+
+// TestIssue142EmbedChildrenIntoParents tests the exact scenario from GitHub issue #142:
+// When a CRTDL references an element that has a parent AND children (a 3-level hierarchy),
+// the children should be resolved first, embedded into the element, then wrapped in parent context.
+// Specifically: column definitions at the viewDefinition level (not inside select) should be supported.
+func TestIssue142EmbedChildrenIntoParents(t *testing.T) {
+	t.Run("child with column at viewDefinition level embedded in parent", func(t *testing.T) {
+		// Exact structure from issue #142
+		lookupTables := []models.LookupTable{
+			{
+				URL:          "https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose",
+				ResourceType: "Condition",
+				Elements: map[string]models.LookupElement{
+					"Condition.code": {
+						Children: []string{
+							"Condition.code.coding:sct",
+							"Condition.code.coding:icd10-gm",
+							"Condition.code.coding:alpha-id",
+							"Condition.code.coding:orphanet",
+						},
+						ViewDefinition: models.ViewDefSnippet{
+							ForEachOrNull: "code",
+							Select:        []models.SelectClause{},
+						},
+					},
+					"Condition.code.coding:icd10-gm": {
+						Parent:   "Condition.code",
+						Children: []string{"Condition.code.coding:icd10-gm.system", "Condition.code.coding:icd10-gm.code"},
+						ViewDefinition: models.ViewDefSnippet{
+							ForEachOrNull: "coding.where(system = 'http://fhir.de/CodeSystem/bfarm/icd-10-gm')",
+							Select:        []models.SelectClause{},
+						},
+					},
+					"Condition.code.coding:icd10-gm.system": {
+						Parent: "Condition.code.coding:icd10-gm",
+						ViewDefinition: models.ViewDefSnippet{
+							// Column at viewDefinition level (not inside select) - this is the key scenario
+							Column: []models.ColumnDefinition{
+								{Name: "Condition_code_codingicd10gm_system", Path: "system", Type: "string"},
+							},
+						},
+					},
+					"Condition.code.coding:icd10-gm.code": {
+						Parent: "Condition.code.coding:icd10-gm",
+						ViewDefinition: models.ViewDefSnippet{
+							// Column at viewDefinition level
+							Column: []models.ColumnDefinition{
+								{Name: "Condition_code_codingicd10gm_code", Path: "code", Type: "code"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// CRTDL references only the middle-tier element
+		group := models.AttributeGroup{
+			Name:           "Diagnosis",
+			GroupReference: "https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose",
+			Attributes: []models.Attribute{
+				{AttributeRef: "Condition.code.coding:icd10-gm"},
+			},
+		}
+
+		builder := services.NewViewDefinitionBuilder(lookupTables)
+		viewDef, err := builder.BuildViewDefinition(group)
+
+		require.NoError(t, err)
+		require.NotNil(t, viewDef)
+
+		// Expected structure (from issue #142):
+		// {
+		//   "select": [
+		//     { "column": [id, patient] },
+		//     {
+		//       "forEachOrNull": "code",
+		//       "select": [
+		//         {
+		//           "forEachOrNull": "coding.where(system = '...')",
+		//           "select": [
+		//             { "column": [system] },
+		//             { "column": [code] }
+		//           ]
+		//         }
+		//       ]
+		//     }
+		//   ]
+		// }
+
+		// Find the outer forEachOrNull: "code" wrapper (from parent)
+		var codeSelectClause *models.SelectClause
+		for i, sel := range viewDef.Select {
+			if sel.ForEachOrNull == "code" {
+				codeSelectClause = &viewDef.Select[i]
+				break
+			}
+		}
+		require.NotNil(t, codeSelectClause, "Should have forEachOrNull: 'code' wrapper from parent")
+
+		// Inside should have the icd10-gm forEachOrNull
+		var icd10gmSelectClause *models.SelectClause
+		for i, sel := range codeSelectClause.Select {
+			if sel.ForEachOrNull == "coding.where(system = 'http://fhir.de/CodeSystem/bfarm/icd-10-gm')" {
+				icd10gmSelectClause = &codeSelectClause.Select[i]
+				break
+			}
+		}
+		require.NotNil(t, icd10gmSelectClause, "Should have forEachOrNull for icd10-gm inside code wrapper")
+
+		// Inside icd10-gm should have the children's columns
+		columnNames := services.ExtractColumnNames(*viewDef)
+		assert.Contains(t, columnNames, "id")
+		assert.Contains(t, columnNames, "patient")
+		assert.Contains(t, columnNames, "Condition_code_codingicd10gm_system")
+		assert.Contains(t, columnNames, "Condition_code_codingicd10gm_code")
+	})
+
+	t.Run("element with column at viewDefinition level resolves correctly", func(t *testing.T) {
+		// Test that Column at viewDefinition level (no Select, no children) works
+		lookupTables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Patient",
+				ResourceType: "Patient",
+				Elements: map[string]models.LookupElement{
+					"Patient.birthDate": {
+						ViewDefinition: models.ViewDefSnippet{
+							Column: []models.ColumnDefinition{
+								{Name: "birth_date", Path: "birthDate", Type: "date"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		group := models.AttributeGroup{
+			Name:           "Patients",
+			GroupReference: "https://example.com/Patient",
+			Attributes: []models.Attribute{
+				{AttributeRef: "Patient.birthDate"},
+			},
+		}
+
+		builder := services.NewViewDefinitionBuilder(lookupTables)
+		viewDef, err := builder.BuildViewDefinition(group)
+
+		require.NoError(t, err)
+		require.NotNil(t, viewDef)
+
+		columnNames := services.ExtractColumnNames(*viewDef)
+		assert.Contains(t, columnNames, "id")
+		assert.Contains(t, columnNames, "birth_date")
+	})
+}


### PR DESCRIPTION
## Summary
- Add `Column` field to `ViewDefSnippet` model to support column definitions at the viewDefinition level
- Update `resolveWithChildren` to handle leaf elements with column at viewDefinition level
- Update `viewDefSnippetToSelectClause` to include Column field when converting snippets

This enables proper embedding of children into parents for 3-level hierarchies where leaf elements define columns directly at the viewDefinition level (not inside a select array).

## Test plan
- [x] Added `TestIssue142EmbedChildrenIntoParents` with 2 test cases covering the exact scenario from the issue
- [x] All existing ViewDefinition builder tests pass
- [x] All unit tests pass

Closes #142