### PR TITLE
feat(flattening): only add patient column for Patient compartment resources

### DIFF
--- a/internal/models/flattening.go
+++ b/internal/models/flattening.go
@@ -178,12 +178,83 @@ func GetFixedIDColumn() ColumnDefinition {
 	}
 }
 
-// GetFixedPatientColumn returns the fixed "patient" column definition for non-Patient resources
-func GetFixedPatientColumn() ColumnDefinition {
-	return ColumnDefinition{
-		Name: "patient",
-		Path: "subject.reference",
-	}
+// patientCompartmentPaths maps FHIR R4 resource types in the Patient compartment to their
+// patient reference FHIRPath. Only resources with a single, clear patient reference element
+// are included. Resources with complex multi-element paths (AuditEvent, Appointment, Group,
+// Person, Provenance, Schedule) are intentionally excluded.
+// Source: https://hl7.org/fhir/R4/compartmentdefinition-patient.html
+var patientCompartmentPaths = map[string]string{
+	// Resources using subject.reference
+	"Account":                  "subject.reference",
+	"AdverseEvent":             "subject.reference",
+	"Basic":                    "subject.reference",
+	"CarePlan":                 "subject.reference",
+	"CareTeam":                 "subject.reference",
+	"ChargeItem":               "subject.reference",
+	"ClinicalImpression":       "subject.reference",
+	"Communication":            "subject.reference",
+	"CommunicationRequest":     "subject.reference",
+	"Composition":              "subject.reference",
+	"Condition":                "subject.reference",
+	"DeviceRequest":            "subject.reference",
+	"DeviceUseStatement":       "subject.reference",
+	"DiagnosticReport":         "subject.reference",
+	"DocumentManifest":         "subject.reference",
+	"DocumentReference":        "subject.reference",
+	"Encounter":                "subject.reference",
+	"Flag":                     "subject.reference",
+	"Goal":                     "subject.reference",
+	"ImagingStudy":             "subject.reference",
+	"Invoice":                  "subject.reference",
+	"List":                     "subject.reference",
+	"MeasureReport":            "subject.reference",
+	"Media":                    "subject.reference",
+	"MedicationAdministration": "subject.reference",
+	"MedicationDispense":       "subject.reference",
+	"MedicationRequest":        "subject.reference",
+	"MedicationStatement":      "subject.reference",
+	"Observation":              "subject.reference",
+	"Procedure":                "subject.reference",
+	"QuestionnaireResponse":    "subject.reference",
+	"RequestGroup":             "subject.reference",
+	"RiskAssessment":           "subject.reference",
+	"ServiceRequest":           "subject.reference",
+	"Specimen":                 "subject.reference",
+	"SupplyRequest":            "subject.reference",
+
+	// Resources using patient.reference
+	"AllergyIntolerance":          "patient.reference",
+	"BodyStructure":               "patient.reference",
+	"Claim":                       "patient.reference",
+	"ClaimResponse":               "patient.reference",
+	"Consent":                     "patient.reference",
+	"CoverageEligibilityRequest":  "patient.reference",
+	"CoverageEligibilityResponse": "patient.reference",
+	"DetectedIssue":               "patient.reference",
+	"EpisodeOfCare":               "patient.reference",
+	"ExplanationOfBenefit":        "patient.reference",
+	"FamilyMemberHistory":         "patient.reference",
+	"Immunization":                "patient.reference",
+	"ImmunizationEvaluation":      "patient.reference",
+	"ImmunizationRecommendation":  "patient.reference",
+	"MolecularSequence":           "patient.reference",
+	"NutritionOrder":              "patient.reference",
+	"RelatedPerson":               "patient.reference",
+	"SupplyDelivery":              "patient.reference",
+	"VisionPrescription":          "patient.reference",
+
+	// Resources using other reference paths
+	"Coverage":          "beneficiary.reference",
+	"EnrollmentRequest": "candidate.reference",
+	"ResearchSubject":   "individual.reference",
+}
+
+// GetPatientReferencePath returns the FHIRPath to the patient reference for a given
+// resource type, and whether the resource is in the FHIR R4 Patient compartment.
+// Returns ("", false) for Patient itself and for resources not in the compartment.
+func GetPatientReferencePath(resourceType string) (string, bool) {
+	path, ok := patientCompartmentPaths[resourceType]
+	return path, ok
 }
 
 // NewBaseViewDefinition creates a base ViewDefinition with required fields

--- a/internal/services/viewdefinition_builder.go
+++ b/internal/services/viewdefinition_builder.go
@@ -90,15 +90,20 @@ func isParentInAttributeList(lookup *models.LookupTable, elementID string, attrR
 	return isParentInAttributeList(lookup, element.Parent, attrRefs)
 }
 
-// buildFixedColumns creates the fixed columns (id, patient) for a ViewDefinition
+// buildFixedColumns creates the fixed columns (id, and optionally patient) for a ViewDefinition.
+// The patient column path varies by resource type because FHIR R4 Patient compartment resources
+// reference patients through different element names (subject, patient, beneficiary, etc.).
+// Non-compartment resources (e.g. Organization) have no patient column at all.
 func (b *ViewDefinitionBuilder) buildFixedColumns(resourceType string) []models.ColumnDefinition {
 	columns := []models.ColumnDefinition{
 		models.GetFixedIDColumn(),
 	}
 
-	// Add patient column for non-Patient resources
-	if resourceType != "Patient" {
-		columns = append(columns, models.GetFixedPatientColumn())
+	if path, ok := models.GetPatientReferencePath(resourceType); ok {
+		columns = append(columns, models.ColumnDefinition{
+			Name: "patient",
+			Path: path,
+		})
 	}
 
 	return columns

--- a/tests/unit/flattening_config_test.go
+++ b/tests/unit/flattening_config_test.go
@@ -176,16 +176,64 @@ func TestNewBaseViewDefinition(t *testing.T) {
 	assert.Empty(t, viewDef.Select)
 }
 
-func TestGetFixedColumns(t *testing.T) {
-	t.Run("id column", func(t *testing.T) {
-		col := models.GetFixedIDColumn()
-		assert.Equal(t, "id", col.Name)
-		assert.Equal(t, "id", col.Path)
+func TestGetFixedIDColumn(t *testing.T) {
+	col := models.GetFixedIDColumn()
+	assert.Equal(t, "id", col.Name)
+	assert.Equal(t, "id", col.Path)
+}
+
+func TestGetPatientReferencePath(t *testing.T) {
+	t.Run("resources with subject.reference", func(t *testing.T) {
+		subjectResources := []string{
+			"Observation", "Condition", "DiagnosticReport", "MedicationRequest",
+			"Procedure", "Encounter", "Specimen", "ServiceRequest",
+		}
+		for _, rt := range subjectResources {
+			path, ok := models.GetPatientReferencePath(rt)
+			assert.True(t, ok, "%s should be in patient compartment", rt)
+			assert.Equal(t, "subject.reference", path, "%s should use subject.reference", rt)
+		}
 	})
 
-	t.Run("patient column", func(t *testing.T) {
-		col := models.GetFixedPatientColumn()
-		assert.Equal(t, "patient", col.Name)
-		assert.Equal(t, "subject.reference", col.Path)
+	t.Run("resources with patient.reference", func(t *testing.T) {
+		patientResources := []string{
+			"AllergyIntolerance", "Consent", "Immunization", "EpisodeOfCare",
+			"FamilyMemberHistory", "NutritionOrder", "VisionPrescription",
+		}
+		for _, rt := range patientResources {
+			path, ok := models.GetPatientReferencePath(rt)
+			assert.True(t, ok, "%s should be in patient compartment", rt)
+			assert.Equal(t, "patient.reference", path, "%s should use patient.reference", rt)
+		}
+	})
+
+	t.Run("resources with other reference paths", func(t *testing.T) {
+		path, ok := models.GetPatientReferencePath("Coverage")
+		assert.True(t, ok)
+		assert.Equal(t, "beneficiary.reference", path)
+
+		path, ok = models.GetPatientReferencePath("ResearchSubject")
+		assert.True(t, ok)
+		assert.Equal(t, "individual.reference", path)
+
+		path, ok = models.GetPatientReferencePath("EnrollmentRequest")
+		assert.True(t, ok)
+		assert.Equal(t, "candidate.reference", path)
+	})
+
+	t.Run("Patient resource is not in compartment map", func(t *testing.T) {
+		_, ok := models.GetPatientReferencePath("Patient")
+		assert.False(t, ok, "Patient should not be in compartment map")
+	})
+
+	t.Run("non-compartment resources return false", func(t *testing.T) {
+		nonCompartmentResources := []string{
+			"Organization", "Practitioner", "Medication", "Location",
+			"Device", "Substance", "HealthcareService", "PractitionerRole",
+		}
+		for _, rt := range nonCompartmentResources {
+			_, ok := models.GetPatientReferencePath(rt)
+			assert.False(t, ok, "%s should not be in patient compartment", rt)
+		}
 	})
 }

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -71,7 +71,7 @@ func TestBuildViewDefinition(t *testing.T) {
 		require.NotEmpty(t, viewDef.Select)
 	})
 
-	t.Run("non-Patient resource includes patient column", func(t *testing.T) {
+	t.Run("patient compartment resource includes patient column with correct path", func(t *testing.T) {
 		lookupTables := []models.LookupTable{
 			newLookupTable("https://example.com/Condition", "Condition", map[string]models.LookupElement{
 				"Condition.code": {
@@ -86,6 +86,45 @@ func TestBuildViewDefinition(t *testing.T) {
 		assert.Equal(t, "Condition", viewDef.Resource)
 		require.NotEmpty(t, viewDef.Select)
 		assert.Len(t, viewDef.Select[0].Column, 2) // id and patient
+		assert.Equal(t, "patient", viewDef.Select[0].Column[1].Name)
+		assert.Equal(t, "subject.reference", viewDef.Select[0].Column[1].Path)
+	})
+
+	t.Run("patient compartment resource with patient.reference path", func(t *testing.T) {
+		lookupTables := []models.LookupTable{
+			newLookupTable("https://example.com/AllergyIntolerance", "AllergyIntolerance", map[string]models.LookupElement{
+				"AllergyIntolerance.code": {
+					ViewDefinition: newViewDefSnippet(newSelectClause("code", "code.coding[0].code")),
+				},
+			}),
+		}
+		group := newAttributeGroup("Allergies", "https://example.com/AllergyIntolerance", "AllergyIntolerance.code")
+
+		viewDef := buildAndAssertViewDef(t, lookupTables, group)
+
+		assert.Equal(t, "AllergyIntolerance", viewDef.Resource)
+		require.NotEmpty(t, viewDef.Select)
+		assert.Len(t, viewDef.Select[0].Column, 2) // id and patient
+		assert.Equal(t, "patient", viewDef.Select[0].Column[1].Name)
+		assert.Equal(t, "patient.reference", viewDef.Select[0].Column[1].Path)
+	})
+
+	t.Run("non-compartment resource does not include patient column", func(t *testing.T) {
+		lookupTables := []models.LookupTable{
+			newLookupTable("https://example.com/Organization", "Organization", map[string]models.LookupElement{
+				"Organization.name": {
+					ViewDefinition: newViewDefSnippet(newSelectClause("name", "name")),
+				},
+			}),
+		}
+		group := newAttributeGroup("Organizations", "https://example.com/Organization", "Organization.name")
+
+		viewDef := buildAndAssertViewDef(t, lookupTables, group)
+
+		assert.Equal(t, "Organization", viewDef.Resource)
+		require.NotEmpty(t, viewDef.Select)
+		assert.Len(t, viewDef.Select[0].Column, 1) // only id, no patient
+		assert.Equal(t, "id", viewDef.Select[0].Column[0].Name)
 	})
 
 	t.Run("missing lookup profile", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a `patientCompartmentPaths` map of 55 FHIR R4 Patient compartment resource types mapped to their correct patient reference FHIRPath (`subject.reference`, `patient.reference`, `beneficiary.reference`, etc.)
- Update `buildFixedColumns` to only add a patient column for compartment resources, using the resource-specific path
- Remove the now-unused `GetFixedPatientColumn()` function which hardcoded `subject.reference` for all non-Patient resources

Closes #189