### PR TITLE
feat: align TORCH client protocol with alpha 14 reference

### DIFF
--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -77,6 +77,8 @@ type TORCHConfig struct {
 	ExtractionTimeoutMinutes  int    `yaml:"extraction_timeout_minutes" json:"extraction_timeout_minutes"`
 	PollingIntervalSeconds    int    `yaml:"polling_interval_seconds" json:"polling_interval_seconds"`
 	MaxPollingIntervalSeconds int    `yaml:"max_polling_interval_seconds" json:"max_polling_interval_seconds"`
+	FileReadyRetries          int    `yaml:"file_ready_retries" json:"file_ready_retries"`
+	FileReadyIntervalSeconds  int    `yaml:"file_ready_interval_seconds" json:"file_ready_interval_seconds"`
 }
 
 // SendMode defines the mode for sending data
@@ -288,6 +290,8 @@ func DefaultConfig() ProjectConfig {
 				ExtractionTimeoutMinutes:  30,
 				PollingIntervalSeconds:    5,
 				MaxPollingIntervalSeconds: 30,
+				FileReadyRetries:          10,
+				FileReadyIntervalSeconds:  10,
 			},
 			Flattening: DefaultFlatteningConfig(),
 		},

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -70,6 +70,8 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 				ExtractionTimeoutMinutes:  viper.GetInt("services.torch.extraction_timeout_minutes"),
 				PollingIntervalSeconds:    viper.GetInt("services.torch.polling_interval_seconds"),
 				MaxPollingIntervalSeconds: viper.GetInt("services.torch.max_polling_interval_seconds"),
+				FileReadyRetries:          viper.GetInt("services.torch.file_ready_retries"),
+				FileReadyIntervalSeconds:  viper.GetInt("services.torch.file_ready_interval_seconds"),
 			},
 			DIMP: models.DIMPConfig{
 				URL:                    ExpandEnvVars(viper.GetString("services.dimp.url")),
@@ -179,6 +181,12 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 		}
 		if config.Services.TORCH.MaxPollingIntervalSeconds == 0 {
 			config.Services.TORCH.MaxPollingIntervalSeconds = 30
+		}
+		if config.Services.TORCH.FileReadyRetries == 0 {
+			config.Services.TORCH.FileReadyRetries = 10
+		}
+		if config.Services.TORCH.FileReadyIntervalSeconds == 0 {
+			config.Services.TORCH.FileReadyIntervalSeconds = 10
 		}
 		// Apply DIMP Bundle split threshold default if not set
 		if config.Services.DIMP.BundleSplitThresholdMB == 0 {

--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -67,6 +67,19 @@ type TORCHSimpleOutput struct {
 	URL  string `json:"url"`
 }
 
+// OperationOutcome represents a FHIR OperationOutcome resource used for progress diagnostics
+type OperationOutcome struct {
+	ResourceType string                  `json:"resourceType"`
+	Issue        []OperationOutcomeIssue `json:"issue"`
+}
+
+// OperationOutcomeIssue represents an issue within an OperationOutcome
+type OperationOutcomeIssue struct {
+	Severity    string `json:"severity"`
+	Code        string `json:"code"`
+	Diagnostics string `json:"diagnostics"`
+}
+
 // TORCHError represents errors from TORCH operations
 type TORCHError struct {
 	Operation  string // "submit", "poll", "download"
@@ -138,7 +151,7 @@ func (c *TORCHClient) SubmitExtraction(crtdlPath string) (string, error) {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/fhir+json")
 	req.Header.Set("Authorization", c.buildBasicAuthHeader())
 
 	// Send request
@@ -207,6 +220,8 @@ func (c *TORCHClient) PollExtractionStatus(extractionURL string, showProgress bo
 		}()
 	}
 
+	var lastDiagnostics string
+
 	for {
 		// Check timeout
 		if pollConfig.CheckTimeout() {
@@ -239,7 +254,7 @@ func (c *TORCHClient) PollExtractionStatus(extractionURL string, showProgress bo
 		}
 
 		// Handle response
-		complete, fileURLs, err := handlePollResponse(resp, c)
+		complete, fileURLs, diagnostics, err := handlePollResponse(resp, c)
 		if err != nil {
 			return nil, err
 		}
@@ -247,6 +262,15 @@ func (c *TORCHClient) PollExtractionStatus(extractionURL string, showProgress bo
 		if complete {
 			c.logger.Info("TORCH extraction completed", "polls", pollConfig.PollCount)
 			return fileURLs, nil
+		}
+
+		// Log progress diagnostics from OperationOutcome (only when changed)
+		if diagnostics != "" && diagnostics != lastDiagnostics {
+			c.logger.Info("TORCH extraction progress", "diagnostics", diagnostics)
+			if spinner != nil {
+				spinner.UpdateMessage(diagnostics)
+			}
+			lastDiagnostics = diagnostics
 		}
 
 		// Still in progress - wait with exponential backoff
@@ -288,6 +312,12 @@ func (c *TORCHClient) DownloadExtractionFiles(fileURLs []string, destinationDir 
 
 		outputFileName := lib.GetCompressedFilename(fileName, compress)
 		destPath := filepath.Join(destinationDir, outputFileName)
+
+		// Wait for file to become available (handles nginx eventual consistency)
+		if err := c.waitForFileAvailability(fileURL); err != nil {
+			c.logger.Error("File not available for download", "url", fileURL, "error", err)
+			return nil, fmt.Errorf("file not available for download %s: %w", fileURL, err)
+		}
 
 		var spinner *ui.Spinner
 		if showProgress {
@@ -564,6 +594,82 @@ func (c *TORCHClient) buildBasicAuthHeader() string {
 	credentials := c.config.Username + ":" + c.config.Password
 	encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
 	return "Basic " + encoded
+}
+
+// waitForFileAvailability waits until a file URL is available for download.
+// Skips the check if FileReadyRetries <= 0 (zero-value means disabled).
+func (c *TORCHClient) waitForFileAvailability(fileURL string) error {
+	if c.config.FileReadyRetries <= 0 {
+		return nil
+	}
+
+	interval := time.Duration(c.config.FileReadyIntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+
+	for attempt := 1; attempt <= c.config.FileReadyRetries; attempt++ {
+		available, err := c.checkFileAvailable(fileURL)
+		if err != nil {
+			c.logger.Warn("File availability check error", "url", fileURL, "attempt", attempt, "error", err)
+		}
+		if available {
+			c.logger.Debug("File is available", "url", fileURL, "attempt", attempt)
+			return nil
+		}
+
+		if attempt < c.config.FileReadyRetries {
+			c.logger.Debug("File not yet available, retrying", "url", fileURL, "attempt", attempt, "next_check_in", interval)
+			time.Sleep(interval)
+		}
+	}
+
+	return fmt.Errorf("file not available after %d retries: %s", c.config.FileReadyRetries, fileURL)
+}
+
+// checkFileAvailable checks if a file is available via HEAD request.
+// Falls back to Range GET if HEAD returns 403, 404, or 405.
+func (c *TORCHClient) checkFileAvailable(fileURL string) (bool, error) {
+	req, err := http.NewRequest("HEAD", fileURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create HEAD request: %w", err)
+	}
+	req.Header.Set("Authorization", c.buildBasicAuthHeader())
+
+	resp, err := c.httpClient.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	_ = resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return resp.ContentLength > 0, nil
+	case http.StatusForbidden, http.StatusMethodNotAllowed, http.StatusNotFound:
+		// HEAD not supported or file not found — fall back to Range request
+		return c.checkFileAvailableWithRange(fileURL)
+	default:
+		return false, fmt.Errorf("unexpected status %d from HEAD request", resp.StatusCode)
+	}
+}
+
+// checkFileAvailableWithRange checks file availability using a GET with Range header.
+// Accepts 200 or 206 as successful responses.
+func (c *TORCHClient) checkFileAvailableWithRange(fileURL string) (bool, error) {
+	req, err := http.NewRequest("GET", fileURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create Range GET request: %w", err)
+	}
+	req.Header.Set("Authorization", c.buildBasicAuthHeader())
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := c.httpClient.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	_ = resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent, nil
 }
 
 // makeAbsoluteURL converts relative URLs to absolute using the configured baseURL.

--- a/internal/services/torch_poller.go
+++ b/internal/services/torch_poller.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,16 +43,17 @@ func createPollRequest(extractionURL string, c *TORCHClient) (*http.Request, err
 	return req, nil
 }
 
-// handlePollResponse processes a polling response and returns completion status and file URLs
-func handlePollResponse(resp *http.Response, c *TORCHClient) (complete bool, fileURLs []string, err error) {
+// handlePollResponse processes a polling response and returns completion status, file URLs, and progress diagnostics
+func handlePollResponse(resp *http.Response, c *TORCHClient) (complete bool, fileURLs []string, diagnostics string, err error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 
 	switch resp.StatusCode {
-	case http.StatusAccepted:
-		// Still in progress
-		return false, nil, nil
+	case http.StatusAccepted, http.StatusProcessing:
+		// Still in progress (202 Accepted or 102 Processing)
+		diagnostics = extractProgressDiagnostics(bodyBytes)
+		return false, nil, diagnostics, nil
 
 	case http.StatusOK:
 		// Extraction complete - parse result
@@ -59,9 +61,9 @@ func handlePollResponse(resp *http.Response, c *TORCHClient) (complete bool, fil
 		c.logger.Debug("TORCH extraction response body", "body", string(bodyBytes))
 		fileURLs, err := c.parseExtractionResult(bodyBytes)
 		if err != nil {
-			return false, nil, err
+			return false, nil, "", err
 		}
-		return true, fileURLs, nil
+		return true, fileURLs, "", nil
 
 	default:
 		// Error response
@@ -71,13 +73,38 @@ func handlePollResponse(resp *http.Response, c *TORCHClient) (complete bool, fil
 			"status", resp.Status,
 			"error_body", string(bodyBytes))
 
-		return false, nil, &TORCHError{
+		return false, nil, "", &TORCHError{
 			Operation:  "poll",
 			StatusCode: resp.StatusCode,
 			Message:    string(bodyBytes),
 			ErrorType:  errorType,
 		}
 	}
+}
+
+// extractProgressDiagnostics parses an OperationOutcome response body and returns
+// the first informational diagnostic message, if any.
+func extractProgressDiagnostics(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	var outcome OperationOutcome
+	if err := json.Unmarshal(body, &outcome); err != nil {
+		return ""
+	}
+
+	if outcome.ResourceType != "OperationOutcome" {
+		return ""
+	}
+
+	for _, issue := range outcome.Issue {
+		if issue.Severity == "information" && issue.Diagnostics != "" {
+			return issue.Diagnostics
+		}
+	}
+
+	return ""
 }
 
 // CalculateNextPollInterval calculates exponential backoff for next polling attempt

--- a/tests/contract/torch_service_test.go
+++ b/tests/contract/torch_service_test.go
@@ -26,7 +26,7 @@ func TestTORCHService_SubmitExtraction_Success(t *testing.T) {
 		// Verify request format per TORCH API spec
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "/fhir/$extract-data", r.URL.Path)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/fhir+json", r.Header.Get("Content-Type"))
 
 		// Verify Basic authentication header
 		authHeader := r.Header.Get("Authorization")

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -709,6 +709,82 @@ func TestTORCHConfig_WithDefaults(t *testing.T) {
 	assert.Equal(t, 30, config.Services.TORCH.ExtractionTimeoutMinutes, "Should default to 30 minutes")
 	assert.Equal(t, 5, config.Services.TORCH.PollingIntervalSeconds, "Should default to 5 seconds")
 	assert.Equal(t, 30, config.Services.TORCH.MaxPollingIntervalSeconds, "Should default to 30 seconds")
+	assert.Equal(t, 10, config.Services.TORCH.FileReadyRetries, "Should default to 10 retries")
+	assert.Equal(t, 10, config.Services.TORCH.FileReadyIntervalSeconds, "Should default to 10 seconds")
+}
+
+func TestTORCHConfig_FileReadySettings(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+services:
+  torch:
+    base_url: "http://localhost:8080"
+    username: "testuser"
+    password: "testpass"
+    extraction_timeout_minutes: 30
+    polling_interval_seconds: 5
+    max_polling_interval_seconds: 30
+    file_ready_retries: 5
+    file_ready_interval_seconds: 3
+
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, 5, config.Services.TORCH.FileReadyRetries, "FileReadyRetries should be loaded")
+	assert.Equal(t, 3, config.Services.TORCH.FileReadyIntervalSeconds, "FileReadyIntervalSeconds should be loaded")
+}
+
+func TestTORCHConfig_FileReadySettingsDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	// Config without file_ready settings — should get defaults
+	configContent := `
+services:
+  torch:
+    base_url: "http://localhost:8080"
+    username: "testuser"
+    password: "testpass"
+
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, 10, config.Services.TORCH.FileReadyRetries, "FileReadyRetries should default to 10")
+	assert.Equal(t, 10, config.Services.TORCH.FileReadyIntervalSeconds, "FileReadyIntervalSeconds should default to 10")
 }
 
 func TestTORCHConfig_ValidateMalformedURL(t *testing.T) {

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -42,7 +42,7 @@ func TestTORCHClient_SubmitExtraction_Success(t *testing.T) {
 		// Verify request
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "/fhir/$extract-data", r.URL.Path)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/fhir+json", r.Header.Get("Content-Type"))
 
 		// Verify authentication
 		authHeader := r.Header.Get("Authorization")
@@ -181,6 +181,190 @@ func TestTORCHClient_PollExtractionStatus_ImmediateSuccess(t *testing.T) {
 	require.Len(t, urls, 2)
 	assert.Equal(t, server.URL+"/output/batch-1.ndjson", urls[0])
 	assert.Equal(t, server.URL+"/output/batch-2.ndjson", urls[1])
+}
+
+// TestTORCHClient_PollExtractionStatus_HTTP102Processing verifies that HTTP 102 (Processing)
+// is handled the same as HTTP 202 (Accepted) during polling. Note: Go's net/http client
+// transparently consumes 1xx status codes, so we cannot test 102 directly with httptest.
+// This test verifies the code path via 202, which shares the same switch case.
+func TestTORCHClient_PollExtractionStatus_HTTP102Processing(t *testing.T) {
+	pollCount := 0
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pollCount++
+		if pollCount < 3 {
+			// Return 202 (exercises same code path as 102 Processing)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		// Return 200 (complete)
+		result := map[string]any{
+			"resourceType": "Parameters",
+			"parameter": []map[string]any{
+				{
+					"name": "output",
+					"part": []map[string]any{
+						{
+							"name":     "url",
+							"valueUrl": serverURL + "/output/result.ndjson",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                   server.URL,
+		Username:                  "testuser",
+		Password:                  "testpass",
+		ExtractionTimeoutMinutes:  1,
+		PollingIntervalSeconds:    1,
+		MaxPollingIntervalSeconds: 5,
+	}
+
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+	urls, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+
+	assert.NoError(t, err)
+	require.Len(t, urls, 1)
+	assert.Equal(t, server.URL+"/output/result.ndjson", urls[0])
+	assert.Equal(t, 3, pollCount, "Should have polled 3 times before completion")
+}
+
+func TestTORCHClient_PollExtractionStatus_WithOperationOutcomeDiagnostics(t *testing.T) {
+	pollCount := 0
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pollCount++
+		if pollCount < 3 {
+			// Return 202 with OperationOutcome containing progress diagnostics
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceType": "OperationOutcome",
+				"issue": []map[string]any{
+					{
+						"severity":    "information",
+						"code":        "informational",
+						"diagnostics": "Processing Patient resources",
+					},
+				},
+			})
+			return
+		}
+
+		// Return 200 (complete)
+		result := map[string]any{
+			"resourceType": "Parameters",
+			"parameter": []map[string]any{
+				{
+					"name": "output",
+					"part": []map[string]any{
+						{
+							"name":     "url",
+							"valueUrl": serverURL + "/output/result.ndjson",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                   server.URL,
+		Username:                  "testuser",
+		Password:                  "testpass",
+		ExtractionTimeoutMinutes:  1,
+		PollingIntervalSeconds:    1,
+		MaxPollingIntervalSeconds: 5,
+	}
+
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+	urls, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+
+	assert.NoError(t, err)
+	require.Len(t, urls, 1)
+	assert.Equal(t, 3, pollCount)
+}
+
+func TestTORCHClient_PollExtractionStatus_DiagnosticsNotRepeated(t *testing.T) {
+	pollCount := 0
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pollCount++
+		if pollCount < 4 {
+			// Return same diagnostic message for first 3 polls
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceType": "OperationOutcome",
+				"issue": []map[string]any{
+					{
+						"severity":    "information",
+						"code":        "informational",
+						"diagnostics": "Processing Patient resources",
+					},
+				},
+			})
+			return
+		}
+
+		// Return 200 (complete)
+		result := map[string]any{
+			"resourceType": "Parameters",
+			"parameter": []map[string]any{
+				{
+					"name": "output",
+					"part": []map[string]any{
+						{
+							"name":     "url",
+							"valueUrl": serverURL + "/output/result.ndjson",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                   server.URL,
+		Username:                  "testuser",
+		Password:                  "testpass",
+		ExtractionTimeoutMinutes:  1,
+		PollingIntervalSeconds:    1,
+		MaxPollingIntervalSeconds: 5,
+	}
+
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+	urls, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+
+	// Should succeed — the duplicate diagnostics are just not re-logged
+	assert.NoError(t, err)
+	require.Len(t, urls, 1)
+	assert.Equal(t, 4, pollCount)
 }
 
 func TestTORCHClient_PollExtractionStatus_EmptyOutput(t *testing.T) {
@@ -822,6 +1006,170 @@ func TestTORCHClient_DownloadExtractionFiles_InvalidDestinationPermissions(t *te
 	assert.Error(t, err)
 }
 
+
+// =============================================
+// File Availability Tests for TORCH Client
+// =============================================
+
+func TestTORCHClient_WaitForFileAvailability_ImmediateSuccess(t *testing.T) {
+	ndjsonContent := `{"resourceType":"Patient","id":"1"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.Header().Set("Content-Length", "36")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// GET for actual download
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ndjsonContent))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                  server.URL,
+		Username:                 "testuser",
+		Password:                 "testpass",
+		FileReadyRetries:         1,
+		FileReadyIntervalSeconds: 1,
+	}
+
+	tempDir := t.TempDir()
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+
+	fileURLs := []string{server.URL + "/output/Patient.ndjson"}
+	files, err := client.DownloadExtractionFiles(fileURLs, tempDir, false, false, "")
+
+	assert.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "Patient.ndjson", files[0].FileName)
+}
+
+func TestTORCHClient_WaitForFileAvailability_RetryThenSuccess(t *testing.T) {
+	headCount := 0
+	ndjsonContent := `{"resourceType":"Patient","id":"1"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			headCount++
+			if headCount <= 2 {
+				// First 2 HEAD requests return 404
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			// Third HEAD request succeeds
+			w.Header().Set("Content-Length", "36")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == "GET" && r.Header.Get("Range") != "" {
+			// Range fallback for 404 from HEAD
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// GET for actual download
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ndjsonContent))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                  server.URL,
+		Username:                 "testuser",
+		Password:                 "testpass",
+		FileReadyRetries:         5,
+		FileReadyIntervalSeconds: 1,
+	}
+
+	tempDir := t.TempDir()
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+
+	fileURLs := []string{server.URL + "/output/Patient.ndjson"}
+	files, err := client.DownloadExtractionFiles(fileURLs, tempDir, false, false, "")
+
+	assert.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, 3, headCount, "Should have made 3 HEAD requests (2 failures + 1 success)")
+}
+
+func TestTORCHClient_WaitForFileAvailability_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Range fallback also returns not found
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                  server.URL,
+		Username:                 "testuser",
+		Password:                 "testpass",
+		FileReadyRetries:         2,
+		FileReadyIntervalSeconds: 1,
+	}
+
+	tempDir := t.TempDir()
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+
+	fileURLs := []string{server.URL + "/output/Patient.ndjson"}
+	_, err := client.DownloadExtractionFiles(fileURLs, tempDir, false, false, "")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file not available")
+}
+
+func TestTORCHClient_WaitForFileAvailability_RangeFallback(t *testing.T) {
+	ndjsonContent := `{"resourceType":"Patient","id":"1"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			// HEAD not allowed — triggers Range fallback
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Method == "GET" && r.Header.Get("Range") != "" {
+			// Range GET succeeds with 206
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("{"))
+			return
+		}
+		// Full GET for download
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ndjsonContent))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                  server.URL,
+		Username:                 "testuser",
+		Password:                 "testpass",
+		FileReadyRetries:         1,
+		FileReadyIntervalSeconds: 1,
+	}
+
+	tempDir := t.TempDir()
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+
+	fileURLs := []string{server.URL + "/output/Patient.ndjson"}
+	files, err := client.DownloadExtractionFiles(fileURLs, tempDir, false, false, "")
+
+	assert.NoError(t, err)
+	require.Len(t, files, 1)
+}
 
 // =============================================
 // Compression Tests for TORCH Client


### PR DESCRIPTION
## Summary

Closes #170

- **Content-Type**: Use `application/fhir+json` instead of `application/json` for extraction submissions
- **HTTP 102 Processing**: Handle alongside 202 Accepted during polling (TORCH alpha 14 uses 1xx intermediary responses)
- **OperationOutcome diagnostics**: Parse progress messages from polling responses and display via spinner (deduplicated)
- **File availability waiting**: HEAD/Range-based readiness check before each download to handle nginx eventual consistency, with configurable retries (`file_ready_retries`, `file_ready_interval_seconds`)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] Unit tests pass: `go test -v ./tests/unit/... -run "TestTORCH|TestTORCHConfig"`
- [x] Contract tests pass: `go test -v ./tests/contract/... -run "TestTORCH"`
- [ ] Full test suite: `go test ./...`
- [ ] Verify with real TORCH alpha 14 instance