### PR TITLE
ci: add Renovate tracking for Docker images and pin TORCH digest

### DIFF
--- a/.github/test/torch/compose.yaml
+++ b/.github/test/torch/compose.yaml
@@ -16,7 +16,7 @@ services:
         - torch
   torch:
     restart: unless-stopped
-    image: ghcr.io/medizininformatik-initiative/torch:1.0.0-alpha.16
+    image: ghcr.io/medizininformatik-initiative/torch:1.0.0-alpha.16@sha256:ce42d79d8cd4829e91b3ff403cf09097cdc7980b1d521ed2a4e2a4811e7155dd
     # image: torch:latest
     networks: [ "aether", "torch" ]
     ports:

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,18 @@
     "dependencies"
   ],
   "prConcurrentLimit": 1,
+  "packageRules": [
+    {
+      "description": "Use semver for MII pre-release Docker images so alpha.N increments are tracked",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/medizininformatik-initiative/torch",
+        "ghcr.io/medizininformatik-initiative/fhir-flattener"
+      ],
+      "versioning": "semver",
+      "ignoreUnstable": false
+    }
+  ],
   "customManagers": [
     {
       "description": [


### PR DESCRIPTION
## Summary
- Add `packageRules` to `renovate.json` so Renovate tracks MII Docker images (TORCH, fhir-flattener) using `semver` versioning with `ignoreUnstable: false`, enabling automatic PRs for pre-release `alpha.N` bumps
- Pin TORCH image digest in `.github/test/torch/compose.yaml` for reproducible builds

Closes #185