### PR TITLE
feat(docs): multi-version documentation with version switcher

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,28 +4,30 @@ on:
   push:
     branches:
       - main
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-deploy.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build docs from (e.g. v0.4.0)'
+        required: true
+        type: string
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build Documentation
+  deploy:
+    name: Build and Deploy Documentation
     runs-on: ubuntu-24.04
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       startsWith(github.event.workflow_run.head_branch, 'v'))
+    if: ${{ !(github.event_name == 'release' && github.event.release.prerelease) }}
 
     steps:
       - name: Harden Runner
@@ -33,19 +35,42 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Get version
-        id: version
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_run" ]; then
-            echo "tag=$(gh release view --json tagName -q .tagName 2>/dev/null || echo 'dev')" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=dev" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Determine version and ref
+        id: vars
         env:
-          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+            echo "ref=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${EVENT_NAME}" == "release" ]]; then
+            echo "version=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "ref=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "version=${DISPATCH_TAG}" >> "$GITHUB_OUTPUT"
+            echo "ref=${DISPATCH_TAG}" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository at target ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.vars.outputs.ref }}
+
+      - name: Patch config for historical builds
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          # Historical tags have hardcoded base: '/aether/' — patch it
+          sed -i "s|base: '/aether/'|base: '/aether/${VERSION}/'|" docs/.vitepress/config.ts
+          # Also patch hardcoded favicon paths
+          sed -i "s|href: '/aether/|href: '/aether/${VERSION}/|g" docs/.vitepress/config.ts
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -62,27 +87,111 @@ jobs:
         run: npm run docs:build
         working-directory: docs
         env:
-          VITE_LATEST_RELEASE: ${{ steps.version.outputs.tag }}
+          VITE_BASE_PATH: /aether/${{ steps.vars.outputs.version }}/
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+      - name: Save build output
+        run: cp -r docs/.vitepress/dist /tmp/docs-build
+
+      - name: Checkout gh-pages branch
+        run: |
+          git fetch origin gh-pages:gh-pages 2>/dev/null || true
+          if git rev-parse --verify gh-pages >/dev/null 2>&1; then
+            git checkout gh-pages
+          else
+            # Create orphan branch with initial files
+            git checkout --orphan gh-pages
+            git rm -rf .
+            echo '[]' > versions.json
+            touch .nojekyll
+            cat > index.html << 'HEREDOC'
+          <!DOCTYPE html>
+          <html>
+          <head><meta http-equiv="refresh" content="0; url=/aether/dev/"></head>
+          <body><a href="/aether/dev/">Redirecting to latest docs...</a></body>
+          </html>
+          HEREDOC
+            git add versions.json .nojekyll index.html
+            git commit -m "Initialize gh-pages branch"
+          fi
+
+      - name: Deploy version directory
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          rm -rf "${VERSION}"
+          cp -r /tmp/docs-build "${VERSION}"
+
+      - name: Update versions.json
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          DOC_VERSION: ${{ steps.vars.outputs.version }}
+          IS_RELEASE: ${{ steps.vars.outputs.is_release }}
         with:
-          path: 'docs/.vitepress/dist'
+          script: |
+            const fs = require('fs');
+            const version = process.env.DOC_VERSION;
+            const isRelease = process.env.IS_RELEASE === 'true';
 
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    runs-on: ubuntu-24.04
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+            let versions = [];
+            try {
+              versions = JSON.parse(fs.readFileSync('versions.json', 'utf8'));
+            } catch {
+              versions = [];
+            }
 
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
-        with:
-          egress-policy: audit
+            // Remove existing entry for this version
+            versions = versions.filter(v => v.version !== version);
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+            // If this is a release, unmark all others as latest
+            if (isRelease) {
+              versions.forEach(v => { v.latest = false; });
+            }
+
+            // Add new entry
+            versions.push({
+              version,
+              path: `/aether/${version}/`,
+              latest: isRelease
+            });
+
+            // Sort: latest first, then semver descending, dev last
+            versions.sort((a, b) => {
+              if (a.version === 'dev') return 1;
+              if (b.version === 'dev') return -1;
+              if (a.latest && !b.latest) return -1;
+              if (!a.latest && b.latest) return 1;
+              const aParts = a.version.replace('v', '').split('.').map(Number);
+              const bParts = b.version.replace('v', '').split('.').map(Number);
+              for (let i = 0; i < 3; i++) {
+                if ((bParts[i] || 0) !== (aParts[i] || 0)) {
+                  return (bParts[i] || 0) - (aParts[i] || 0);
+                }
+              }
+              return 0;
+            });
+
+            fs.writeFileSync('versions.json', JSON.stringify(versions, null, 2) + '\n');
+            console.log('Updated versions.json:', JSON.stringify(versions, null, 2));
+
+      - name: Update root redirect
+        if: steps.vars.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          cat > index.html << HEREDOC
+          <!DOCTYPE html>
+          <html>
+          <head><meta http-equiv="refresh" content="0; url=/aether/${VERSION}/"></head>
+          <body><a href="/aether/${VERSION}/">Redirecting to latest docs...</a></body>
+          </html>
+          HEREDOC
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "${VERSION}" versions.json index.html .nojekyll
+          git commit -m "Deploy docs: ${VERSION}" || echo "No changes to commit"
+          git push origin gh-pages

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,20 +1,20 @@
 import { defineConfig } from 'vitepress'
 
-const version = process.env.VITE_LATEST_RELEASE || 'dev'
+const basePath = process.env.VITE_BASE_PATH || '/aether/'
 
 export default defineConfig({
   title: 'Aether',
   description: 'Healthcare Data Integration Platform',
   lang: 'en-US',
-  base: '/aether/',
+  base: basePath,
 
   // Favicon configuration
   head: [
-    ['link', { rel: 'icon', type: 'image/x-icon', href: '/aether/favicon.ico' }],
-    ['link', { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/aether/favicon-16x16.png' }],
-    ['link', { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/aether/favicon-32x32.png' }],
-    ['link', { rel: 'icon', type: 'image/png', sizes: '96x96', href: '/aether/favicon-96x96.png' }],
-    ['link', { rel: 'apple-touch-icon', sizes: '180x180', href: '/aether/apple-touch-icon.png' }]
+    ['link', { rel: 'icon', type: 'image/x-icon', href: `${basePath}favicon.ico` }],
+    ['link', { rel: 'icon', type: 'image/png', sizes: '16x16', href: `${basePath}favicon-16x16.png` }],
+    ['link', { rel: 'icon', type: 'image/png', sizes: '32x32', href: `${basePath}favicon-32x32.png` }],
+    ['link', { rel: 'icon', type: 'image/png', sizes: '96x96', href: `${basePath}favicon-96x96.png` }],
+    ['link', { rel: 'apple-touch-icon', sizes: '180x180', href: `${basePath}apple-touch-icon.png` }]
   ],
 
   // Theme configuration
@@ -26,7 +26,7 @@ export default defineConfig({
     // Top navigation bar
     nav: [
       {
-        text: version,
+        text: 'GitHub',
         items: [
           {
             text: 'Issues',

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface VersionEntry {
+  version: string
+  path: string
+  latest?: boolean
+}
+
+const versions = ref<VersionEntry[]>([])
+const currentVersion = ref('dev')
+const isOpen = ref(false)
+const loaded = ref(false)
+
+function detectCurrentVersion(): string {
+  if (typeof window === 'undefined') return 'dev'
+  // Path format: /aether/dev/ or /aether/v0.4.0/...
+  const match = window.location.pathname.match(/^\/aether\/(v[\d.]+|dev)/)
+  return match ? match[1] : 'dev'
+}
+
+function navigate(entry: VersionEntry) {
+  isOpen.value = false
+  if (entry.version === currentVersion.value) return
+  window.location.href = entry.path
+}
+
+function closeDropdown(e: MouseEvent) {
+  const target = e.target as HTMLElement
+  if (!target.closest('.version-switcher')) {
+    isOpen.value = false
+  }
+}
+
+onMounted(async () => {
+  currentVersion.value = detectCurrentVersion()
+
+  try {
+    const res = await fetch('/aether/versions.json')
+    if (res.ok) {
+      versions.value = await res.json()
+      loaded.value = true
+    }
+  } catch {
+    // Graceful fallback: just show the current version text
+  }
+
+  document.addEventListener('click', closeDropdown)
+})
+</script>
+
+<template>
+  <div class="version-switcher" v-if="loaded && versions.length > 0">
+    <button class="version-button" @click="isOpen = !isOpen" :aria-expanded="isOpen">
+      {{ currentVersion }}
+      <svg class="caret" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"
+        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </button>
+    <div class="version-menu" v-show="isOpen">
+      <button
+        v-for="entry in versions"
+        :key="entry.version"
+        class="version-item"
+        :class="{ active: entry.version === currentVersion }"
+        @click="navigate(entry)"
+      >
+        {{ entry.version }}
+        <span v-if="entry.latest" class="latest-badge">latest</span>
+      </button>
+    </div>
+  </div>
+  <span v-else-if="!loaded" class="version-text">{{ currentVersion }}</span>
+</template>
+
+<style scoped>
+.version-switcher {
+  position: relative;
+  margin-right: 8px;
+}
+
+.version-button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+  height: 36px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--vp-c-text-1);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.25s, color 0.25s;
+}
+
+.version-button:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.caret {
+  transition: transform 0.25s;
+}
+
+.version-button[aria-expanded="true"] .caret {
+  transform: rotate(180deg);
+}
+
+.version-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 120px;
+  padding: 4px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-elv);
+  box-shadow: var(--vp-shadow-3);
+  z-index: 100;
+}
+
+.version-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.25s, color 0.25s;
+}
+
+.version-item:hover {
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-1);
+}
+
+.version-item.active {
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+
+.latest-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+  font-weight: 600;
+}
+
+.version-text {
+  margin-right: 8px;
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,12 +1,13 @@
 import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
+import VersionSwitcher from './VersionSwitcher.vue'
 
 export default {
   extends: DefaultTheme,
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
-      // Insert custom layout slots here if needed
+      'nav-bar-content-before': () => h(VersionSwitcher)
     })
   }
 } satisfies Theme


### PR DESCRIPTION
## Summary

Closes #193

- Switches docs deployment from artifact-based `actions/deploy-pages` to **gh-pages branch** approach where each version gets its own subdirectory (`dev/`, `v0.4.0/`, etc.)
- Adds a **VersionSwitcher** Vue component that fetches a `versions.json` manifest at runtime and renders a styled dropdown in the nav bar
- Makes VitePress `base` path dynamic via `VITE_BASE_PATH` env var so each version build has correct asset paths
- Rewrites the docs-deploy workflow with three triggers: push to main → `dev/`, release → `vX.Y.Z/`, workflow_dispatch → backfill historical tags

### Post-merge steps

1. **Reconfigure GitHub Pages** in repo settings: Source → "Deploy from a branch", Branch → `gh-pages` / `/ (root)`
2. **Backfill historical versions** via workflow_dispatch for tags: `v0.1.0`, `v0.2.0`, `v0.2.1`, `v0.3.0`, `v0.4.0`