### PR TITLE
fix: enable Renovate tracking for golangci-lint binary version

### DIFF
--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
           version: v2.5.0
 
       - name: Upload lint results

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,19 @@
       "matchStrings": [
         "# renovate: datasource=github-release-attachments depName=(?<depName>\\S+?)(?: (?:lookupName|packageName)=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: extractVersion=(?<extractVersion>\\S+?))?\\s+\\w+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s+(\\w+?_CHECKSUM\\s*:\\s*[\"']?(?<currentDigest>\\w+)[\"']?)?"
       ]
+    },
+    {
+      "description": [
+        "Like customManagers:githubActionsVersions, but matches annotated action inputs (e.g. version:) instead of _VERSION env vars."
+      ],
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+\\w+\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `# renovate: datasource=github-releases depName=golangci/golangci-lint` annotation comment to `_lint.yaml` above the `version:` input
- Adds a custom regex manager to `renovate.json` that matches annotated action inputs (e.g. `version:`) — the existing `customManagers:githubActionsVersions` preset only matches `_VERSION` env vars and cannot match bare YAML keys

## Details

The `customManagers:githubActionsVersions` preset regex requires keys ending in `_VERSION` (e.g. `GOLANGCI_LINT_VERSION: v2.5.0`). The `version:` input parameter in `golangci-lint-action` doesn't match this pattern, so the annotation comment alone wouldn't be sufficient.

The new custom manager uses a generalized regex (`\w+` instead of `[A-Za-z0-9_]+?_VERSION`) to match any YAML key after a `# renovate:` annotation, making it reusable for other action inputs in the future.

Closes #172

## Test plan
- [ ] Verify Renovate picks up the `version: v2.5.0` line and creates a PR to bump to v2.9.0
- [ ] Verify the JSON schema validates against `renovate-schema.json`
- [ ] Verify the regex matches the annotation + version line (tested locally with Python re module)