### PR TITLE
fix: use ldflags to inject version at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Project metadata
 PROJECT_NAME := aether
 BINARY_NAME := aether
-VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "1.0.0")
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "dev")
 BUILD_DIR := bin
 MAIN_PATH := cmd/aether/main.go
 
@@ -19,7 +19,7 @@ GOMOD := $(GOCMD) mod
 GOFMT := $(GOCMD) fmt
 
 # Build flags
-LDFLAGS := -ldflags "-X main.Version=$(VERSION)"
+LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
 # Platforms
 PLATFORMS := linux darwin

--- a/cmd/aether/main.go
+++ b/cmd/aether/main.go
@@ -1,10 +1,16 @@
 /*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+Copyright © 2025 Aether Contributors
 */
 package main
 
 import "github.com/medizininformatik-initiative/aether/cmd"
 
+// version is set at build time via ldflags:
+//
+//	go build -ldflags "-X main.version=1.2.3"
+var version = "dev"
+
 func main() {
+	cmd.SetVersion(version)
 	cmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,9 @@ var (
 	// Global flags
 	cfgFile string
 	verbose bool
+
+	// version is set via SetVersion before Execute
+	version = "dev"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -60,7 +63,13 @@ Configuration:
 For more information:
   Documentation: https://github.com/medizininformatik-initiative/aether
   Report issues: https://github.com/medizininformatik-initiative/aether/issues`,
-	Version: "1.0.0",
+	Version: version,
+}
+
+// SetVersion sets the version displayed by --version. Call before Execute.
+func SetVersion(v string) {
+	version = v
+	rootCmd.Version = v
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/tests/unit/version_test.go
+++ b/tests/unit/version_test.go
@@ -1,0 +1,14 @@
+package unit
+
+import (
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetVersion_DoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		cmd.SetVersion("1.2.3")
+	})
+}


### PR DESCRIPTION
## Summary

- Fix `aether --version` reporting `1.0.0` instead of `0.2.0` by implementing proper ldflags-based version injection
- Add `version` variable in `main` package as the ldflags target, with `SetVersion()` bridge to the `cmd` package
- Fix Makefile ldflags path from `-X main.Version` (uppercase, non-existent) to `-X main.version` (lowercase, correct)
- Change Makefile version fallback from `"1.0.0"` to `"dev"` for untagged builds

## Test plan

- [x] `make build && bin/aether --version` outputs `Aether version 0.2.0`
- [x] Custom ldflags override works (`go build -ldflags "-X main.version=99.0.0-test"`)
- [x] Plain `go build` (no ldflags) outputs `Aether version dev`
- [x] All existing tests pass (`go test ./...`)
- [x] New unit test for `SetVersion` passes

Closes #156