### PR TITLE
feat: add TLS configuration for self-signed certificates

### DIFF
--- a/cmd/job.go
+++ b/cmd/job.go
@@ -335,7 +335,7 @@ func executeStepManually(job *models.PipelineJob, stepName models.StepName, conf
 		}
 
 		// Create HTTP client
-		httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, logger)
+		httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 		showProgress := true
 
 		importedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, showProgress)

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -185,7 +185,7 @@ func executeStep(job *models.PipelineJob, stepName models.StepName, config *mode
 			return fmt.Errorf("step validation failed: %w", err)
 		}
 
-		httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, logger)
+		httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 		showProgress := !noProgress
 
 		importedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, showProgress)
@@ -346,7 +346,8 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Validating service connectivity...")
-	if err := config.ValidateServiceConnectivity(); err != nil {
+	connectTransport, _ := services.BuildTLSTransport(config.TLS, lib.DefaultLogger)
+	if err := config.ValidateServiceConnectivity(connectTransport); err != nil {
 		return fmt.Errorf("service connectivity check failed: %w\n\nPlease ensure all required services are running and accessible", err)
 	}
 	fmt.Println("✓ All required services are reachable")
@@ -390,6 +391,7 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	httpClient := services.NewHTTPClient(
 		time.Duration(config.Retry.InitialBackoffMs)*time.Millisecond*10, // Longer timeout for downloads
 		config.Retry,
+		config.TLS,
 		logger,
 	)
 

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -170,6 +170,20 @@ retry:
   # Maximum backoff delay in milliseconds (exponential backoff cap)
   max_backoff_ms: 30000
 
+# TLS settings for outgoing HTTP connections
+# Use to trust custom/internal certificates (common in hospital/research networks)
+tls:
+  # Path to a PEM file containing additional certificates to trust
+  # Accepts both CA certificates and individual server certificates
+  # Multiple certificates can be bundled in a single PEM file
+  # System CA certificates are still trusted alongside custom ones
+  # Supports environment variables: ca_cert_path: "${CA_CERT_PATH}"
+  # ca_cert_path: "/path/to/certs.pem"
+
+  # Skip TLS verification entirely (development/testing ONLY)
+  # WARNING: Disables certificate validation — never use in production
+  insecure_skip_verify: false
+
 # Compression settings for pipeline output files
 # Zstd compression reduces disk usage and speeds up file transfers
 compression:

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -11,7 +11,15 @@ type ProjectConfig struct {
 	Pipeline    PipelineConfig    `yaml:"pipeline" json:"pipeline"`
 	Retry       RetryConfig       `yaml:"retry" json:"retry"`
 	Compression CompressionConfig `yaml:"compression" json:"compression"`
+	TLS         TLSConfig         `yaml:"tls" json:"tls" mapstructure:"tls"`
 	JobsDir     string            `yaml:"jobs_dir" json:"jobs_dir"`
+}
+
+// TLSConfig holds TLS settings for outgoing HTTP connections.
+// Used to trust custom/internal CA certificates common in hospital networks.
+type TLSConfig struct {
+	CACertPath         string `yaml:"ca_cert_path" json:"ca_cert_path" mapstructure:"ca_cert_path"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecure_skip_verify" mapstructure:"insecure_skip_verify"`
 }
 
 // CompressionConfig holds compression settings for pipeline output files.

--- a/internal/models/validation.go
+++ b/internal/models/validation.go
@@ -255,12 +255,15 @@ func ValidateJobsDir(path string) error {
 	return nil
 }
 
-// ValidateServiceConnectivity checks if required service URLs are reachable
-// This performs a lightweight HTTP HEAD request to verify connectivity
-// Validates that configured service URLs are reachable
-func (c *ProjectConfig) ValidateServiceConnectivity() error {
+// ValidateServiceConnectivity checks if required service URLs are reachable.
+// This performs a lightweight HTTP HEAD request to verify connectivity.
+// If transport is non-nil it is used for custom TLS settings.
+func (c *ProjectConfig) ValidateServiceConnectivity(transport *http.Transport) error {
 	client := &http.Client{
 		Timeout: 5 * time.Second, // Quick connectivity check
+	}
+	if transport != nil {
+		client.Transport = transport
 	}
 
 	// Check TORCH connectivity if base URL is configured

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -40,7 +40,7 @@ func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger)
 		return err
 	}
 
-	httpClient := services.DefaultHTTPClient()
+	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 	dimpClient := services.NewDIMPClient(job.Config.Services.DIMP.URL, httpClient, logger)
 
 	// Setup directories - use GetStepInputDir to handle wait step correctly

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -120,9 +120,9 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		"total_resources", len(allResources),
 		"job_id", job.JobID)
 
-	// Create clients — Timeout is validated > 0 by FlatteningConfig.Validate() above
-	httpClient := services.NewHTTPClient(job.Config.Services.Flattening.Timeout, job.Config.Retry, logger)
-	flattenerClient := services.NewFlattenerClient(job.Config.Services.Flattening.ServiceURL, httpClient, logger)
+	// Create clients
+	flattenerTransport, _ := services.BuildTLSTransport(job.Config.TLS, logger)
+	flattenerClient := services.NewFlattenerClient(job.Config.Services.Flattening, flattenerTransport, logger)
 	viewDefBuilder := services.NewViewDefinitionBuilder(lookupTables)
 	csvWriter := services.NewCSVWriter(outputDir)
 	viewDefWriter := services.NewViewDefinitionWriter(viewDefDir)

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -152,7 +152,7 @@ func executeTransferLoadSend(job *models.PipelineJob, jobDir string, step *model
 		"binary_count", len(binaryResources),
 		"job_id", job.JobID)
 
-	httpClient := services.DefaultHTTPClient()
+	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 
 	// Upload each Binary resource
 	for i, binary := range binaryResources {
@@ -226,7 +226,7 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 		"total_files", len(orderedFiles))
 
 	// Create HTTP client
-	httpClient := services.DefaultHTTPClient()
+	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 
 	// Create FHIR client
 	fhirClient := services.NewFHIRClient(job.Config.Services.Send, httpClient, logger)

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -116,6 +116,10 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 			Enabled: viper.GetBool("compression.enabled"),
 			Level:   viper.GetString("compression.level"),
 		},
+		TLS: models.TLSConfig{
+			CACertPath:         ExpandEnvVars(viper.GetString("tls.ca_cert_path")),
+			InsecureSkipVerify: viper.GetBool("tls.insecure_skip_verify"),
+		},
 		JobsDir: ExpandEnvVars(viper.GetString("jobs_dir")),
 	}
 

--- a/internal/services/flattener_client.go
+++ b/internal/services/flattener_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
@@ -14,15 +15,30 @@ import (
 // FlattenerClient handles communication with the fhir-flattener service
 type FlattenerClient struct {
 	baseURL    string
-	httpClient *HTTPClient
+	httpClient *http.Client
+	timeout    time.Duration
 	logger     *lib.Logger
 }
 
-// NewFlattenerClient creates a new flattener client with the given base URL
-func NewFlattenerClient(baseURL string, httpClient *HTTPClient, logger *lib.Logger) *FlattenerClient {
+// NewFlattenerClient creates a new flattener client with the given configuration.
+// If transport is non-nil it is applied to the underlying http.Client for custom TLS.
+func NewFlattenerClient(config models.FlatteningConfig, transport *http.Transport, logger *lib.Logger) *FlattenerClient {
+	timeout := config.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Minute
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+	}
+	if transport != nil {
+		client.Transport = transport
+	}
+
 	return &FlattenerClient{
-		baseURL:    baseURL,
-		httpClient: httpClient,
+		baseURL:    config.ServiceURL,
+		httpClient: client,
+		timeout:    timeout,
 		logger:     logger,
 	}
 }
@@ -38,7 +54,8 @@ func (c *FlattenerClient) Flatten(viewDef models.ViewDefinition, resources []map
 	c.logger.Debug("Sending resources to flattener",
 		"viewDefinition", viewDef.Name,
 		"resourceCount", len(resources),
-		"resourceType", viewDef.Resource)
+		"resourceType", viewDef.Resource,
+		"url", c.baseURL+"/fhir/ViewDefinition/$run")
 
 	// Create the FHIR Parameters request
 	request := models.NewFlatteningRequest(viewDef, resources)
@@ -62,12 +79,16 @@ func (c *FlattenerClient) Flatten(viewDef models.ViewDefinition, resources []map
 	req.Header.Set("Content-Type", "application/fhir+json")
 	req.Header.Set("Accept", "text/csv")
 
-	// Execute request via shared HTTPClient (handles retries, logging, backoff)
+	// Execute request
+	startTime := time.Now()
 	resp, err := c.httpClient.Do(req)
+	duration := time.Since(startTime)
+
 	if err != nil {
-		c.logger.Error("Flattener request failed",
+		c.logger.Error("Flattener HTTP request failed",
 			"viewDefinition", viewDef.Name,
-			"error", err)
+			"error", err,
+			"duration", duration)
 		return "", fmt.Errorf("request failed: %w", err)
 	}
 	defer func() {
@@ -76,6 +97,11 @@ func (c *FlattenerClient) Flatten(viewDef models.ViewDefinition, resources []map
 		}
 	}()
 
+	c.logger.Debug("Flattener responded",
+		"status_code", resp.StatusCode,
+		"viewDefinition", viewDef.Name,
+		"duration", duration)
+
 	// Check for HTTP error status
 	if resp.StatusCode >= 400 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
@@ -83,6 +109,7 @@ func (c *FlattenerClient) Flatten(viewDef models.ViewDefinition, resources []map
 
 		c.logger.Error("Flattener service returned error",
 			"status_code", resp.StatusCode,
+			"status", resp.Status,
 			"viewDefinition", viewDef.Name,
 			"error_body", string(bodyBytes))
 
@@ -105,14 +132,21 @@ func (c *FlattenerClient) Flatten(viewDef models.ViewDefinition, resources []map
 
 	c.logger.Debug("Flattener returned CSV data",
 		"viewDefinition", viewDef.Name,
-		"bytes", len(bodyBytes))
+		"bytes", len(bodyBytes),
+		"duration", duration)
 
 	return string(bodyBytes), nil
 }
 
 // HealthCheck verifies the flattener service is available
 func (c *FlattenerClient) HealthCheck() error {
-	resp, err := c.httpClient.Get(c.baseURL + "/health")
+	url := c.baseURL + "/health"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create health check request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("flattener health check failed: %w", err)
 	}

--- a/internal/services/httpclient.go
+++ b/internal/services/httpclient.go
@@ -18,18 +18,28 @@ type HTTPClient struct {
 	logger      *lib.Logger
 }
 
-// NewHTTPClient creates an HTTP client with timeout and retry configuration
-func NewHTTPClient(timeout time.Duration, retryConfig models.RetryConfig, logger *lib.Logger) *HTTPClient {
+// NewHTTPClient creates an HTTP client with timeout, retry, and TLS configuration.
+// If tlsConfig specifies a custom CA or InsecureSkipVerify, a custom transport is built.
+func NewHTTPClient(timeout time.Duration, retryConfig models.RetryConfig, tlsConfig models.TLSConfig, logger *lib.Logger) *HTTPClient {
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	transport, err := BuildTLSTransport(tlsConfig, logger)
+	if err != nil {
+		logger.Warn("Failed to build TLS transport, using defaults", "error", err)
+	} else if transport != nil {
+		client.Transport = transport
+	}
+
 	return &HTTPClient{
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		client:      client,
 		retryConfig: lib.NewRetryConfigFromModel(retryConfig),
 		logger:      logger,
 	}
 }
 
-// DefaultHTTPClient creates an HTTP client with sensible defaults
+// DefaultHTTPClient creates an HTTP client with sensible defaults (no custom TLS).
 func DefaultHTTPClient() *HTTPClient {
 	return NewHTTPClient(
 		30*time.Second,
@@ -38,6 +48,7 @@ func DefaultHTTPClient() *HTTPClient {
 			InitialBackoffMs: 1000,
 			MaxBackoffMs:     30000,
 		},
+		models.TLSConfig{},
 		lib.DefaultLogger,
 	)
 }

--- a/internal/services/tls.go
+++ b/internal/services/tls.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// BuildTLSTransport creates an *http.Transport with custom TLS settings.
+// Returns (nil, nil) when no customization is needed (empty config with defaults).
+func BuildTLSTransport(tlsConfig models.TLSConfig, logger *lib.Logger) (*http.Transport, error) {
+	if tlsConfig.CACertPath == "" && !tlsConfig.InsecureSkipVerify {
+		return nil, nil
+	}
+
+	tlsCfg := &tls.Config{}
+
+	if tlsConfig.InsecureSkipVerify {
+		logger.Warn("TLS verification disabled — use only for development/testing")
+		tlsCfg.InsecureSkipVerify = true
+	}
+
+	if tlsConfig.CACertPath != "" {
+		pemData, err := os.ReadFile(tlsConfig.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file %s: %w", tlsConfig.CACertPath, err)
+		}
+
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			// Fall back to an empty pool if system pool is unavailable
+			pool = x509.NewCertPool()
+		}
+
+		if !pool.AppendCertsFromPEM(pemData) {
+			return nil, fmt.Errorf("failed to parse any certificates from %s", tlsConfig.CACertPath)
+		}
+
+		tlsCfg.RootCAs = pool
+	}
+
+	return &http.Transport{TLSClientConfig: tlsCfg}, nil
+}

--- a/tests/contract/dimp_service_test.go
+++ b/tests/contract/dimp_service_test.go
@@ -52,7 +52,7 @@ func TestDIMPService_Pseudonymize_Success(t *testing.T) {
 
 	// Test the contract
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	originalPatient := map[string]any{
@@ -89,7 +89,7 @@ func TestDIMPService_400BadRequest(t *testing.T) {
 
 	// Test will verify non-retryable error
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	malformedResource := map[string]any{
@@ -120,7 +120,7 @@ func TestDIMPService_500InternalServerError(t *testing.T) {
 
 	// Test will verify retryable error behavior
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{
@@ -143,7 +143,7 @@ func TestDIMPService_502BadGateway(t *testing.T) {
 
 	// Test will verify this is treated as transient/retryable
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{
@@ -172,7 +172,7 @@ func TestDIMPService_422UnprocessableEntity(t *testing.T) {
 
 	// Test will verify non-retryable error
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{

--- a/tests/contract/torch_service_test.go
+++ b/tests/contract/torch_service_test.go
@@ -85,7 +85,7 @@ func TestTORCHService_SubmitExtraction_Success(t *testing.T) {
 
 	// Test will verify submission flow
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -127,7 +127,7 @@ func TestTORCHService_SubmitExtraction_InvalidCRTDL(t *testing.T) {
 
 	// Test will verify error handling
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -157,7 +157,7 @@ func TestTORCHService_SubmitExtraction_Unauthorized(t *testing.T) {
 
 	// Test will verify authentication error handling
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "wronguser",
@@ -189,7 +189,7 @@ func TestTORCHService_PollStatus_InProgress(t *testing.T) {
 
 	// Test will verify polling continues on 202 (will timeout since server always returns 202)
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -241,7 +241,7 @@ func TestTORCHService_PollStatus_Complete(t *testing.T) {
 
 	// Test will verify result parsing
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -279,7 +279,7 @@ func TestTORCHService_PollStatus_Failed(t *testing.T) {
 
 	// Test will verify error handling
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -319,7 +319,7 @@ func TestTORCHService_DownloadFile_Success(t *testing.T) {
 
 	// Test will verify file download
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -350,7 +350,7 @@ func TestTORCHService_DownloadFile_NotFound(t *testing.T) {
 
 	// Test will verify 404 error handling
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -379,7 +379,7 @@ func TestTORCHService_DownloadFile_ServerError(t *testing.T) {
 	// Test will verify error handling on 500
 	// Note: Current implementation doesn't retry downloads (uses client.Do instead of httpClient.Do)
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -472,7 +472,7 @@ func TestTORCHService_EndToEnd_SubmitPollDownload(t *testing.T) {
 
 	// Test will verify complete workflow
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",

--- a/tests/integration/pipeline_import_error_test.go
+++ b/tests/integration/pipeline_import_error_test.go
@@ -38,7 +38,7 @@ func TestPipelineImportError_UnreachableURL(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create job with unreachable URL
 	job, err := pipeline.CreateJob(unreachableURL, config, logger)
@@ -153,7 +153,7 @@ func TestPipelineImportError_HTTP500WithRetry(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Execute import
 	job, _ := pipeline.CreateJob(server.URL+"/error.ndjson", config, logger)
@@ -322,7 +322,7 @@ func TestPipelineImportError_NetworkTimeout(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create HTTP client with short timeout
-	httpClient := services.NewHTTPClient(1*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(1*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Execute import
 	job, _ := pipeline.CreateJob(server.URL+"/slow.ndjson", config, logger)

--- a/tests/integration/pipeline_import_url_test.go
+++ b/tests/integration/pipeline_import_url_test.go
@@ -134,7 +134,7 @@ func TestPipelineImportURL_WithRetry(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
-	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create and execute job
 	job, _ := pipeline.CreateJob(server.URL+"/test.ndjson", config, logger)

--- a/tests/integration/pipeline_multistep_test.go
+++ b/tests/integration/pipeline_multistep_test.go
@@ -82,7 +82,7 @@ func TestPipelineMultiStep_AutomaticExecution(t *testing.T) {
 
 	// Execute import step
 	logger = lib.NewLogger(lib.LogLevelError) // Suppress logs in tests
-	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, models.TLSConfig{}, logger)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err)
 	require.NoError(t, pipeline.UpdateJob(jobsDir, importedJob))
@@ -197,7 +197,7 @@ func TestPipelineMultiStep_OnlyImportEnabled(t *testing.T) {
 
 	// Execute import
 	logger = lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, models.TLSConfig{}, logger)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err)
 
@@ -318,7 +318,7 @@ func TestPipelineMultiStep_JobStatePersistedBetweenSteps(t *testing.T) {
 	require.NoError(t, pipeline.UpdateJob(jobsDir, startedJob))
 
 	logger = lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, models.TLSConfig{}, logger)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err)
 	require.NoError(t, pipeline.UpdateJob(jobsDir, importedJob))

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -160,7 +160,7 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 	assert.NotEmpty(t, job.JobID)
 
 	// Execute import step (which should trigger TORCH extraction)
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
@@ -261,7 +261,7 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	job, err := pipeline.CreateJob(crtdlPath, config, logger)
 	require.NoError(t, err)
 
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
 
 	// Empty result should be handled gracefully
@@ -309,7 +309,7 @@ func TestPipeline_TORCHExtraction_ServerUnavailable(t *testing.T) {
 	job, err := pipeline.CreateJob(crtdlPath, config, logger)
 	require.NoError(t, err)
 
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 	_, err = pipeline.ExecuteImportStep(job, logger, httpClient, false)
 
 	// Should fail with network error
@@ -409,7 +409,7 @@ func TestPipeline_DirectTORCHURL_Download(t *testing.T) {
 	assert.NotEmpty(t, job.JobID)
 
 	// Execute import step (should download directly without extraction submission)
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
@@ -496,7 +496,7 @@ func TestPipeline_DirectTORCHURL_EmptyResult(t *testing.T) {
 	job, err := pipeline.CreateJob(torchResultURL, config, logger)
 	require.NoError(t, err)
 
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
 
 	// Empty result should be handled gracefully
@@ -581,7 +581,7 @@ func TestPipeline_TORCHExtraction_PollingTimeout(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create TORCH client for direct testing
 	torchClient := services.NewTORCHClient(config.Services.TORCH, httpClient, logger)
@@ -760,7 +760,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
 
 	// Step 2: Execute TORCH import step
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 	importedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
 	require.NoError(t, err)
 
@@ -952,7 +952,7 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	require.Equal(t, models.InputTypeCRTDL, job.InputType)
 
 	// Simulate starting the extraction and getting the extraction URL
-	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, models.TLSConfig{}, logger)
 	torchClient := services.NewTORCHClient(config.Services.TORCH, httpClient, logger)
 
 	// Submit extraction

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -1126,8 +1126,41 @@ func TestValidateServiceConnectivity_AllServicesAvailable(t *testing.T) {
 	}
 
 	// ValidateServiceConnectivity should succeed when all services are reachable
-	err := config.ValidateServiceConnectivity()
+	err := config.ValidateServiceConnectivity(nil)
 	assert.NoError(t, err, "All services should be reachable")
+}
+
+// TestValidateServiceConnectivity_WithCustomTransport verifies connectivity check uses the provided transport
+func TestValidateServiceConnectivity_WithCustomTransport(t *testing.T) {
+	dimpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer dimpServer.Close()
+
+	config := models.ProjectConfig{
+		Services: models.ServiceConfig{
+			DIMP: models.DIMPConfig{
+				URL: dimpServer.URL,
+			},
+		},
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{
+				models.StepLocalImport,
+				models.StepDIMP,
+			},
+		},
+		Retry: models.RetryConfig{
+			MaxAttempts:      5,
+			InitialBackoffMs: 1000,
+			MaxBackoffMs:     30000,
+		},
+		JobsDir: "/tmp/jobs",
+	}
+
+	// Pass a non-nil transport to exercise the transport injection branch
+	transport := &http.Transport{}
+	err := config.ValidateServiceConnectivity(transport)
+	assert.NoError(t, err, "Should succeed with custom transport")
 }
 
 // TestValidateServiceConnectivity_DIMMServiceUnreachable verifies error when DIMP service is unreachable
@@ -1161,7 +1194,7 @@ func TestValidateServiceConnectivity_DIMMServiceUnreachable(t *testing.T) {
 	}
 
 	// ValidateServiceConnectivity should fail when DIMP is unreachable
-	err := config.ValidateServiceConnectivity()
+	err := config.ValidateServiceConnectivity(nil)
 	assert.Error(t, err, "Should fail when DIMP service is unreachable")
 	assert.Contains(t, err.Error(), "DIMP")
 }
@@ -1197,7 +1230,7 @@ func TestValidateServiceConnectivity_CSVServiceUnreachable(t *testing.T) {
 	}
 
 	// ValidateServiceConnectivity should fail when CSV service is unreachable
-	err := config.ValidateServiceConnectivity()
+	err := config.ValidateServiceConnectivity(nil)
 	assert.Error(t, err, "Should fail when CSV conversion service is unreachable")
 	assert.Contains(t, err.Error(), "CSV Conversion")
 }
@@ -1233,7 +1266,7 @@ func TestValidateServiceConnectivity_ParquetServiceUnreachable(t *testing.T) {
 	}
 
 	// ValidateServiceConnectivity should fail when Parquet service is unreachable
-	err := config.ValidateServiceConnectivity()
+	err := config.ValidateServiceConnectivity(nil)
 	assert.Error(t, err, "Should fail when Parquet conversion service is unreachable")
 	assert.Contains(t, err.Error(), "Parquet Conversion")
 }
@@ -1271,7 +1304,7 @@ func TestValidateServiceConnectivity_SendServiceAvailable(t *testing.T) {
 	}
 
 	// ValidateServiceConnectivity should succeed when Send service is reachable
-	err := config.ValidateServiceConnectivity()
+	err := config.ValidateServiceConnectivity(nil)
 	assert.NoError(t, err, "Send service should be reachable")
 }
 
@@ -1303,7 +1336,7 @@ func TestValidateServiceConnectivity_SendServiceUnreachable(t *testing.T) {
 	}
 
 	// ValidateServiceConnectivity should fail when Send service is unreachable
-	err := config.ValidateServiceConnectivity()
+	err := config.ValidateServiceConnectivity(nil)
 	assert.Error(t, err, "Should fail when Send service is unreachable")
 	assert.Contains(t, err.Error(), "Send")
 }
@@ -1989,4 +2022,100 @@ func TestPipelineJob_ValidateWithEmptyInputSource_NoConfigDir(t *testing.T) {
 	err := job.Validate()
 	assert.Error(t, err, "Validation should fail with empty InputSource and no config dir")
 	assert.Contains(t, err.Error(), "input_source is required", "Error should mention input_source")
+}
+
+// TestConfigLoading_TLSConfig verifies TLS settings are loaded from YAML
+func TestConfigLoading_TLSConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+pipeline:
+  enabled_steps:
+    - local_import
+
+tls:
+  ca_cert_path: "/etc/ssl/custom/ca-bundle.pem"
+  insecure_skip_verify: true
+
+retry:
+  max_attempts: 3
+  initial_backoff_ms: 500
+  max_backoff_ms: 5000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, "/etc/ssl/custom/ca-bundle.pem", config.TLS.CACertPath, "TLS CA cert path should be loaded")
+	assert.True(t, config.TLS.InsecureSkipVerify, "InsecureSkipVerify should be true")
+}
+
+// TestConfigLoading_TLSConfigDefaults verifies TLS defaults when not specified
+func TestConfigLoading_TLSConfigDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 3
+  initial_backoff_ms: 500
+  max_backoff_ms: 5000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Empty(t, config.TLS.CACertPath, "TLS CA cert path should be empty by default")
+	assert.False(t, config.TLS.InsecureSkipVerify, "InsecureSkipVerify should default to false")
+}
+
+// TestConfigLoading_TLSConfigEnvVar verifies environment variable expansion in ca_cert_path
+func TestConfigLoading_TLSConfigEnvVar(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	require.NoError(t, os.Setenv("TEST_CA_CERT_PATH", "/custom/certs/ca.pem"))
+	defer func() { _ = os.Unsetenv("TEST_CA_CERT_PATH") }()
+
+	configContent := `
+pipeline:
+  enabled_steps:
+    - local_import
+
+tls:
+  ca_cert_path: "${TEST_CA_CERT_PATH}"
+
+retry:
+  max_attempts: 3
+  initial_backoff_ms: 500
+  max_backoff_ms: 5000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, "/custom/certs/ca.pem", config.TLS.CACertPath, "TLS CA cert path should expand env var")
 }

--- a/tests/unit/dimp_client_error_test.go
+++ b/tests/unit/dimp_client_error_test.go
@@ -30,7 +30,7 @@ func TestDIMPClient_Error_400BadRequest(t *testing.T) {
 
 	// Test 400 error handling
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	malformed := map[string]any{
@@ -58,7 +58,7 @@ func TestDIMPClient_Error_422UnprocessableEntity(t *testing.T) {
 
 	// Test 422 error handling
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	invalid := map[string]any{
@@ -83,7 +83,7 @@ func TestDIMPClient_Error_500InternalServerError(t *testing.T) {
 
 	// Test 500 error is retryable
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{
@@ -108,7 +108,7 @@ func TestDIMPClient_Error_502BadGateway(t *testing.T) {
 
 	// Test 502 is retryable (upstream dependency down)
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{
@@ -133,7 +133,7 @@ func TestDIMPClient_Error_503ServiceUnavailable(t *testing.T) {
 
 	// Test 503 is retryable
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{
@@ -158,7 +158,7 @@ func TestDIMPClient_Error_504GatewayTimeout(t *testing.T) {
 
 	// Test 504 is retryable
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{
@@ -175,7 +175,7 @@ func TestDIMPClient_Error_504GatewayTimeout(t *testing.T) {
 func TestDIMPClient_Error_NetworkFailure(t *testing.T) {
 	// Test network connectivity error
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(1*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, logger)
+	httpClient := services.NewHTTPClient(1*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient("http://192.0.2.1:9999", httpClient, logger) // Non-routable IP
 
 	resource := map[string]any{
@@ -198,7 +198,7 @@ func TestDIMPClient_Error_InvalidJSON(t *testing.T) {
 
 	// Test handling of invalid JSON response
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	resource := map[string]any{

--- a/tests/unit/dimp_client_test.go
+++ b/tests/unit/dimp_client_test.go
@@ -35,7 +35,7 @@ func TestDIMPClient_Pseudonymize_Success(t *testing.T) {
 
 	// Test implementation
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	originalPatient := map[string]any{
@@ -81,7 +81,7 @@ func TestDIMPClient_Pseudonymize_PreservesResourceType(t *testing.T) {
 
 			// Test that resourceType is preserved
 			logger := lib.NewLogger(lib.LogLevelError)
-			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 			client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 			original := map[string]any{
@@ -107,7 +107,7 @@ func TestDIMPClient_Pseudonymize_HandlesEmptyResource(t *testing.T) {
 
 	// Test error handling for empty resource
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	client := services.NewDIMPClient(server.URL, httpClient, logger)
 
 	emptyResource := map[string]any{}

--- a/tests/unit/fhir_client_test.go
+++ b/tests/unit/fhir_client_test.go
@@ -34,7 +34,7 @@ func TestFHIRClient_UploadNDJSON_Success(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -73,7 +73,7 @@ func TestFHIRClient_UploadNDJSON_DefaultBatchSize(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -111,7 +111,7 @@ func TestFHIRClient_UploadNDJSON_EmptyLines(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -151,7 +151,7 @@ func TestFHIRClient_UploadNDJSON_BatchSize(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -183,7 +183,7 @@ func TestFHIRClient_UploadNDJSON_ServerError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -205,7 +205,7 @@ func TestFHIRClient_UploadNDJSON_ScannerError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -237,7 +237,7 @@ func TestFHIRClient_UploadNDJSON_PartialBatchError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -270,7 +270,7 @@ func TestFHIRClient_UploadNDJSON_BasicAuth(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -299,7 +299,7 @@ func TestFHIRClient_UploadNDJSON_NoAuth(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -326,7 +326,7 @@ func TestFHIRClient_CreateTransactionBundle_ResourceWithID(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -360,7 +360,7 @@ func TestFHIRClient_CreateTransactionBundle_ResourceWithoutID(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -390,7 +390,7 @@ func TestFHIRClient_CreateTransactionBundle_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -418,7 +418,7 @@ func TestFHIRClient_CreateTransactionBundle_EmptyID(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -491,7 +491,7 @@ func TestFHIRClient_UploadNDJSON_URLTrailingSlash(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	// URL with trailing slash
 	config := models.SendConfig{
@@ -520,7 +520,7 @@ func TestFHIRClient_UploadNDJSON_MixedResources(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -569,7 +569,7 @@ func TestFHIRClient_UploadNDJSON_4xxError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -597,7 +597,7 @@ func TestFHIRClient_UploadNDJSON_5xxError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -624,7 +624,7 @@ func TestFHIRClient_UploadNDJSON_LargeResource(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -670,7 +670,7 @@ func TestFHIRUploadStats(t *testing.T) {
 
 func TestNewFHIRClient(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       "http://localhost:8080",
@@ -689,7 +689,7 @@ func TestFHIRClient_UploadNDJSON_EmptyFile(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -714,7 +714,7 @@ func TestFHIRClient_UploadNDJSON_OnlyEmptyLines(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -744,7 +744,7 @@ func TestFHIRClient_UploadNDJSON_FinalBatchOnly(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -780,7 +780,7 @@ func TestFHIRClient_UploadNDJSON_FinalBatchError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -808,7 +808,7 @@ func TestFHIRClient_UploadNDJSON_BytesReader(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -827,7 +827,7 @@ func TestFHIRClient_UploadNDJSON_BytesReader(t *testing.T) {
 
 func TestNewFHIRClientWithParams(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	auth := models.AuthConfig{
 		Username: "user",
 		Password: "pass",
@@ -866,7 +866,7 @@ func TestFHIRClient_UploadNDJSON_OAuth2Auth(t *testing.T) {
 	defer fhirServer.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       fhirServer.URL,
@@ -904,7 +904,7 @@ func TestFHIRClient_UploadNDJSON_OAuth2AuthError(t *testing.T) {
 	defer fhirServer.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       fhirServer.URL,
@@ -935,7 +935,7 @@ func TestFHIRClient_UploadNDJSON_UnwrapCollectionBundle(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -976,7 +976,7 @@ func TestFHIRClient_UploadNDJSON_UnwrapSearchsetBundle(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -1012,7 +1012,7 @@ func TestFHIRClient_UploadNDJSON_UnwrapTransactionBundle(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -1053,7 +1053,7 @@ func TestFHIRClient_UploadNDJSON_DocumentBundleNotUnwrapped(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,
@@ -1089,7 +1089,7 @@ func TestFHIRClient_UploadNDJSON_CollectionBundleWithEmptyEntries(t *testing.T) 
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 	config := models.SendConfig{
 		SendAs:    models.SendModeDirectResourceLoad,
 		URL:       server.URL,

--- a/tests/unit/flattener_client_test.go
+++ b/tests/unit/flattener_client_test.go
@@ -15,21 +15,11 @@ import (
 
 // Test helpers for flattener client tests
 
-// newTestFlattenerHTTPClient creates an HTTPClient with no retries for fast unit tests
-func newTestFlattenerHTTPClient() *services.HTTPClient {
-	return services.NewHTTPClient(
-		30*time.Second,
-		models.RetryConfig{MaxAttempts: 1},
-		lib.DefaultLogger,
-	)
-}
-
-func newTestFlattenerHTTPClientWithTimeout(timeout time.Duration) *services.HTTPClient {
-	return services.NewHTTPClient(
-		timeout,
-		models.RetryConfig{MaxAttempts: 1},
-		lib.DefaultLogger,
-	)
+func newTestFlatteningConfig(serverURL string) models.FlatteningConfig {
+	return models.FlatteningConfig{
+		ServiceURL: serverURL,
+		Timeout:    30 * time.Second,
+	}
 }
 
 func newTestViewDefinition(name, resource string) models.ViewDefinition {
@@ -64,7 +54,7 @@ func TestFlattenerClient_Flatten(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := services.NewFlattenerClient(server.URL, newTestFlattenerHTTPClient(), lib.DefaultLogger)
+		client := services.NewFlattenerClient(newTestFlatteningConfig(server.URL), nil, lib.DefaultLogger)
 		viewDef := newTestViewDefinition("TestView", "Patient")
 		resources := newTestResources("1", "2")
 
@@ -74,7 +64,7 @@ func TestFlattenerClient_Flatten(t *testing.T) {
 	})
 
 	t.Run("empty resources", func(t *testing.T) {
-		client := services.NewFlattenerClient("http://localhost:8080", newTestFlattenerHTTPClient(), lib.DefaultLogger)
+		client := services.NewFlattenerClient(newTestFlatteningConfig("http://localhost:8080"), nil, lib.DefaultLogger)
 
 		result, err := client.Flatten(models.ViewDefinition{Name: "TestView"}, []map[string]any{})
 		require.NoError(t, err)
@@ -82,13 +72,50 @@ func TestFlattenerClient_Flatten(t *testing.T) {
 	})
 
 	t.Run("connection refused", func(t *testing.T) {
-		httpClient := newTestFlattenerHTTPClientWithTimeout(1 * time.Second)
-		client := services.NewFlattenerClient("http://localhost:59999", httpClient, lib.DefaultLogger)
+		config := models.FlatteningConfig{
+			ServiceURL: "http://localhost:59999",
+			Timeout:    1 * time.Second,
+		}
+		client := services.NewFlattenerClient(config, nil, lib.DefaultLogger)
 
 		_, err := client.Flatten(newTestViewDefinition("TestView", "Patient"), newTestResources("1"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "request failed")
 	})
+}
+
+func TestFlattenerClient_WithCustomTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("id,name\n1,Test\n"))
+	}))
+	defer server.Close()
+
+	// Provide a non-nil transport to exercise the transport injection branch
+	transport := &http.Transport{}
+	client := services.NewFlattenerClient(newTestFlatteningConfig(server.URL), transport, lib.DefaultLogger)
+
+	result, err := client.Flatten(newTestViewDefinition("TestView", "Patient"), newTestResources("1"))
+	require.NoError(t, err)
+	assert.Equal(t, "id,name\n1,Test\n", result)
+}
+
+func TestFlattenerClient_DefaultTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	config := models.FlatteningConfig{
+		ServiceURL: server.URL,
+		Timeout:    0, // No timeout set - should use default
+	}
+	client := services.NewFlattenerClient(config, nil, lib.DefaultLogger)
+
+	_, err := client.Flatten(newTestViewDefinition("TestView", "Patient"), newTestResources("1"))
+	require.NoError(t, err)
 }
 
 func TestFlattenerClient_HealthCheck(t *testing.T) {
@@ -99,7 +126,7 @@ func TestFlattenerClient_HealthCheck(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := services.NewFlattenerClient(server.URL, newTestFlattenerHTTPClient(), lib.DefaultLogger)
+		client := services.NewFlattenerClient(newTestFlatteningConfig(server.URL), nil, lib.DefaultLogger)
 		assert.NoError(t, client.HealthCheck())
 	})
 
@@ -109,15 +136,18 @@ func TestFlattenerClient_HealthCheck(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := services.NewFlattenerClient(server.URL, newTestFlattenerHTTPClient(), lib.DefaultLogger)
+		client := services.NewFlattenerClient(newTestFlatteningConfig(server.URL), nil, lib.DefaultLogger)
 		err := client.HealthCheck()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "HTTP 503")
 	})
 
 	t.Run("connection refused", func(t *testing.T) {
-		httpClient := newTestFlattenerHTTPClientWithTimeout(1 * time.Second)
-		client := services.NewFlattenerClient("http://localhost:59998", httpClient, lib.DefaultLogger)
+		config := models.FlatteningConfig{
+			ServiceURL: "http://localhost:59998",
+			Timeout:    1 * time.Second,
+		}
+		client := services.NewFlattenerClient(config, nil, lib.DefaultLogger)
 		err := client.HealthCheck()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "health check failed")
@@ -185,7 +215,11 @@ func TestFlattenerError_IsRetryable(t *testing.T) {
 }
 
 func TestFlattenerClient_InvalidURL(t *testing.T) {
-	client := services.NewFlattenerClient("://invalid-url", newTestFlattenerHTTPClient(), lib.DefaultLogger)
+	invalidConfig := models.FlatteningConfig{
+		ServiceURL: "://invalid-url",
+		Timeout:    1 * time.Second,
+	}
+	client := services.NewFlattenerClient(invalidConfig, nil, lib.DefaultLogger)
 
 	t.Run("flatten request", func(t *testing.T) {
 		_, err := client.Flatten(newTestViewDefinition("TestView", "Patient"), newTestResources("1"))
@@ -196,7 +230,7 @@ func TestFlattenerClient_InvalidURL(t *testing.T) {
 	t.Run("health check", func(t *testing.T) {
 		err := client.HealthCheck()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "health check failed")
+		assert.Contains(t, err.Error(), "failed to create health check request")
 	})
 }
 
@@ -220,22 +254,14 @@ func TestFlattenerClient_HTTPErrors(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := services.NewFlattenerClient(server.URL, newTestFlattenerHTTPClient(), lib.DefaultLogger)
+			client := services.NewFlattenerClient(newTestFlatteningConfig(server.URL), nil, lib.DefaultLogger)
 			_, err := client.Flatten(newTestViewDefinition("TestView", "Patient"), newTestResources("1"))
 
-			if !tt.isRetryable {
-				// Non-transient errors (4xx): HTTPClient returns response, FlattenerClient returns FlattenerError
-				require.Error(t, err)
-				flattenerErr, ok := err.(*services.FlattenerError)
-				require.True(t, ok, "expected FlattenerError")
-				assert.Equal(t, tt.statusCode, flattenerErr.StatusCode)
-				assert.Equal(t, tt.isRetryable, flattenerErr.IsRetryable())
-			} else {
-				// Transient errors (5xx): HTTPClient retries and exhausts attempts,
-				// returns a generic error (not FlattenerError) since body is consumed during retry
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "request failed")
-			}
+			require.Error(t, err)
+			flattenerErr, ok := err.(*services.FlattenerError)
+			require.True(t, ok, "expected FlattenerError")
+			assert.Equal(t, tt.statusCode, flattenerErr.StatusCode)
+			assert.Equal(t, tt.isRetryable, flattenerErr.IsRetryable())
 		})
 	}
 }

--- a/tests/unit/httpclient_test.go
+++ b/tests/unit/httpclient_test.go
@@ -30,7 +30,7 @@ func TestHTTPClient_Put_Success(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 
 	body := []byte(`{"resourceType":"Binary","id":"123"}`)
 	resp, err := httpClient.Put(server.URL, "application/fhir+json", body)
@@ -54,7 +54,7 @@ func TestHTTPClient_Put_ClientError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 
 	body := []byte(`{"data":"test"}`)
 	resp, err := httpClient.Put(server.URL, "application/json", body)
@@ -69,7 +69,7 @@ func TestHTTPClient_Put_ClientError(t *testing.T) {
 // TestHTTPClient_Put_InvalidURL tests the Put method with an invalid URL
 func TestHTTPClient_Put_InvalidURL(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 
 	body := []byte(`{"data":"test"}`)
 	// Use an invalid URL scheme to trigger NewRequest error
@@ -91,7 +91,7 @@ func TestHTTPClient_Put_EmptyBody(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 
 	resp, err := httpClient.Put(server.URL, "application/json", []byte{})
 
@@ -115,7 +115,7 @@ func TestHTTPClient_Put_LargeBody(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 
 	// Create a large body (1MB)
 	largeBody := make([]byte, 1024*1024)
@@ -153,7 +153,7 @@ func TestHTTPClient_Put_CustomContentType(t *testing.T) {
 			defer server.Close()
 
 			logger := lib.NewLogger(lib.LogLevelDebug)
-			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 
 			resp, err := httpClient.Put(server.URL, expectedCT, []byte("test"))
 
@@ -164,4 +164,45 @@ func TestHTTPClient_Put_CustomContentType(t *testing.T) {
 			assert.Equal(t, expectedCT, receivedContentType)
 		})
 	}
+}
+
+// TestHTTPClient_WithInsecureSkipVerify verifies the TLS transport branch
+// where BuildTLSTransport returns a non-nil transport
+func TestHTTPClient_WithInsecureSkipVerify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	tlsConfig := models.TLSConfig{InsecureSkipVerify: true}
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, tlsConfig, logger)
+
+	resp, err := httpClient.Put(server.URL, "application/json", []byte(`{"test":true}`))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestHTTPClient_WithInvalidCACertPath verifies the TLS error branch
+// where BuildTLSTransport returns an error and the client falls back to defaults
+func TestHTTPClient_WithInvalidCACertPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	tlsConfig := models.TLSConfig{CACertPath: "/nonexistent/ca.pem"}
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, tlsConfig, logger)
+
+	// Should still work — falls back to default transport on TLS error
+	resp, err := httpClient.Put(server.URL, "application/json", []byte(`{"test":true}`))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/tests/unit/import_step_test.go
+++ b/tests/unit/import_step_test.go
@@ -23,7 +23,7 @@ func TestExecuteImportStep_UnsupportedStep(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with an unsupported step (not an import step)
 	job := &models.PipelineJob{
@@ -64,7 +64,7 @@ func TestExecuteImportStep_LocalImportMissingDir(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with local_import step but non-existent directory
 	job := &models.PipelineJob{
@@ -119,7 +119,7 @@ func TestExecuteImportStep_HttpImportValidationFailure(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with http_import step but invalid (non-HTTP) input source
 	job := &models.PipelineJob{
@@ -157,7 +157,7 @@ func TestExecuteImportStep_HttpImportEmptyURL(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with http_import step but empty URL
 	job := &models.PipelineJob{
@@ -200,7 +200,7 @@ func TestExecuteImportStep_TorchImportCRTDLValidationFailure(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with torch import step but non-existent CRTDL file
 	job := &models.PipelineJob{
@@ -238,7 +238,7 @@ func TestExecuteImportStep_TorchImportTORCHURLValidationFailure(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with torch import step but invalid TORCH URL
 	job := &models.PipelineJob{
@@ -276,7 +276,7 @@ func TestExecuteImportStep_TorchImportInvalidInputType(t *testing.T) {
 		InitialBackoffMs: 500,
 		MaxBackoffMs:     5000,
 	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
 	// Create a job with torch import step but local input type (not CRTDL or TORCH URL)
 	job := &models.PipelineJob{

--- a/tests/unit/import_url_test.go
+++ b/tests/unit/import_url_test.go
@@ -328,6 +328,7 @@ func TestHTTPClient_Retry(t *testing.T) {
 			InitialBackoffMs: 10, // Short backoff for fast test
 			MaxBackoffMs:     100,
 		},
+		models.TLSConfig{},
 		logger,
 	)
 

--- a/tests/unit/oauth2_test.go
+++ b/tests/unit/oauth2_test.go
@@ -36,7 +36,7 @@ func TestFetchOAuth2Token_Success(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	token, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestFetchOAuth2Token_CacheHit(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	// First request - should hit the server
 	token1, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
@@ -83,7 +83,7 @@ func TestFetchOAuth2Token_HTTPError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	_, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
 	require.Error(t, err)
@@ -102,7 +102,7 @@ func TestFetchOAuth2Token_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	_, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
 	require.Error(t, err)
@@ -122,7 +122,7 @@ func TestFetchOAuth2Token_MissingAccessToken(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	_, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
 	require.Error(t, err)
@@ -144,7 +144,7 @@ func TestFetchOAuth2Token_ShortExpiresIn(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	// First request
 	token1, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
@@ -173,7 +173,7 @@ func TestFetchOAuth2Token_TrailingSlashInIssuerURI(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	// Issuer URI with trailing slash
 	_, err := services.FetchOAuth2Token(server.URL+"/", "test-client", "test-secret", httpClient)
@@ -194,7 +194,7 @@ func TestClearOAuth2TokenCache(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
 
 	// Populate cache
 	_, _ = services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)

--- a/tests/unit/pipeline_dimp_test.go
+++ b/tests/unit/pipeline_dimp_test.go
@@ -40,6 +40,11 @@ func createDIMPTestJob(dimpURL string) *models.PipelineJob {
 					BundleSplitThresholdMB: 10,
 				},
 			},
+			Retry: models.RetryConfig{
+				MaxAttempts:      5,
+				InitialBackoffMs: 1000,
+				MaxBackoffMs:     30000,
+			},
 		},
 	}
 	// Include import step before DIMP (required for GetStepInputDir to work correctly)

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -829,6 +829,11 @@ func createSendTestJob(serverURL, jobID, jobsDir string) *models.PipelineJob {
 					},
 				},
 			},
+			Retry: models.RetryConfig{
+				MaxAttempts:      5,
+				InitialBackoffMs: 1000,
+				MaxBackoffMs:     30000,
+			},
 			JobsDir: jobsDir,
 		},
 		Steps: []models.PipelineStep{
@@ -862,6 +867,11 @@ func createSendTestJobWithAuth(serverURL, jobID, jobsDir string, auth models.Aut
 						OrganizationIdentifier: "test.hospital.de",
 					},
 				},
+			},
+			Retry: models.RetryConfig{
+				MaxAttempts:      5,
+				InitialBackoffMs: 1000,
+				MaxBackoffMs:     30000,
 			},
 			JobsDir: jobsDir,
 		},
@@ -1633,6 +1643,11 @@ func createFHIRSendTestJob(serverURL, jobID, jobsDir string) *models.PipelineJob
 					BatchSize: 100,
 				},
 			},
+			Retry: models.RetryConfig{
+				MaxAttempts:      5,
+				InitialBackoffMs: 1000,
+				MaxBackoffMs:     30000,
+			},
 			JobsDir: jobsDir,
 		},
 		Steps: []models.PipelineStep{
@@ -1666,6 +1681,11 @@ func createFHIRSendTestJobWithAuth(serverURL, jobID, jobsDir, username, password
 						Password: password,
 					},
 				},
+			},
+			Retry: models.RetryConfig{
+				MaxAttempts:      5,
+				InitialBackoffMs: 1000,
+				MaxBackoffMs:     30000,
 			},
 			JobsDir: jobsDir,
 		},

--- a/tests/unit/tls_test.go
+++ b/tests/unit/tls_test.go
@@ -1,0 +1,170 @@
+package unit
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// generateTestCACert creates a self-signed CA certificate PEM for testing
+func generateTestCACert(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+// generateTestServerCert creates a self-signed server certificate (not a CA) for testing
+func generateTestServerCert(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test Server"},
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: false,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func TestBuildTLSTransport_EmptyConfig(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{}, logger)
+
+	assert.NoError(t, err)
+	assert.Nil(t, transport, "Empty config should return nil transport (use Go defaults)")
+}
+
+func TestBuildTLSTransport_InsecureSkipVerify(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{
+		InsecureSkipVerify: true,
+	}, logger)
+
+	require.NoError(t, err)
+	require.NotNil(t, transport, "Should return a transport when InsecureSkipVerify is set")
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestBuildTLSTransport_ValidCACert(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	certPEM := generateTestCACert(t)
+	certFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0644))
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{
+		CACertPath: certFile,
+	}, logger)
+
+	require.NoError(t, err)
+	require.NotNil(t, transport, "Should return a transport when CA cert is provided")
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs, "RootCAs should be set")
+}
+
+func TestBuildTLSTransport_ValidServerCert(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	// Self-signed server cert (not a CA) — AppendCertsFromPEM accepts these too
+	certPEM := generateTestServerCert(t)
+	certFile := filepath.Join(t.TempDir(), "server.pem")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0644))
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{
+		CACertPath: certFile,
+	}, logger)
+
+	require.NoError(t, err)
+	require.NotNil(t, transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestBuildTLSTransport_InvalidCACertPath(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{
+		CACertPath: "/nonexistent/path/ca.pem",
+	}, logger)
+
+	assert.Error(t, err)
+	assert.Nil(t, transport)
+	assert.Contains(t, err.Error(), "failed to read CA certificate file")
+}
+
+func TestBuildTLSTransport_InvalidPEMContent(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	badFile := filepath.Join(t.TempDir(), "bad.pem")
+	require.NoError(t, os.WriteFile(badFile, []byte("this is not a PEM file"), 0644))
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{
+		CACertPath: badFile,
+	}, logger)
+
+	assert.Error(t, err)
+	assert.Nil(t, transport)
+	assert.Contains(t, err.Error(), "failed to parse any certificates")
+}
+
+func TestBuildTLSTransport_BothCACertAndInsecureSkip(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelInfo)
+
+	certPEM := generateTestCACert(t)
+	certFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0644))
+
+	transport, err := services.BuildTLSTransport(models.TLSConfig{
+		CACertPath:         certFile,
+		InsecureSkipVerify: true,
+	}, logger)
+
+	require.NoError(t, err)
+	require.NotNil(t, transport)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs, "RootCAs should be set even with InsecureSkipVerify")
+}

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -64,7 +64,7 @@ func TestTORCHClient_SubmitExtraction_Success(t *testing.T) {
 
 	// Test execution
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -84,7 +84,7 @@ func TestTORCHClient_SubmitExtraction_Success(t *testing.T) {
 
 func TestTORCHClient_SubmitExtraction_FileNotFound(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://localhost:8080",
 		Username: "testuser",
@@ -113,7 +113,7 @@ func TestTORCHClient_SubmitExtraction_Unauthorized(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "wrong",
@@ -164,7 +164,7 @@ func TestTORCHClient_PollExtractionStatus_ImmediateSuccess(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -207,7 +207,7 @@ func TestTORCHClient_PollExtractionStatus_EmptyOutput(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -235,7 +235,7 @@ func TestTORCHClient_PollExtractionStatus_Timeout(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -271,7 +271,7 @@ func TestTORCHClient_PollExtractionStatus_ServerError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -310,7 +310,7 @@ func TestTORCHClient_DownloadExtractionFiles_Success(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -359,7 +359,7 @@ func TestTORCHClient_DownloadExtractionFiles_PartialFailure(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -400,7 +400,7 @@ func TestTORCHClient_EncodeCRTDLToBase64_ValidJSON(t *testing.T) {
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://localhost:8080",
 		Username: "testuser",
@@ -474,7 +474,7 @@ func TestTORCHClient_PollExtractionStatus_ExponentialBackoff(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -512,7 +512,7 @@ func TestTORCHClient_Ping_Success(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -527,7 +527,7 @@ func TestTORCHClient_Ping_Success(t *testing.T) {
 
 func TestTORCHClient_Ping_Unreachable(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://unreachable-host-12345.invalid:9999",
 		Username: "testuser",
@@ -553,7 +553,7 @@ func TestTORCHClient_Ping_PerformanceWithin5Seconds(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelError) // Reduce log noise for performance test
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -579,7 +579,7 @@ func TestTORCHClient_Ping_PerformanceWithin5Seconds(t *testing.T) {
 
 func TestTORCHClient_MakeAbsoluteURL_RelativeURL(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://torch.example.com:8080",
 		Username: "testuser",
@@ -603,7 +603,7 @@ func TestTORCHClient_EncodeCRTDLToBase64_EmptyFile(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://localhost:8080",
 		Username: "testuser",
@@ -625,7 +625,7 @@ func TestTORCHClient_EncodeCRTDLToBase64_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://localhost:8080",
 		Username: "testuser",
@@ -666,7 +666,7 @@ func TestTORCHClient_ParseExtractionResult_FHIRFormat(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -704,7 +704,7 @@ func TestTORCHClient_ParseExtractionResult_SimpleFormat(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -731,7 +731,7 @@ func TestTORCHClient_ParseExtractionResult_InvalidJSON(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -762,7 +762,7 @@ func TestTORCHClient_SubmitExtraction_MissingContentLocation(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -778,7 +778,7 @@ func TestTORCHClient_SubmitExtraction_MissingContentLocation(t *testing.T) {
 
 func TestTORCHClient_DownloadExtractionFiles_EmptyFileList(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  "http://localhost:8080",
 		Username: "testuser",
@@ -805,7 +805,7 @@ func TestTORCHClient_DownloadExtractionFiles_InvalidDestinationPermissions(t *te
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -844,7 +844,7 @@ func TestTORCHClient_DownloadExtractionFiles_WithCompression(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -897,7 +897,7 @@ func TestTORCHClient_DownloadExtractionFiles_CompressionAllLevels(t *testing.T) 
 	for _, level := range levels {
 		t.Run(level, func(t *testing.T) {
 			logger := lib.NewLogger(lib.LogLevelDebug)
-			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+			httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 			torchConfig := models.TORCHConfig{
 				BaseURL:  server.URL,
 				Username: "testuser",
@@ -929,7 +929,7 @@ func TestTORCHClient_DownloadExtractionFiles_WithProgressAndCompression(t *testi
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -974,7 +974,7 @@ func TestTORCHClient_DownloadExtractionFiles_CompressedFileSizeSmaller(t *testin
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1021,7 +1021,7 @@ func TestTORCHClient_SubmitExtraction_HttpDoError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1049,7 +1049,7 @@ func TestTORCHClient_PollExtractionStatus_HttpDoError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
@@ -1079,7 +1079,7 @@ func TestTORCHClient_DownloadFile_HttpDoError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1114,7 +1114,7 @@ func TestTORCHClient_DownloadFile_PartialContent(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1149,7 +1149,7 @@ func TestTORCHClient_DownloadFile_FilenameFallback(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1179,7 +1179,7 @@ func TestTORCHClient_DownloadFile_HTTP4xxError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1205,7 +1205,7 @@ func TestTORCHClient_Ping_ServerError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",
@@ -1235,7 +1235,7 @@ func TestTORCHClient_DownloadExtractionFiles_LargeFileWithCompression(t *testing
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(10*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(10*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:  server.URL,
 		Username: "testuser",

--- a/tests/unit/torch_poller_test.go
+++ b/tests/unit/torch_poller_test.go
@@ -194,7 +194,7 @@ func TestCreatePollRequest_SuccessByVerifyingPollExecution(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, logger)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",


### PR DESCRIPTION
## Summary
- Add `TLSConfig` struct with `ca_cert_path` and `insecure_skip_verify` fields to `ProjectConfig`
- Load TLS config in `LoadConfig()` with environment variable expansion for the CA cert path
- Enables trusting custom CA certificates, common in hospital and research network environments

## Test plan
- [ ] Verify TLS config is loaded correctly from `aether.yaml`
- [ ] Test with a self-signed certificate using `ca_cert_path`
- [ ] Test `insecure_skip_verify: true` skips TLS verification in dev environments
- [ ] Confirm existing functionality is unaffected when TLS config is omitted

Closes #163