### PR TITLE
docs: update documentation to match current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Aether
 
-A command-line tool for processing FHIR healthcare data through TORCH extraction and DIMP pseudonymization.
+A command-line tool for processing FHIR healthcare data through configurable pipeline steps.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev/)
@@ -18,12 +18,12 @@ A command-line tool for processing FHIR healthcare data through TORCH extraction
 Aether helps you:
 1. **Extract** patient data from a TORCH server using CRTDL query files
 2. **Pseudonymize** the data using a DIMP service to protect patient privacy
+3. **Flatten** FHIR data to CSV using SQL-on-FHIR ViewDefinitions
+4. **Send** processed data to FHIR servers or DSF transfer systems
 
 ## Installation
 
-Aether is available as binary for Linux, macOS and Windows.
-
-For Linux and macOS, an install script is provided. It downloads the binary and verifies GitHub attestations using the GitHub CLI tool (if installed):
+For Linux and macOS:
 
 ```bash
 curl -sSfL https://raw.githubusercontent.com/medizininformatik-initiative/aether/main/install.sh | sh
@@ -39,7 +39,7 @@ aether --help
 
 ## Configuration
 
-Create a file named `aether.yaml` in your working directory:
+Create `aether.yaml` in your working directory:
 
 ```yaml
 services:
@@ -59,8 +59,6 @@ pipeline:
 jobs_dir: "./jobs"
 ```
 
-Replace the URLs and credentials with your actual server details.
-
 ## Usage
 
 ### Run a Pipeline
@@ -69,26 +67,14 @@ Replace the URLs and credentials with your actual server details.
 aether pipeline start your-query.crtdl
 ```
 
-This will:
-1. Send your CRTDL query to TORCH
-2. Wait for extraction to complete
-3. Download the FHIR data
-4. Send it to DIMP for pseudonymization
-5. Save the results in the `jobs` folder
-
 ### Check Status
 
 ```bash
-# List all jobs
 aether job list
-
-# Check a specific job
 aether pipeline status <job-id>
 ```
 
-### Resume a Failed Pipeline
-
-If something goes wrong, you can resume:
+### Resume a Pipeline
 
 ```bash
 aether pipeline continue <job-id>
@@ -98,6 +84,7 @@ aether pipeline continue <job-id>
 
 - [Full Documentation](https://medizininformatik-initiative.github.io/aether/)
 - [Configuration Options](https://medizininformatik-initiative.github.io/aether/getting-started/configuration)
+- [Pipeline Steps](https://medizininformatik-initiative.github.io/aether/guides/pipeline-steps)
 
 ## License
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -62,7 +62,20 @@ export default defineConfig({
           items: [
             { text: 'TORCH Integration', link: '/guides/torch-integration' },
             { text: 'DIMP', link: '/guides/dimp' },
-            { text: 'Pipeline Steps', link: '/guides/pipeline-steps' }
+            {
+              text: 'Pipeline Steps',
+              link: '/guides/pipeline-steps',
+              collapsed: true,
+              items: [
+                { text: 'TORCH Import', link: '/guides/steps/torch-import' },
+                { text: 'Local Import', link: '/guides/steps/local-import' },
+                { text: 'HTTP Import', link: '/guides/steps/http-import' },
+                { text: 'DIMP', link: '/guides/steps/dimp' },
+                { text: 'Flattening', link: '/guides/steps/flattening' },
+                { text: 'Wait', link: '/guides/steps/wait' },
+                { text: 'Send', link: '/guides/steps/send' }
+              ]
+            }
           ]
         },
         {

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -1,299 +1,210 @@
 # CLI Commands
 
-Complete reference for all Aether CLI commands and options.
+Reference for Aether CLI commands.
 
 ## Global Options
-
-All commands support these options:
 
 ```bash
 aether [global-options] <command> [command-options]
 ```
 
-**Global Options:**
-- `--config, -c FILE` - Path to aether.yaml configuration file
-- `--jobs-dir DIR` - Override jobs directory
-- `--help, -h` - Show command help
-- `--version, -v` - Show Aether version
-- `--debug` - Enable debug logging
+- `--config FILE` - Path to configuration file (default: ./aether.yaml)
+- `--verbose, -v` - Enable verbose logging
+- `--help, -h` - Show help
+- `--version` - Show version
 
-## Commands
+## Pipeline Commands
 
 ### aether pipeline start
 
-Start a new pipeline execution.
+Start a new pipeline job.
 
-**Syntax:**
 ```bash
-aether pipeline start [options] <input>
+aether pipeline start [crtdl-file] [options]
 ```
 
 **Arguments:**
-- `<input>` - Path to FHIR directory or CRTDL query file
+- `[crtdl-file]` - Path to CRTDL query file (required if torch or flattening enabled)
 
 **Options:**
-- `--config, -c FILE` - Configuration file (default: aether.yaml)
-- `--jobs-dir DIR` - Override jobs directory
-- `--steps STEP1,STEP2` - Override enabled steps
+- `--no-progress` - Disable progress indicators
+- `--dir PATH` - Directory for local import (overrides config)
 
 **Examples:**
 ```bash
-# Start from local FHIR files
-aether pipeline start /data/fhir/
+# TORCH extraction with CRTDL
+aether pipeline start query.crtdl
 
-# Start from CRTDL query
-aether pipeline start my_cohort.crtdl
+# Local import with CRTDL for flattening
+aether pipeline start query.crtdl --dir /path/to/data
 
-# Override configuration
-aether pipeline start --config prod.yaml query.crtdl
+# Local import without CRTDL (uses config directory)
+aether pipeline start
 
-# Run specific steps only
-aether pipeline start --steps import,dimp /data/fhir/
+# Local import with directory override
+aether pipeline start --dir /path/to/data
+
+# HTTP download
+aether pipeline start https://example.com/fhir/data.ndjson
+
+# Disable progress bars
+aether pipeline start query.crtdl --no-progress
 ```
 
 ### aether pipeline status
 
-Check the status of a running or completed pipeline.
+Check pipeline job status.
 
-**Syntax:**
 ```bash
-aether pipeline status [options] <job-id>
+aether pipeline status <job-id>
 ```
 
-**Arguments:**
-- `<job-id>` - Job identifier
+**Output:**
+- Job ID and status
+- Current step
+- Progress per step (files, bytes)
+- Error messages if failed
 
-**Options:**
-- `--json` - Output as JSON
-- `--jobs-dir DIR` - Override jobs directory
-
-**Examples:**
+**Example:**
 ```bash
-# Check job status
-aether pipeline status abc123
-
-# Get JSON output for scripting
-aether pipeline status --json abc123
+aether pipeline status abc-123-def
 ```
 
 ### aether pipeline continue
 
-Resume a failed pipeline from where it stopped.
+Resume a paused or failed pipeline.
 
-**Syntax:**
 ```bash
-aether pipeline continue [options] <job-id>
+aether pipeline continue <job-id>
 ```
 
-**Arguments:**
-- `<job-id>` - Job identifier of failed pipeline
-
-**Options:**
-- `--config, -c FILE` - Configuration file
-- `--jobs-dir DIR` - Override jobs directory
+**Use cases:**
+- Resume after terminal close
+- Continue after fixing errors
+- Resume from wait step after placing files in wait directory
 
 **Examples:**
 ```bash
 # Resume failed job
-aether pipeline continue abc123
+aether pipeline continue abc-123-def
 
-# Resume with specific configuration
-aether pipeline continue --config prod.yaml abc123
+# Resume from wait step (after placing files)
+aether pipeline continue abc-123-def
 ```
+
+## Job Commands
 
 ### aether job list
 
-List all jobs.
+List all pipeline jobs.
 
-**Syntax:**
 ```bash
-aether job list [options]
-```
-
-**Options:**
-- `--jobs-dir DIR` - Override jobs directory
-- `--status STATUS` - Filter by status (running, completed, failed)
-- `--json` - Output as JSON
-- `--limit N` - Show last N jobs (default: 10)
-
-**Examples:**
-```bash
-# List all jobs
 aether job list
-
-# Show failed jobs only
-aether job list --status failed
-
-# Get as JSON for scripting
-aether job list --json
 ```
 
-### aether job logs
+**Output columns:**
+- JOB ID - Full UUID
+- STATUS - completed/in_progress/failed/pending
+- STEP - Current step
+- FILES - Total files processed
+- AGE - Time since creation
 
-View logs for a specific job.
+**Status symbols:**
+- `✓` - Completed
+- `→` - In progress
+- `✗` - Failed
+- `○` - Pending
 
-**Syntax:**
+**Example:**
 ```bash
-aether job logs [options] <job-id>
+aether job list
 ```
 
-**Arguments:**
-- `<job-id>` - Job identifier
+### aether job run
+
+Execute a specific pipeline step manually.
+
+```bash
+aether job run <job-id> --step <step-name>
+```
 
 **Options:**
-- `--jobs-dir DIR` - Override jobs directory
-- `--follow, -f` - Stream logs continuously
-- `--step STEP` - Show logs for specific step only
-- `--errors-only` - Show only error lines
+- `--step` - Step to execute (required)
+
+**Valid steps:** `torch`, `local_import`, `http_import`, `dimp`, `validation`, `csv_conversion`, `parquet_conversion`
 
 **Examples:**
 ```bash
-# View job logs
-aether job logs abc123
+# Run DIMP step manually
+aether job run abc-123-def --step dimp
 
-# Stream logs as they happen
-aether job logs --follow abc123
-
-# View only DIMP step logs
-aether job logs --step dimp abc123
-
-# Show only errors
-aether job logs --errors-only abc123
+# Run import step manually
+aether job run abc-123-def --step local_import
 ```
 
-### aether job delete
-
-Delete a completed job and its data.
-
-**Syntax:**
-```bash
-aether job delete [options] <job-id>
-```
-
-**Arguments:**
-- `<job-id>` - Job identifier
-
-**Options:**
-- `--jobs-dir DIR` - Override jobs directory
-- `--force, -f` - Skip confirmation prompt
-
-**Examples:**
-```bash
-# Delete job (with confirmation)
-aether job delete abc123
-
-# Force delete without confirmation
-aether job delete --force abc123
-```
+## Other Commands
 
 ### aether completion
 
 Generate shell completion scripts.
 
-**Syntax:**
 ```bash
 aether completion <shell>
 ```
 
-**Arguments:**
-- `<shell>` - Shell type: bash, zsh, fish, powershell
+**Shells:** `bash`, `zsh`, `fish`, `powershell`
 
 **Examples:**
 ```bash
 # Generate bash completions
-aether completion bash
+aether completion bash > /etc/bash_completion.d/aether
 
-# Install for zsh
-aether completion zsh | sudo tee /etc/zsh/completions/_aether
-
-# Install for bash
-aether completion bash | sudo tee /etc/bash_completion.d/aether
+# Generate zsh completions
+aether completion zsh > "${fpath[1]}/_aether"
 ```
 
 ### aether version
 
-Show Aether version and build information.
+Show version information.
 
-**Syntax:**
 ```bash
 aether version
-```
-
-**Output:**
-```
-Aether v1.0.0
-Build: abc123def456
-Go: 1.21.0
 ```
 
 ### aether help
 
 Show help information.
 
-**Syntax:**
 ```bash
 aether help [command]
 ```
 
-**Arguments:**
-- `[command]` - Optional specific command to show help for
-
 **Examples:**
 ```bash
-# Show general help
 aether help
-
-# Show help for specific command
+aether help pipeline
 aether help pipeline start
 ```
 
-## Exit Codes
+## Configuration Loading
 
-- `0` - Success
-- `1` - General error
-- `2` - Configuration error
-- `3` - Invalid input
-- `4` - Service unavailable
-- `5` - Pipeline failed (retryable)
-- `6` - Pipeline failed (fatal)
-
-## Output Formats
-
-### Default (Human-Readable)
-
-```
-Job: abc123
-Status: running
-Steps: torch, import, dimp
-Progress: 45%
-Elapsed: 2m 30s
-ETA: 3m 15s
-```
-
-### JSON Format
-
-```json
-{
-  "job_id": "abc123",
-  "status": "running",
-  "steps": ["torch", "import", "dimp"],
-  "progress": 0.45,
-  "elapsed_seconds": 150,
-  "eta_seconds": 195
-}
-```
+Aether loads configuration in this order:
+1. `--config` flag
+2. `./aether.yaml` (current directory)
+3. `~/.config/aether/aether.yaml` (user config)
 
 ## Environment Variables
 
-- `AETHER_CONFIG` - Default configuration file path
-- `AETHER_JOBS_DIR` - Default jobs directory
-- `AETHER_LOG_LEVEL` - Logging level (debug, info, warn, error)
-- `TORCH_USERNAME` - TORCH username
-- `TORCH_PASSWORD` - TORCH password
-- `DIMP_URL` - DIMP service URL
+Configuration values support environment variable substitution:
+
+```yaml
+services:
+  torch:
+    username: "${TORCH_USERNAME}"
+    password: "${TORCH_PASSWORD}"
+```
 
 ## Next Steps
 
-- [Configuration Reference](./config-reference.md) - Configuration file options
-- [Pipeline Steps](../guides/pipeline-steps.md) - Pipeline architecture
-- [Troubleshooting](../getting-started/installation.md) - Common issues
+- [Configuration Reference](./config-reference.md) - All configuration options
+- [Pipeline Steps](../guides/pipeline-steps.md) - Step details

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -1,491 +1,370 @@
 # Configuration Reference
 
-Comprehensive reference for all Aether configuration options.
+Complete reference for all Aether configuration options.
 
-For an introduction, see [Configuration Guide](../getting-started/configuration.md).
-
-## Complete Configuration Schema
+## Configuration Schema
 
 ```yaml
-# Service endpoints
 services:
-  dimp:
-    url: string                 # DIMP pseudonymization service URL
-    bundle_split_threshold_mb: integer # Bundle size threshold (1-100, default: 10)
-  csv_conversion:
-    url: string                 # CSV conversion service URL (future)
-  parquet_conversion:
-    url: string                 # Parquet conversion service URL (future)
   torch:
-    base_url: string            # TORCH FHIR server URL
-    username: string            # TORCH username
-    password: string            # TORCH password
-    extraction_timeout_minutes: integer # Timeout for extractions (default: 30)
-    polling_interval_seconds: integer # Initial poll interval (default: 5)
-    max_polling_interval_seconds: integer # Max poll interval (default: 30)
+    base_url: string
+    username: string
+    password: string
+    extraction_timeout_minutes: integer  # default: 30
+    polling_interval_seconds: integer    # default: 5
+    max_polling_interval_seconds: integer # default: 30
 
-# Pipeline configuration
+  dimp:
+    url: string
+    bundle_split_threshold_mb: integer   # 1-100, default: 10
+
+  flattening:
+    service_url: string
+    lookup_path: string
+    formats: [string]                    # ["csv"]
+    timeout: duration                    # default: 30m
+
+  send:
+    send_as: string                      # "direct_resource_load" or "transfer_load"
+    url: string
+    batch_size: integer                  # 1-1000, default: 100
+    auth:
+      username: string
+      password: string
+      oauth_issuer_uri: string
+      oauth_client_id: string
+      oauth_client_secret: string
+    transfer:
+      project_identifier: string
+      organization_identifier: string
+
+  local_import:
+    dir: string
+
 pipeline:
-  enabled_steps:
-    - string                    # List of steps: torch, import, dimp, validation, csv_conversion, parquet_conversion
+  enabled_steps: [string]
 
-# Retry strategy
 retry:
-  max_attempts: integer         # Max retry attempts (1-10, default: 5)
-  initial_backoff_ms: integer   # Initial backoff in milliseconds (default: 1000)
-  max_backoff_ms: integer       # Maximum backoff in milliseconds (default: 30000)
+  max_attempts: integer                  # 1-10, default: 5
+  initial_backoff_ms: integer            # default: 1000
+  max_backoff_ms: integer                # default: 30000
 
-# Compression settings
 compression:
-  enabled: boolean              # Enable zstd compression (default: true)
-  level: string                 # Compression level: fastest, default, better, best
+  enabled: boolean                       # default: true
+  level: string                          # fastest, default, better, best
 
-# Job configuration
-jobs_dir: string                # Directory for job state and data (default: ./jobs)
+jobs_dir: string                         # default: ./jobs
 ```
 
-## Service Options
+## Services
 
-### DIMP Configuration
+### TORCH
 
-**Key**: `services.dimp`
-**Type**: Object
-**Required**: Yes (if DIMP step enabled)
-**Default**: None
+TORCH server for FHIR data extraction.
 
-Configuration for DIMP de-identification service.
+```yaml
+services:
+  torch:
+    base_url: "https://torch.example.org"
+    username: "${TORCH_USER}"
+    password: "${TORCH_PASSWORD}"
+    extraction_timeout_minutes: 30
+    polling_interval_seconds: 5
+    max_polling_interval_seconds: 30
+```
 
-**Nested Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `base_url` | string | - | TORCH server URL (required if torch step enabled) |
+| `username` | string | - | Authentication username |
+| `password` | string | - | Authentication password |
+| `extraction_timeout_minutes` | int | 30 | Max wait time for extraction |
+| `polling_interval_seconds` | int | 5 | Initial status check interval |
+| `max_polling_interval_seconds` | int | 30 | Max interval (exponential backoff cap) |
 
-- `url` (String): DIMP service endpoint
-- `bundle_split_threshold_mb` (Integer): Auto-split large bundles (1-100 MB, default: 10)
+### DIMP
+
+DIMP pseudonymization service.
 
 ```yaml
 services:
   dimp:
-    url: "http://localhost:32861/fhir"
+    url: "http://dimp:32861/fhir"
     bundle_split_threshold_mb: 10
 ```
 
-For production:
-```yaml
-services:
-  dimp:
-    url: "https://dimp.prod.healthcare.org/api/fhir"
-    bundle_split_threshold_mb: 50
-```
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | string | - | DIMP service URL (required if dimp step enabled) |
+| `bundle_split_threshold_mb` | int | 10 | Split Bundles larger than this (1-100 MB) |
 
-### CSV Conversion URL
+### Flattening
 
-**Key**: `services.csv_conversion_url`
-**Type**: String (URL)
-**Required**: No
-**Default**: None
-**Status**: Placeholder for future feature
-
-Endpoint for CSV conversion service.
+fhir-flattener service for FHIR to CSV transformation.
 
 ```yaml
 services:
-  csv_conversion_url: "http://localhost:9000/convert/csv"
+  flattening:
+    service_url: "http://fhir-flattener:8000"
+    lookup_path: "/config/flatten-lookup.json"
+    formats:
+      - csv
+    timeout: 30m
 ```
 
-### Parquet Conversion URL
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `service_url` | string | - | fhir-flattener service URL |
+| `lookup_path` | string | - | Path to lookup table file |
+| `formats` | []string | ["csv"] | Output formats |
+| `timeout` | duration | 30m | Request timeout |
 
-**Key**: `services.parquet_conversion_url`
-**Type**: String (URL)
-**Required**: No
-**Default**: None
-**Status**: Placeholder for future feature
+### Send
 
-Endpoint for Parquet conversion service.
+Destination server for uploading processed data.
+
+#### Direct Resource Load
+
+Upload FHIR resources directly to a FHIR server.
 
 ```yaml
 services:
-  parquet_conversion_url: "http://localhost:9000/convert/parquet"
+  send:
+    send_as: "direct_resource_load"
+    url: "https://fhir-server.example.com/fhir"
+    batch_size: 100
+    auth:
+      username: "${FHIR_USER}"
+      password: "${FHIR_PASSWORD}"
 ```
 
-### TORCH Configuration
+#### Transfer Load
 
-**Key**: `services.torch`
-**Type**: Object
-**Required**: Yes (if TORCH step enabled)
-**Default**: None
-
-TORCH FHIR server connection details.
-
-**Nested Options:**
-
-- `base_url` (String): TORCH server URL
-- `username` (String): TORCH username
-- `password` (String): TORCH password
+Package files for DSF-based transfer.
 
 ```yaml
 services:
-  torch:
-    base_url: "https://torch.hospital.org"
-    username: "researcher-name"
-    password: "secure-password"
+  send:
+    send_as: "transfer_load"
+    url: "https://transfer.example.com/fhir"
+    auth:
+      oauth_issuer_uri: "${OAUTH_ISSUER}"
+      oauth_client_id: "${OAUTH_CLIENT}"
+      oauth_client_secret: "${OAUTH_SECRET}"
+    transfer:
+      project_identifier: "MII-PROJECT"
+      organization_identifier: "your-org.example.de"
 ```
 
-**Security**: Use environment variables for sensitive credentials:
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `send_as` | string | - | `direct_resource_load` or `transfer_load` |
+| `url` | string | - | FHIR server base URL |
+| `batch_size` | int | 100 | Resources per transaction (direct mode, 1-1000) |
 
-```bash
-export TORCH_USERNAME="researcher"
-export TORCH_PASSWORD="secret"
-```
+**Authentication (choose one):**
 
-Then in config:
+| Option | Description |
+|--------|-------------|
+| `auth.username` + `auth.password` | Basic authentication |
+| `auth.oauth_issuer_uri` + `oauth_client_id` + `oauth_client_secret` | OAuth2 client credentials |
+
+**Transfer settings (transfer_load mode only):**
+
+| Option | Description |
+|--------|-------------|
+| `transfer.project_identifier` | MII project identifier |
+| `transfer.organization_identifier` | Organization identifier |
+
+### Local Import
+
+Default directory for local FHIR imports.
+
 ```yaml
 services:
-  torch:
-    base_url: "https://torch.hospital.org"
-    username: "${TORCH_USERNAME}"
-    password: "${TORCH_PASSWORD}"
+  local_import:
+    dir: "/data/fhir"
 ```
 
-## Pipeline Options
+| Option | Type | Description |
+|--------|------|-------------|
+| `dir` | string | Default import directory (overridable with `--dir` flag) |
 
-### Enabled Steps
-
-**Key**: `pipeline.enabled_steps`
-**Type**: Array of strings
-**Required**: Yes
-**Default**: None
-
-List of pipeline steps to execute in order.
+## Pipeline
 
 ```yaml
 pipeline:
   enabled_steps:
-    - torch      # Optional: Extract from TORCH
-    - import     # Required: Import FHIR data
-    - dimp       # Optional: Pseudonymization
-```
-
-**Available Steps** (must be in order):
-- `torch` - Extract from TORCH server
-- `import` - Parse and validate FHIR data
-- `dimp` - Pseudonymization via DIMP
-- `validation` - Data quality validation (placeholder)
-- `csv_conversion` - Convert to CSV (placeholder)
-- `parquet_conversion` - Convert to Parquet (placeholder)
-
-**Valid Sequences**:
-```yaml
-# Option A: Local files + DIMP
-- import
-- dimp
-
-# Option B: TORCH + DIMP
-- torch
-- import
-- dimp
-
-# Option C: Full pipeline
-- torch
-- import
-- dimp
-- validation
-- csv_conversion
-```
-
-## Retry Options
-
-### Max Attempts
-
-**Key**: `retry.max_attempts`
-**Type**: Integer
-**Range**: 1-10
-**Default**: 5
-
-Maximum number of automatic retry attempts for transient errors.
-
-```yaml
-retry:
-  max_attempts: 3  # Fewer retries for fast-fail
-```
-
-Higher values = more resilience but longer wait times.
-
-### Initial Backoff
-
-**Key**: `retry.initial_backoff_ms`
-**Type**: Integer (milliseconds)
-**Range**: 100-5000
-**Default**: 1000 (1 second)
-
-Initial wait time before first retry.
-
-```yaml
-retry:
-  initial_backoff_ms: 500  # Start with 500ms
-```
-
-### Max Backoff
-
-**Key**: `retry.max_backoff_ms`
-**Type**: Integer (milliseconds)
-**Range**: 1000-60000
-**Default**: 30000 (30 seconds)
-
-Maximum wait time between retries.
-
-```yaml
-retry:
-  max_backoff_ms: 10000  # Cap at 10 seconds
-```
-
-**Exponential Backoff Formula**:
-```
-wait_time = min(initial * (2 ^ attempt), max_backoff)
-```
-
-Example with defaults:
-- Attempt 1: 1s
-- Attempt 2: 2s
-- Attempt 3: 4s
-- Attempt 4: 8s
-- Attempt 5: 16s
-- Attempt 6+: 30s (capped)
-
-## Compression Options
-
-Aether uses zstd compression for FHIR NDJSON files, reducing disk usage and improving file transfer speeds. Compression is enabled by default.
-
-### Compression Enabled
-
-**Key**: `compression.enabled`
-**Type**: Boolean
-**Default**: `true`
-
-Enable or disable zstd compression for pipeline output files.
-
-```yaml
-compression:
-  enabled: true   # Compressed files use .ndjson.zst extension
-```
-
-When enabled:
-- Output files use `.ndjson.zst` extension
-- Typical compression ratio: 4-7x depending on level
-- Transparent decompression when reading files
-
-When disabled:
-- Output files use plain `.ndjson` extension
-- Useful for debugging or compatibility with tools that don't support zstd
-
-### Compression Level
-
-**Key**: `compression.level`
-**Type**: String
-**Default**: `"default"`
-**Valid Values**: `fastest`, `default`, `better`, `best`
-
-Controls the trade-off between compression speed and ratio.
-
-```yaml
-compression:
-  level: "default"  # Balanced speed and compression
-```
-
-**Level Comparison**:
-
-| Level     | Speed      | Ratio  | Use Case                          |
-|-----------|------------|--------|-----------------------------------|
-| `fastest` | ~500 MB/s  | ~3-4x  | Large datasets, CPU-constrained   |
-| `default` | ~200 MB/s  | ~4-5x  | Balanced (recommended)            |
-| `better`  | ~100 MB/s  | ~5-6x  | Storage-constrained environments  |
-| `best`    | ~50 MB/s   | ~6-7x  | Archival, maximum compression     |
-
-**Backward Compatibility**: Aether automatically detects and reads both compressed (`.ndjson.zst`) and uncompressed (`.ndjson`) files, regardless of the compression setting. This allows processing of data from older pipeline runs or external sources.
-
-## Job Options
-
-### Jobs Directory
-
-**Key**: `jobs.jobs_dir`
-**Type**: String (directory path)
-**Default**: `./jobs`
-
-Directory for storing job state and data.
-
-```yaml
-jobs:
-  jobs_dir: "./jobs"
-```
-
-For network storage:
-```yaml
-jobs:
-  jobs_dir: "/mnt/shared/aether/jobs"
-```
-
-**Requirements**:
-- Must be writable by Aether process
-- Sufficient disk space for processed data
-- Should be backed up regularly
-
-## Complete Example Configurations
-
-### Development Setup
-
-```yaml
-# aether.yaml - local development
-services:
-  dimp_url: "http://localhost:8083/fhir"
-
-pipeline:
-  enabled_steps:
-    - import
+    - local_import
     - dimp
-
-retry:
-  max_attempts: 3
-  initial_backoff_ms: 500
-  max_backoff_ms: 5000
-
-jobs:
-  jobs_dir: "./jobs"
+    - flattening
 ```
 
-### Production TORCH + DIMP
+**Available steps:**
+
+| Step | Description |
+|------|-------------|
+| `torch` | Import via TORCH (requires CRTDL) |
+| `local_import` | Import from local directory |
+| `http_import` | Import from HTTP URL |
+| `dimp` | Pseudonymize via DIMP |
+| `wait` | Pause for manual inspection |
+| `flattening` | Transform to CSV (requires CRTDL) |
+| `send` | Upload to destination server |
+| `validation` | Validate FHIR data (placeholder) |
+| `csv_conversion` | Convert to CSV (placeholder) |
+| `parquet_conversion` | Convert to Parquet (placeholder) |
+
+**Rules:**
+- One import step must be first (torch, local_import, or http_import)
+- Wait step cannot be first or consecutive
+- Flattening requires CRTDL input
+
+## Retry
 
 ```yaml
-# aether.yaml - production
-services:
-  torch:
-    base_url: "https://torch.prod.healthcare.org"
-    username: "${TORCH_USERNAME}"
-    password: "${TORCH_PASSWORD}"
-  dimp_url: "https://dimp.prod.healthcare.org/api/fhir"
-
-pipeline:
-  enabled_steps:
-    - torch
-    - import
-    - dimp
-
 retry:
   max_attempts: 5
   initial_backoff_ms: 1000
   max_backoff_ms: 30000
-
-jobs:
-  jobs_dir: "/data/aether/jobs"
 ```
 
-### Local Files Only
+| Option | Type | Default | Range | Description |
+|--------|------|---------|-------|-------------|
+| `max_attempts` | int | 5 | 1-10 | Max retry attempts for transient errors |
+| `initial_backoff_ms` | int | 1000 | - | Initial backoff delay |
+| `max_backoff_ms` | int | 30000 | - | Max backoff delay |
+
+Exponential backoff: `wait = min(initial * 2^attempt, max)`
+
+## Compression
 
 ```yaml
-# aether.yaml - local processing
-pipeline:
-  enabled_steps:
-    - import
-
-jobs:
-  jobs_dir: "./output"
+compression:
+  enabled: true
+  level: "default"
 ```
 
-### High-Volume Processing
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | true | Enable zstd compression |
+| `level` | string | "default" | Compression level |
+
+**Compression levels:**
+
+| Level | Speed | Ratio | Use Case |
+|-------|-------|-------|----------|
+| `fastest` | ~500 MB/s | ~3-4x | Large datasets, CPU-constrained |
+| `default` | ~200 MB/s | ~4-5x | Balanced (recommended) |
+| `better` | ~100 MB/s | ~5-6x | Storage-constrained |
+| `best` | ~50 MB/s | ~6-7x | Archival |
+
+Output files use `.ndjson.zst` extension when enabled. Aether auto-detects and reads both compressed and uncompressed files.
+
+## Jobs Directory
 
 ```yaml
-# aether.yaml - optimized for large datasets
-services:
-  dimp_url: "http://dimp-cluster:8083/fhir"
-
-pipeline:
-  enabled_steps:
-    - import
-    - dimp
-
-retry:
-  max_attempts: 3
-  initial_backoff_ms: 2000
-  max_backoff_ms: 10000
-
-jobs:
-  jobs_dir: "/mnt/fast-storage/jobs"
+jobs_dir: "./jobs"
 ```
 
-## Environment Variable References
+Directory for job state and data files.
 
-Configuration supports environment variable substitution:
+## Environment Variables
+
+All string values support environment variable substitution:
 
 ```yaml
 services:
   torch:
-    base_url: "${TORCH_BASE_URL}"
     username: "${TORCH_USERNAME}"
     password: "${TORCH_PASSWORD}"
-  dimp_url: "${DIMP_URL}"
-
-jobs:
-  jobs_dir: "${AETHER_DATA_DIR}/jobs"
+  send:
+    url: "${FHIR_SERVER_URL}"
 ```
 
-Set environment variables:
-```bash
-export TORCH_BASE_URL="https://torch.hospital.org"
-export TORCH_USERNAME="researcher"
-export TORCH_PASSWORD="secret"
-export DIMP_URL="http://localhost:8083/fhir"
-export AETHER_DATA_DIR="/data/aether"
-```
+## Example Configurations
 
-## Configuration Validation
+### TORCH + DIMP
 
-Aether validates configuration on startup:
-
-```bash
-# Validate configuration without running
-aether validate-config aether.yaml
-```
-
-**Common Validation Errors**:
-- Missing required services for enabled steps
-- Invalid directory paths
-- Invalid retry values
-- Malformed YAML
-
-## Troubleshooting
-
-### Config file not found
-
-```
-Error: configuration file not found: aether.yaml
-```
-
-Solution: Ensure `aether.yaml` exists in the working directory or specify path:
-```bash
-aether pipeline start --config /etc/aether/config.yaml query.crtdl
-```
-
-### Service unreachable
-
-```
-Error: DIMP service unreachable: connection refused
-```
-
-Solution: Verify service URL and connectivity:
-```bash
-curl http://localhost:8083/fhir/
-```
-
-### Validation failed
-
-```
-Error: configuration validation failed: DIMP URL required for enabled step 'dimp'
-```
-
-Solution: Add required service configuration:
 ```yaml
 services:
-  dimp_url: "http://localhost:8083/fhir"
+  torch:
+    base_url: "https://torch.hospital.org"
+    username: "${TORCH_USER}"
+    password: "${TORCH_PASS}"
+  dimp:
+    url: "http://dimp:32861/fhir"
+
+pipeline:
+  enabled_steps:
+    - torch
+    - dimp
+
+jobs_dir: "./jobs"
+```
+
+### Local Import with Flattening
+
+```yaml
+services:
+  local_import:
+    dir: "/data/fhir"
+  dimp:
+    url: "http://dimp:32861/fhir"
+  flattening:
+    service_url: "http://fhir-flattener:8000"
+    lookup_path: "/config/lookup.json"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+    - flattening
+
+compression:
+  enabled: true
+  level: "default"
+
+jobs_dir: "./jobs"
+```
+
+### Full Pipeline with Send
+
+```yaml
+services:
+  torch:
+    base_url: "https://torch.hospital.org"
+    username: "${TORCH_USER}"
+    password: "${TORCH_PASS}"
+  dimp:
+    url: "http://dimp:32861/fhir"
+  send:
+    send_as: "transfer_load"
+    url: "https://transfer.mii.de/fhir"
+    auth:
+      oauth_issuer_uri: "${OAUTH_ISSUER}"
+      oauth_client_id: "${OAUTH_CLIENT}"
+      oauth_client_secret: "${OAUTH_SECRET}"
+    transfer:
+      project_identifier: "MII-PROJECT"
+      organization_identifier: "hospital.example.de"
+
+pipeline:
+  enabled_steps:
+    - torch
+    - dimp
+    - send
+
+retry:
+  max_attempts: 5
+
+compression:
+  enabled: true
+
+jobs_dir: "/data/aether/jobs"
 ```
 
 ## Next Steps
 
-- [Configuration Guide](../getting-started/configuration.md) - Configuration introduction
 - [CLI Commands](./cli-commands.md) - Command reference
-- [Getting Started](../getting-started/quick-start.md) - Quick start guide
+- [Pipeline Steps](../guides/pipeline-steps.md) - Step details

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Aether uses a YAML file for configuration. Create `aether.yaml` in your working directory.
+Aether uses a YAML configuration file. Create `aether.yaml` in your working directory.
 
 ## Basic Configuration
 
@@ -22,60 +22,134 @@ pipeline:
 jobs_dir: "./jobs"
 ```
 
-## Configuration Options
+## Service Configuration
 
-### TORCH Settings
+### TORCH
 
 ```yaml
 services:
   torch:
-    base_url: "https://your-torch-server.org"  # TORCH server URL
-    username: "your-username"                   # Your username
-    password: "your-password"                   # Your password
-    extraction_timeout_minutes: 30              # How long to wait (default: 30)
-    polling_interval_seconds: 5                 # Check interval (default: 5)
+    base_url: "https://your-torch-server.org"
+    username: "your-username"
+    password: "your-password"
+    extraction_timeout_minutes: 30
+    polling_interval_seconds: 5
 ```
 
-### DIMP Settings
+### DIMP
 
 ```yaml
 services:
   dimp:
-    url: "http://your-dimp-server:32861/fhir"  # DIMP service URL
-    bundle_split_threshold_mb: 10               # Split large files (default: 10)
+    url: "http://your-dimp-server:32861/fhir"
+    bundle_split_threshold_mb: 10  # Auto-split large bundles
 ```
 
-### Flattening Settings
-
-The flattening service transforms FHIR NDJSON data into CSV files. It requires a CRTDL file as input.
+### Flattening
 
 ```yaml
 services:
   flattening:
-    service_url: "http://fhir-flattener:8000"   # fhir-flattener service URL
-    lookup_path: "/path/to/flatten-lookup.json" # Element-to-ViewDefinition mappings
+    service_url: "http://fhir-flattener:8000"
+    lookup_path: "/path/to/flatten-lookup.json"
     formats:
-      - csv                                     # Output format (only csv supported)
-    timeout: 30m                                # Request timeout (default: 30m)
+      - csv
+    timeout: 30m
 ```
 
-### Pipeline Settings
+### Send
+
+**Direct to FHIR server:**
+```yaml
+services:
+  send:
+    send_as: "direct_resource_load"
+    url: "https://fhir-server.example.com/fhir"
+    batch_size: 100
+    auth:
+      username: "${FHIR_USER}"
+      password: "${FHIR_PASSWORD}"
+```
+
+**DSF transfer:**
+```yaml
+services:
+  send:
+    send_as: "transfer_load"
+    url: "https://transfer-server.example.com/fhir"
+    auth:
+      oauth_issuer_uri: "${OAUTH_ISSUER}"
+      oauth_client_id: "${OAUTH_CLIENT_ID}"
+      oauth_client_secret: "${OAUTH_CLIENT_SECRET}"
+    transfer:
+      project_identifier: "MII-PROJECT"
+      organization_identifier: "your-org.example.de"
+```
+
+### Local Import
+
+```yaml
+services:
+  local_import:
+    dir: "/path/to/fhir/data"  # Override with --dir flag
+```
+
+## Pipeline Steps
 
 ```yaml
 pipeline:
   enabled_steps:
-    - torch       # Extract from TORCH
-    - dimp        # Pseudonymize the data
-    - flattening  # Transform to CSV (requires CRTDL input)
+    - torch         # OR local_import OR http_import
+    - dimp          # Pseudonymization
+    - wait          # Pause for inspection (optional)
+    - flattening    # FHIR to CSV (requires CRTDL)
+    - send          # Upload to destination
 ```
 
-### Jobs Directory
+### Step Placement Rules
+
+**Wait steps:**
+- Can be placed between any two steps
+- Cannot be the first step (needs previous step output)
+- Cannot be consecutive (redundant)
+- Multiple wait steps are supported at different points in the pipeline
+
+**Processing steps (dimp, flattening):**
+- Should only appear once in the pipeline
+- Multiple instances are not supported (output directories would be overwritten)
+
+**Import steps (torch, local_import, http_import):**
+- Must be first
+- Only one import step allowed
+
+## Compression
 
 ```yaml
-jobs_dir: "./jobs"  # Where to store job data and results
+compression:
+  enabled: true        # default: true
+  level: "default"     # fastest, default, better, best
+```
+
+Output files use `.ndjson.zst` extension when enabled.
+
+## Environment Variables
+
+Use environment variables for sensitive data:
+
+```yaml
+services:
+  torch:
+    username: "${TORCH_USERNAME}"
+    password: "${TORCH_PASSWORD}"
+```
+
+```bash
+export TORCH_USERNAME="researcher"
+export TORCH_PASSWORD="secret"
 ```
 
 ## Next Steps
 
 - [Quick Start](./quick-start.md) - Run your first pipeline
-- [TORCH Integration](../guides/torch-integration.md) - Learn more about TORCH
+- [Pipeline Steps](../guides/pipeline-steps.md) - Step details
+- [Configuration Reference](../api-reference/config-reference.md) - All options

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,7 +4,7 @@ Get Aether running in 5 minutes.
 
 ## 1. Create Configuration
 
-Create a file named `aether.yaml` in your working directory:
+Create `aether.yaml` in your working directory:
 
 ```yaml
 services:
@@ -24,7 +24,7 @@ pipeline:
 jobs_dir: "./jobs"
 ```
 
-Replace the URLs and credentials with your actual server details.
+Replace URLs and credentials with your actual server details.
 
 ## 2. Run a Pipeline
 
@@ -37,7 +37,9 @@ Aether will:
 2. Wait for extraction to complete
 3. Download the FHIR data
 4. Pseudonymize it via DIMP
-5. Save results in the `jobs` folder
+5. Save results in `jobs/<job-id>/pseudonymized/`
+
+Output files use `.ndjson.zst` extension (zstd compressed).
 
 ## 3. Check Progress
 
@@ -51,13 +53,39 @@ aether pipeline status <job-id>
 
 ## 4. Resume if Needed
 
-If a pipeline fails, resume it:
+If a pipeline fails or pauses, resume it:
 
 ```bash
 aether pipeline continue <job-id>
 ```
 
+## Alternative: Local Import
+
+Process local FHIR files instead of TORCH extraction:
+
+```yaml
+services:
+  local_import:
+    dir: "/path/to/fhir/data"
+  dimp:
+    url: "http://your-dimp-server:32861/fhir"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+```
+
+```bash
+# Use config directory
+aether pipeline start
+
+# Or override with --dir flag
+aether pipeline start --dir /other/path
+```
+
 ## Next Steps
 
 - [Configuration](./configuration.md) - All configuration options
-- [TORCH Integration](../guides/torch-integration.md) - More about TORCH
+- [Pipeline Steps](../guides/pipeline-steps.md) - Available steps
+- [CLI Commands](../api-reference/cli-commands.md) - Command reference

--- a/docs/guides/pipeline-steps.md
+++ b/docs/guides/pipeline-steps.md
@@ -2,115 +2,60 @@
 
 Aether processes data through configurable pipeline steps.
 
-## Available Steps
+## Import Steps
 
-### 1. TORCH (Data Extraction)
+One import step must be first in the pipeline. Only enable one at a time.
 
-Extracts patient data from a TORCH server.
+| Step | Description |
+|------|-------------|
+| [TORCH Import](./steps/torch-import.md) | Extract data from TORCH server using CRTDL queries |
+| [Local Import](./steps/local-import.md) | Import FHIR NDJSON files from local directory |
+| [HTTP Import](./steps/http-import.md) | Download FHIR NDJSON files from HTTP URL |
 
-**What it does:**
-- Sends your CRTDL query to TORCH
-- Waits for extraction to complete
-- Downloads the FHIR data
+## Processing Steps
 
-**Configuration:**
+| Step | Description |
+|------|-------------|
+| [DIMP](./steps/dimp.md) | Pseudonymize FHIR data using DIMP service |
+| [Flattening](./steps/flattening.md) | Transform FHIR NDJSON to CSV |
+| [Wait](./steps/wait.md) | Pause pipeline for manual inspection |
+| [Send](./steps/send.md) | Upload data to FHIR server or DSF transfer |
+
+## Typical Pipelines
+
+### Basic (TORCH + DIMP)
+
 ```yaml
-services:
-  torch:
-    base_url: "https://your-torch-server.org"
-    username: "your-username"
-    password: "your-password"
-
-pipeline:
-  enabled_steps:
-    - torch
-```
-
-### 2. DIMP (Pseudonymization)
-
-Removes or masks identifying information to protect patient privacy.
-
-**What it does:**
-- Sends FHIR data to the DIMP service
-- Receives dimped data back
-- Saves the protected data
-
-**Configuration:**
-```yaml
-services:
-  dimp:
-    url: "http://your-dimp-server:32861/fhir"
-
 pipeline:
   enabled_steps:
     - torch
     - dimp
 ```
 
-### 3. Flattening (FHIR to CSV)
+### Local Data with Manual Review
 
-Transforms FHIR NDJSON data into flattened CSV files using SQL-on-FHIR ViewDefinitions.
-
-**What it does:**
-- Parses CRTDL file to extract attribute groups
-- Builds ViewDefinitions from lookup tables
-- Sends data to fhir-flattener service
-- Writes CSV files for each attribute group
-
-**Requirements:**
-- Pipeline must be started with a CRTDL file (not local dir or HTTP URL)
-- fhir-flattener service must be running
-- Lookup table (flatten-lookup.json) must be configured
-
-**Configuration:**
 ```yaml
-services:
-  flattening:
-    service_url: "http://fhir-flattener:8000"
-    lookup_path: "/path/to/flatten-lookup.json"
-    formats:
-      - csv
-    timeout: 30m
+pipeline:
+  enabled_steps:
+    - local_import
+    - wait          # Review imported data
+    - dimp
+    - wait          # Review pseudonymized data
+    - flattening
+```
 
+### Full Pipeline with Send
+
+```yaml
 pipeline:
   enabled_steps:
     - torch
     - dimp
     - flattening
-```
-
-**Output:**
-CSV files are written to `jobs/<job-id>/csv/` directory, one file per attribute group.
-
-## Typical Pipelines
-
-### Basic Pipeline (TORCH + DIMP)
-
-```yaml
-pipeline:
-  enabled_steps:
-    - torch   # First: get data from TORCH
-    - dimp    # Then: pseudonymize it
-```
-
-### Full Pipeline (with Flattening)
-
-```yaml
-pipeline:
-  enabled_steps:
-    - torch       # Extract from TORCH
-    - dimp        # Pseudonymize
-    - flattening  # Transform to CSV
-```
-
-Run with:
-```bash
-aether pipeline start your-query.crtdl
+    - send
 ```
 
 ## Monitoring
-
-Check pipeline progress:
 
 ```bash
 # List all jobs
@@ -122,9 +67,8 @@ aether pipeline status <job-id>
 
 ## Resuming
 
-If a step fails, resume without restarting:
-
 ```bash
+# Resume failed or paused job
 aether pipeline continue <job-id>
 ```
 

--- a/docs/guides/steps/dimp.md
+++ b/docs/guides/steps/dimp.md
@@ -1,0 +1,43 @@
+# DIMP (Pseudonymization)
+
+De-identifies FHIR data using a DIMP service.
+
+## What it does
+
+- Sends FHIR Bundles to DIMP service
+- Automatically splits large Bundles (>10MB by default)
+- Saves pseudonymized data
+
+## Configuration
+
+```yaml
+services:
+  dimp:
+    url: "http://your-dimp-server:32861/fhir"
+    bundle_split_threshold_mb: 10  # 1-100 MB, default: 10
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | string | - | DIMP service URL (required) |
+| `bundle_split_threshold_mb` | int | 10 | Split Bundles larger than this (1-100 MB) |
+
+## Bundle Splitting
+
+Large FHIR Bundles are automatically split to prevent HTTP 413 errors:
+
+- Bundles exceeding the threshold are partitioned into smaller chunks
+- Each chunk is sent separately to DIMP
+- Results are reassembled after processing
+- 100% data preservation during split-reassemble
+
+## Output
+
+Pseudonymized files are saved to `jobs/<job-id>/pseudonymized/`

--- a/docs/guides/steps/flattening.md
+++ b/docs/guides/steps/flattening.md
@@ -1,0 +1,48 @@
+# Flattening (FHIR to CSV)
+
+Transforms FHIR NDJSON into CSV files using SQL-on-FHIR ViewDefinitions.
+
+## Requirements
+
+- Pipeline must start with a CRTDL file
+- fhir-flattener service running
+- Lookup table configured
+
+## Configuration
+
+```yaml
+services:
+  flattening:
+    service_url: "http://fhir-flattener:8000"
+    lookup_path: "/path/to/flatten-lookup.json"
+    formats:
+      - csv
+    timeout: 30m
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+    - flattening
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `service_url` | string | - | fhir-flattener service URL |
+| `lookup_path` | string | - | Path to lookup table file |
+| `formats` | []string | ["csv"] | Output formats |
+| `timeout` | duration | 30m | Request timeout |
+
+## How it Works
+
+1. Parses CRTDL file to extract attribute groups
+2. Builds ViewDefinitions from lookup tables
+3. Filters resources by profile
+4. Sends data to fhir-flattener service
+5. Writes CSV files for each attribute group
+
+## Output
+
+CSV files are written to `jobs/<job-id>/csv/`, one file per attribute group.

--- a/docs/guides/steps/http-import.md
+++ b/docs/guides/steps/http-import.md
@@ -1,0 +1,23 @@
+# HTTP Import
+
+Downloads FHIR NDJSON files from an HTTP/HTTPS URL.
+
+## Configuration
+
+```yaml
+pipeline:
+  enabled_steps:
+    - http_import
+```
+
+## Usage
+
+```bash
+aether pipeline start https://example.com/fhir/Patient.ndjson
+```
+
+## Notes
+
+- The URL is provided as the argument to `pipeline start`
+- Supports both HTTP and HTTPS URLs
+- Downloads files to the job directory

--- a/docs/guides/steps/local-import.md
+++ b/docs/guides/steps/local-import.md
@@ -1,0 +1,39 @@
+# Local Import
+
+Imports FHIR NDJSON files from a local directory.
+
+## Configuration
+
+```yaml
+services:
+  local_import:
+    dir: "/path/to/fhir/data"
+
+pipeline:
+  enabled_steps:
+    - local_import
+```
+
+## Usage
+
+```bash
+# Use directory from config
+aether pipeline start
+
+# Override directory via flag
+aether pipeline start --dir /other/path
+
+# With CRTDL for flattening
+aether pipeline start query.crtdl --dir /path/to/data
+```
+
+## Configuration Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `dir` | string | Default import directory (overridable with `--dir` flag) |
+
+## Notes
+
+- The `--dir` flag takes precedence over the config file setting
+- When using flattening step, a CRTDL file is still required as input

--- a/docs/guides/steps/send.md
+++ b/docs/guides/steps/send.md
@@ -1,0 +1,96 @@
+# Send
+
+Uploads pipeline output to a destination server. Supports two modes.
+
+## Direct Resource Load
+
+Sends NDJSON directly to a FHIR server using transaction bundles.
+
+```yaml
+services:
+  send:
+    send_as: "direct_resource_load"
+    url: "https://fhir-server.example.com/fhir"
+    batch_size: 100  # resources per transaction (1-1000)
+    auth:
+      username: "${FHIR_USER}"
+      password: "${FHIR_PASSWORD}"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+    - send
+```
+
+### How it Works
+
+1. Reads NDJSON files from input directory
+2. Batches resources into transaction bundles
+3. Uploads each bundle to the FHIR server
+4. Uses PUT for resources with IDs, POST for resources without
+
+## Transfer Load
+
+Packages files for DSF-based transfer using Binary/DocumentReference resources.
+
+```yaml
+services:
+  send:
+    send_as: "transfer_load"
+    url: "https://transfer-server.example.com/fhir"
+    auth:
+      oauth_issuer_uri: "${OAUTH_ISSUER}"
+      oauth_client_id: "${OAUTH_CLIENT_ID}"
+      oauth_client_secret: "${OAUTH_CLIENT_SECRET}"
+    transfer:
+      project_identifier: "MII-PROJECT"
+      organization_identifier: "your-org.example.de"
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+    - send
+```
+
+### How it Works
+
+1. Reads all files from input directory
+2. Zips each file and wraps in FHIR Binary resource
+3. Creates DocumentReference linking all Binary resources
+4. Uploads to transfer server
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `send_as` | string | - | `direct_resource_load` or `transfer_load` |
+| `url` | string | - | FHIR server base URL |
+| `batch_size` | int | 100 | Resources per transaction (direct mode, 1-1000) |
+
+## Authentication
+
+Choose one method:
+
+**Basic Auth:**
+```yaml
+auth:
+  username: "${FHIR_USER}"
+  password: "${FHIR_PASSWORD}"
+```
+
+**OAuth2 Client Credentials:**
+```yaml
+auth:
+  oauth_issuer_uri: "${OAUTH_ISSUER}"
+  oauth_client_id: "${OAUTH_CLIENT_ID}"
+  oauth_client_secret: "${OAUTH_CLIENT_SECRET}"
+```
+
+## Transfer Settings (transfer_load only)
+
+| Option | Description |
+|--------|-------------|
+| `transfer.project_identifier` | MII project identifier |
+| `transfer.organization_identifier` | Organization identifier |

--- a/docs/guides/steps/torch-import.md
+++ b/docs/guides/steps/torch-import.md
@@ -1,0 +1,43 @@
+# TORCH Import
+
+Extracts patient data from a TORCH server using CRTDL queries.
+
+## What it does
+
+- Sends CRTDL query to TORCH
+- Polls for extraction completion
+- Downloads FHIR NDJSON data
+
+## Configuration
+
+```yaml
+services:
+  torch:
+    base_url: "https://your-torch-server.org"
+    username: "your-username"
+    password: "your-password"
+    extraction_timeout_minutes: 30  # default
+    polling_interval_seconds: 5     # default
+    max_polling_interval_seconds: 30 # default
+
+pipeline:
+  enabled_steps:
+    - torch
+```
+
+## Usage
+
+```bash
+aether pipeline start query.crtdl
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `base_url` | string | - | TORCH server URL (required) |
+| `username` | string | - | Authentication username |
+| `password` | string | - | Authentication password |
+| `extraction_timeout_minutes` | int | 30 | Max wait time for extraction |
+| `polling_interval_seconds` | int | 5 | Initial status check interval |
+| `max_polling_interval_seconds` | int | 30 | Max interval (exponential backoff) |

--- a/docs/guides/steps/wait.md
+++ b/docs/guides/steps/wait.md
@@ -1,0 +1,51 @@
+# Wait
+
+Pauses the pipeline for manual data inspection or modification.
+
+## What it does
+
+- Creates an empty `{previous_step}_wait/` directory
+- Pauses pipeline execution
+- Resumes when `pipeline continue` is run and files are present
+
+## Constraints
+
+- Cannot be the first step
+- No consecutive wait steps allowed
+
+## Configuration
+
+```yaml
+pipeline:
+  enabled_steps:
+    - local_import
+    - wait          # Pause after import
+    - dimp
+    - wait          # Pause after pseudonymization
+    - flattening
+```
+
+## Usage
+
+```bash
+# Pipeline pauses automatically at wait step
+aether pipeline start query.crtdl
+
+# Check status - shows "waiting"
+aether pipeline status <job-id>
+
+# Place modified data in the wait directory
+# e.g., jobs/<job-id>/import_wait/
+
+# Resume pipeline
+aether pipeline continue <job-id>
+```
+
+## Wait Directory
+
+The wait directory is created empty. You must place your data files there before continuing:
+
+- After import step: `jobs/<job-id>/import_wait/`
+- After DIMP step: `jobs/<job-id>/pseudonymized_wait/`
+
+The pipeline will only continue when files are present in the wait directory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Aether
   text: FHIR Data Processing Tool
-  tagline: Extract, dimp, validate, and flatten FHIR data
+  tagline: Extract, pseudonymize, flatten, and send FHIR data
   actions:
     - theme: brand
       text: Get Started
@@ -19,11 +19,23 @@ features:
     details: Extract patient data from TORCH servers using CRTDL queries
     link: /guides/torch-integration
   - icon: 🔐
-    title: DIMP
-    details: De-identify, Minimize, Pseudonymize - Protect patient privacy by dimping FHIR data
+    title: DIMP Pseudonymization
+    details: De-identify and pseudonymize FHIR data to protect patient privacy
     link: /guides/dimp
+  - icon: 📊
+    title: FHIR to CSV
+    details: Transform FHIR NDJSON into CSV using SQL-on-FHIR ViewDefinitions
+    link: /guides/steps/flattening
+  - icon: ⏸️
+    title: Wait
+    details: Pause pipeline for manual data inspection or modification
+    link: /guides/steps/wait
+  - icon: 📤
+    title: Send
+    details: Upload data to FHIR servers or package for DSF transfer
+    link: /guides/steps/send
   - icon: ⚙️
     title: Simple Configuration
-    details: One YAML file to configure everything
+    details: One YAML file to configure everything with environment variable support
     link: /getting-started/configuration
 ---


### PR DESCRIPTION
## Summary

- Add documentation for all pipeline steps (wait, send, local_import, http_import)
- Fix inaccurate CLI commands (remove non-existent job logs, job delete)
- Add send step configuration with both modes (direct_resource_load, transfer_load)
- Add OAuth2 authentication documentation
- Split pipeline-steps into individual files for better navigation
- Update VitePress sidebar with expandable pipeline steps menu
- Update README with flattening and send capabilities
- Update feature cards on landing page

## Test plan

- [ ] Verify docs build successfully with VitePress
- [ ] Check all sidebar links work correctly
- [ ] Verify feature card links on landing page
- [ ] Review configuration examples for accuracy

Closes #138