### PR TITLE
fix(docs): pass latest release version to docs build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -28,6 +30,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Get latest release version
+        id: version
+        run: echo "tag=$(gh release view --json tagName -q .tagName 2>/dev/null || echo 'dev')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -42,6 +50,8 @@ jobs:
       - name: Build documentation
         run: npm run docs:build
         working-directory: docs
+        env:
+          VITE_LATEST_RELEASE: ${{ steps.version.outputs.tag }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitepress'
 
-const version = process.env.VITE_LATEST_RELEASE || 'v0.1.0'
+const version = process.env.VITE_LATEST_RELEASE || 'dev'
 
 export default defineConfig({
   title: 'Aether',


### PR DESCRIPTION
## Summary
- Fetch the latest GitHub release tag during docs build via `gh release view` and pass it as `VITE_LATEST_RELEASE` to VitePress
- Add `release: types: [published]` trigger so docs redeploy immediately when a new release is published
- Change the local dev fallback from `v0.1.0` to `dev`

| Trigger | Version shown |
|---|---|
| Push to main | Latest published release (e.g., `v0.2.1`) |
| Release published | The newly published version |
| Local dev | `dev` |

Closes #159

## Test plan
- [ ] Verify the workflow YAML is valid (syntax checked locally)
- [ ] After merge, push to main triggers docs build with correct version in dropdown
- [ ] Publish a new release and verify docs redeploy with updated version
- [ ] Run `npm run docs:dev` locally without env var and verify dropdown shows `dev`