### PR TITLE
docs: document how to install a specific version

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,6 +11,15 @@ curl -sSfL https://raw.githubusercontent.com/medizininformatik-initiative/aether
 sudo mv aether /usr/local/bin/
 ```
 
+To install a specific version, pass the version number **without** the `v` prefix:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/medizininformatik-initiative/aether/main/install.sh | sh -s -- 0.3.0
+sudo mv aether /usr/local/bin/
+```
+
+> **Note:** Use `0.3.0`, not `v0.3.0`. The `v` prefix is added automatically by the install script.
+
 Without sudo:
 ```bash
 curl -sSfL https://raw.githubusercontent.com/medizininformatik-initiative/aether/main/install.sh | sh


### PR DESCRIPTION
## Summary
- Add instructions for installing a specific aether version via the install script (`sh -s -- 0.3.0`)
- Clarify that the version must be provided **without** the `v` prefix to avoid a broken download URL
- Existing "latest version" example remains the default, with the specific version as an alternative

Closes #180

## Test plan
- [ ] Verify the install command example works: `curl -sSfL ... | sh -s -- 0.3.0`