### PR TITLE
docs: document TORCH URL import feature

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -34,17 +34,18 @@ Available subcommands:
 
 // pipelineStartCmd represents the pipeline start command
 var pipelineStartCmd = &cobra.Command{
-	Use:   "start [crtdl-file]",
+	Use:   "start [input]",
 	Short: "Start a new pipeline job",
 	Long: `Start a new Data Use Process pipeline job.
 
-Input requirements depend on enabled pipeline steps:
-  • CRTDL file required if: flattening OR torch step is enabled
-  • CRTDL file optional if: only local_import or http_import steps enabled
+Input can be a CRTDL file, local directory, HTTP URL, or TORCH result URL:
+  • CRTDL file: submits extraction to TORCH, then downloads results
+  • TORCH URL: polls an existing extraction and downloads results
+    (auto-detected when URL contains /fhir/extraction/ or /fhir/result/)
+  • HTTP URL: downloads a single NDJSON file directly
+  • Local directory: imports files from disk (via --dir flag or config)
 
-For local imports, specify data directory via:
-  • --dir flag (highest priority)
-  • Config file: services.local_import.dir in aether.yaml
+CRTDL file is required if the flattening step is enabled.
 
 Examples:
   # Extract data using CRTDL query via TORCH
@@ -64,6 +65,9 @@ Examples:
 
   # Download from HTTP URL
   aether pipeline start https://example.com/fhir/Patient.ndjson
+
+  # Direct TORCH URL (skip extraction, poll and download results)
+  aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
 
   # Start without progress indicators
   aether pipeline start query.crtdl --no-progress`,

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -20,11 +20,11 @@ aether [global-options] <command> [command-options]
 Start a new pipeline job.
 
 ```bash
-aether pipeline start [crtdl-file] [options]
+aether pipeline start [input] [options]
 ```
 
 **Arguments:**
-- `[crtdl-file]` - Path to CRTDL query file (required if torch or flattening enabled)
+- `[input]` - CRTDL file, TORCH URL, or HTTP URL. CRTDL file required if flattening enabled. TORCH URLs (containing `/fhir/extraction/` or `/fhir/result/`) skip extraction submission.
 
 **Options:**
 - `--no-progress` - Disable progress indicators
@@ -35,6 +35,9 @@ aether pipeline start [crtdl-file] [options]
 # TORCH extraction with CRTDL
 aether pipeline start query.crtdl
 
+# Direct TORCH URL (skip extraction, poll and download results)
+aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+
 # Local import with CRTDL for flattening
 aether pipeline start query.crtdl --dir /path/to/data
 
@@ -44,7 +47,7 @@ aether pipeline start
 # Local import with directory override
 aether pipeline start --dir /path/to/data
 
-# HTTP download
+# HTTP download (single file)
 aether pipeline start https://example.com/fhir/data.ndjson
 
 # Disable progress bars

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -59,6 +59,16 @@ If a pipeline fails or pauses, resume it:
 aether pipeline continue <job-id>
 ```
 
+## Alternative: Direct TORCH URL
+
+If you already have a TORCH extraction URL, skip the CRTDL submission:
+
+```bash
+aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+```
+
+Aether auto-detects URLs containing `/fhir/extraction/` or `/fhir/result/` and polls them directly. See [TORCH Integration](../guides/torch-integration.md#direct-torch-url-import) for details.
+
 ## Alternative: Local Import
 
 Process local FHIR files instead of TORCH extraction:

--- a/docs/guides/pipeline-steps.md
+++ b/docs/guides/pipeline-steps.md
@@ -8,7 +8,7 @@ One import step must be first in the pipeline. Only enable one at a time.
 
 | Step | Description |
 |------|-------------|
-| [TORCH Import](./steps/torch-import.md) | Extract data from TORCH server using CRTDL queries |
+| [TORCH Import](./steps/torch-import.md) | Extract data from TORCH server using CRTDL queries or a direct TORCH URL |
 | [Local Import](./steps/local-import.md) | Import FHIR NDJSON files from local directory |
 | [HTTP Import](./steps/http-import.md) | Download FHIR NDJSON files from HTTP URL |
 

--- a/docs/guides/steps/torch-import.md
+++ b/docs/guides/steps/torch-import.md
@@ -1,12 +1,18 @@
 # TORCH Import
 
-Extracts patient data from a TORCH server using CRTDL queries.
+Extracts patient data from a TORCH server. Supports two modes: CRTDL-based extraction and direct TORCH URL import.
 
 ## What it does
 
+**CRTDL mode** (submit + poll + download):
 - Sends CRTDL query to TORCH
 - Polls for extraction completion
 - Downloads FHIR NDJSON data
+
+**Direct URL mode** (poll + download):
+- Polls an existing TORCH extraction/result URL
+- Downloads FHIR NDJSON data when ready
+- Skips the extraction submission step
 
 ## Configuration
 
@@ -27,9 +33,19 @@ pipeline:
 
 ## Usage
 
+### With CRTDL file
+
 ```bash
 aether pipeline start query.crtdl
 ```
+
+### With TORCH URL
+
+```bash
+aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+```
+
+URLs containing `/fhir/extraction/` or `/fhir/result/` are automatically recognized as TORCH URLs. See the [TORCH Integration guide](../torch-integration.md#direct-torch-url-import) for details.
 
 ## Configuration Options
 

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -54,13 +54,61 @@ services:
     polling_interval_seconds: 10     # Default is 5
 ```
 
-### Reusing Previous Extractions
+### Direct TORCH URL Import
 
-If you already have a TORCH result URL:
+If you already have a TORCH extraction or result URL, you can pass it directly to skip the CRTDL submission step:
 
 ```bash
-aether pipeline start http://torch-server/fhir/result/abc123
+aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
 ```
 
-This skips the extraction and downloads directly.
+Aether auto-detects TORCH URLs by looking for `/fhir/extraction/` or `/fhir/result/` in the URL (case-sensitive). When a TORCH URL is provided, Aether:
+
+1. **Skips extraction submission** — does not send a CRTDL query
+2. **Polls the URL** — sends GET requests with exponential backoff until the extraction is complete (HTTP 200) or times out
+3. **Downloads all result files** — fetches multiple NDJSON files from the extraction result
+
+This is useful when:
+- Reusing results from a previous extraction
+- Sharing extraction URLs between team members
+- Resuming a download from a known TORCH endpoint
+
+#### URL patterns
+
+URLs must contain one of these path segments to be recognized as TORCH URLs:
+
+- `/fhir/extraction/` — e.g., `https://torch.example.com/fhir/extraction/result-123`
+- `/fhir/result/` — e.g., `https://torch.example.com/fhir/result/abc-xyz`
+
+All other HTTP(S) URLs are treated as plain [HTTP imports](./steps/http-import.md) (single-file download, no polling).
+
+#### Configuration
+
+TORCH URL imports still require TORCH configuration for authentication:
+
+```yaml
+services:
+  torch:
+    base_url: "https://your-torch-server.org"
+    username: "your-username"
+    password: "your-password"
+
+pipeline:
+  enabled_steps:
+    - torch
+    - dimp
+```
+
+The `extraction_timeout_minutes` and polling interval settings also apply.
+
+#### Comparison: CRTDL vs TORCH URL vs HTTP
+
+| | CRTDL | TORCH URL | HTTP URL |
+|---|---|---|---|
+| Input example | `query.crtdl` | `https://torch/fhir/result/123` | `https://example.com/data.ndjson` |
+| Submits extraction | Yes | No | No |
+| Polls for completion | Yes | Yes | No |
+| Downloads multiple files | Yes | Yes | No (single file) |
+| Requires TORCH auth | Yes | Yes | No |
+| First pipeline step | `torch` | `torch` | `http_import` |
 


### PR DESCRIPTION
## Summary

- Document the existing TORCH URL import feature across CLI help text and VitePress documentation
- Users can pass a TORCH extraction/result URL directly to `aether pipeline start` to skip CRTDL submission
- URLs containing `/fhir/extraction/` or `/fhir/result/` are auto-detected as TORCH URLs

## Changes

- **`cmd/pipeline.go`**: Update CLI help text with all input types and TORCH URL example, rename `[crtdl-file]` to `[input]`
- **`docs/guides/torch-integration.md`**: Expand "Reusing Previous Extractions" into full "Direct TORCH URL Import" section with URL patterns, config requirements, and comparison table
- **`docs/guides/steps/torch-import.md`**: Add two-mode description (CRTDL vs Direct URL) and usage examples
- **`docs/api-reference/cli-commands.md`**: Update argument description and add TORCH URL example
- **`docs/getting-started/quick-start.md`**: Add "Alternative: Direct TORCH URL" section
- **`docs/guides/pipeline-steps.md`**: Update TORCH Import description to mention direct URL support

## Test plan

- [x] `go build` passes
- [x] All tests pass (`go test ./...`)
- [x] CLI `--help` output verified
- [x] Doc cross-reference links verified

Closes #155