### PR TITLE
Fix: handle large FHIR bundles in NDJSON scanning

### DIFF
--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -159,6 +159,12 @@ pipeline:
     - parquet_conversion
     # - send           # Uncomment to send data to DSF transfer server
 
+  # Maximum NDJSON line size in megabytes (MB)
+  # FHIR Bundles with many resources can produce very large single-line JSON objects.
+  # Increase this if you encounter "token too long" errors when reading NDJSON files.
+  # Default: 100 MB (omit or set to 0 for default)
+  # max_ndjson_line_size_mb: 100
+
 retry:
   # Maximum number of retry attempts for transient errors (network, 5xx)
   # Range: 1-10

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -43,6 +43,7 @@ services:
 
 pipeline:
   enabled_steps: [string]
+  max_ndjson_line_size_mb: integer           # default: 100
 
 retry:
   max_attempts: integer                  # 1-10, default: 5
@@ -198,7 +199,13 @@ pipeline:
     - local_import
     - dimp
     - flattening
+  max_ndjson_line_size_mb: 100
 ```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled_steps` | []string | - | Pipeline steps to execute in order |
+| `max_ndjson_line_size_mb` | int | 100 | Maximum NDJSON line size in MB. Increase if you encounter "token too long" errors when reading large FHIR Bundles. Set to 0 to use default. |
 
 **Available steps:**
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -220,6 +220,7 @@ Persisted Results
 ### Memory Usage
 
 - Streams FHIR NDJSON line-by-line (no buffering entire files)
+- NDJSON scanner buffer supports lines up to 100MB by default (configurable via `pipeline.max_ndjson_line_size_mb`) to handle large FHIR Bundles
 - Job state loaded only when needed
 - Progress bars updated incrementally
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -104,6 +104,10 @@ pipeline:
     - wait          # Pause for inspection (optional)
     - flattening    # FHIR to CSV (requires CRTDL)
     - send          # Upload to destination
+
+  # Max NDJSON line size in MB (default: 100)
+  # Increase if you encounter "token too long" errors with large Bundles
+  # max_ndjson_line_size_mb: 100
 ```
 
 ### Step Placement Rules

--- a/internal/lib/fhir.go
+++ b/internal/lib/fhir.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 // FHIRResource represents a generic FHIR resource as a map
@@ -69,16 +71,34 @@ func ReadNDJSONFile(filePath string, callback func(FHIRResource) error) (int, er
 	return ReadNDJSON(reader, callback)
 }
 
+// DefaultMaxNDJSONLineSize is an alias for models.DefaultMaxNDJSONLineSize.
+// Kept here for convenience so callers of the scanner API don't need to import models.
+const DefaultMaxNDJSONLineSize = models.DefaultMaxNDJSONLineSize
+
+// NewNDJSONScanner creates a bufio.Scanner configured to handle large FHIR NDJSON lines.
+// Uses DefaultMaxNDJSONLineSize (100MB) as the maximum line size.
+func NewNDJSONScanner(r io.Reader) *bufio.Scanner {
+	return NewNDJSONScannerWithMaxSize(r, DefaultMaxNDJSONLineSize)
+}
+
+// NewNDJSONScannerWithMaxSize creates a bufio.Scanner with a custom maximum line size.
+// The buffer starts at min(64KB, maxSize) and grows on demand up to maxSize bytes.
+func NewNDJSONScannerWithMaxSize(r io.Reader, maxSize int) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	initialSize := bufio.MaxScanTokenSize
+	if maxSize < initialSize {
+		initialSize = maxSize
+	}
+	buf := make([]byte, initialSize)
+	scanner.Buffer(buf, maxSize)
+	return scanner
+}
+
 // ReadNDJSON reads FHIR NDJSON from an io.Reader
 // Calls the callback function for each valid resource
 // Returns total lines processed and any fatal error
 func ReadNDJSON(reader io.Reader, callback func(FHIRResource) error) (int, error) {
-	scanner := bufio.NewScanner(reader)
-
-	// Increase buffer size for large FHIR resources
-	const maxCapacity = 1024 * 1024 // 1MB per line
-	buf := make([]byte, maxCapacity)
-	scanner.Buffer(buf, maxCapacity)
+	scanner := NewNDJSONScanner(reader)
 
 	lineNum := 0
 	for scanner.Scan() {

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -257,9 +257,23 @@ func (c *SendConfig) GetBatchSize() int {
 	return c.BatchSize
 }
 
+// DefaultMaxNDJSONLineSize is the default maximum line size for NDJSON scanning (100MB).
+// FHIR Bundles with hundreds of resources can produce multi-megabyte lines.
+const DefaultMaxNDJSONLineSize = 100 * 1024 * 1024
+
 // PipelineConfig defines which steps are enabled and their execution order
 type PipelineConfig struct {
-	EnabledSteps []StepName `yaml:"enabled_steps" json:"enabled_steps"`
+	EnabledSteps        []StepName `yaml:"enabled_steps" json:"enabled_steps"`
+	MaxNDJSONLineSizeMB int        `yaml:"max_ndjson_line_size_mb" json:"max_ndjson_line_size_mb" mapstructure:"max_ndjson_line_size_mb"`
+}
+
+// MaxNDJSONLineSize returns the maximum NDJSON line size in bytes.
+// Defaults to DefaultMaxNDJSONLineSize (100MB) if not configured.
+func (c PipelineConfig) MaxNDJSONLineSize() int {
+	if c.MaxNDJSONLineSizeMB <= 0 {
+		return DefaultMaxNDJSONLineSize
+	}
+	return c.MaxNDJSONLineSizeMB * 1024 * 1024
 }
 
 // RetryConfig controls retry behavior for transient errors

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -172,7 +171,7 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 	thresholdBytes := thresholdMB * 1024 * 1024
 
 	processor := NewResourceProcessor(dimpClient, logger, thresholdBytes, inputFile)
-	scanner := newLargeBufferScanner(fileCtx.InFile)
+	scanner := lib.NewNDJSONScannerWithMaxSize(fileCtx.InFile, job.Config.Pipeline.MaxNDJSONLineSize())
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -246,15 +245,6 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 	}
 
 	return processor.GetResourceCount(), nil
-}
-
-// newLargeBufferScanner creates a bufio.Scanner with a 100MB buffer to handle very large FHIR resources
-// Default bufio.Scanner buffer is 64KB which can cause "token too long" errors with complex queries
-func newLargeBufferScanner(r interface{ Read([]byte) (int, error) }) *bufio.Scanner {
-	scanner := bufio.NewScanner(r)
-	buf := make([]byte, 0, 100*1024*1024)
-	scanner.Buffer(buf, 100*1024*1024)
-	return scanner
 }
 
 // countResourcesInFile counts the number of non-empty lines in an NDJSON file

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -109,7 +108,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		"job_id", job.JobID)
 
 	// Load all resources from input files
-	allResources, err := LoadAllResources(files, logger)
+	allResources, err := LoadAllResources(files, logger, job.Config.Pipeline.MaxNDJSONLineSize())
 	if err != nil {
 		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
 		recordStepError(step, err, models.ErrorTypeNonTransient)
@@ -217,11 +216,11 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 }
 
 // LoadAllResources loads all FHIR resources from the given NDJSON files
-func LoadAllResources(files []string, logger *lib.Logger) ([]map[string]any, error) {
+func LoadAllResources(files []string, logger *lib.Logger, maxLineSize int) ([]map[string]any, error) {
 	var allResources []map[string]any
 
 	for _, filePath := range files {
-		resources, err := LoadResourcesFromFile(filePath, logger)
+		resources, err := LoadResourcesFromFile(filePath, logger, maxLineSize)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), err)
 		}
@@ -233,7 +232,7 @@ func LoadAllResources(files []string, logger *lib.Logger) ([]map[string]any, err
 
 // LoadResourcesFromFile loads FHIR resources from a single NDJSON file
 // Handles both compressed (.ndjson.zst) and uncompressed (.ndjson) files
-func LoadResourcesFromFile(filePath string, logger *lib.Logger) ([]map[string]any, error) {
+func LoadResourcesFromFile(filePath string, logger *lib.Logger, maxLineSize int) ([]map[string]any, error) {
 	// Use lib.OpenFileForReading to auto-detect compression
 	reader, err := lib.OpenFileForReading(filePath)
 	if err != nil {
@@ -242,10 +241,7 @@ func LoadResourcesFromFile(filePath string, logger *lib.Logger) ([]map[string]an
 	defer func() { _ = reader.Close() }()
 
 	var resources []map[string]any
-	scanner := bufio.NewScanner(reader)
-	// Increase buffer size for large resources
-	buf := make([]byte, 0, 100*1024*1024)
-	scanner.Buffer(buf, 100*1024*1024)
+	scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
 
 	lineNum := 0
 	for scanner.Scan() {

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -231,6 +231,7 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 
 	// Create FHIR client
 	fhirClient := services.NewFHIRClient(job.Config.Services.Send, httpClient, logger)
+	fhirClient.MaxLineSize = job.Config.Pipeline.MaxNDJSONLineSize()
 
 	fhirURL := job.Config.Services.Send.URL
 	fmt.Printf("Uploading %d NDJSON file(s) to FHIR server: %s\n\n", len(orderedFiles), fhirURL)

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -138,6 +138,9 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 		config.Pipeline.EnabledSteps = append(config.Pipeline.EnabledSteps, models.StepName(stepStr))
 	}
 
+	// Get max NDJSON line size (optional, defaults to 100MB via MaxNDJSONLineSize())
+	config.Pipeline.MaxNDJSONLineSizeMB = viper.GetInt("pipeline.max_ndjson_line_size_mb")
+
 	// Apply defaults for missing fields only if config wasn't found
 	if !configFound {
 		defaults := models.DefaultConfig()

--- a/internal/services/fhir_client.go
+++ b/internal/services/fhir_client.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
@@ -17,11 +16,12 @@ import (
 
 // FHIRClient handles sending NDJSON files to a FHIR server
 type FHIRClient struct {
-	url        string
-	batchSize  int
-	auth       models.AuthConfig
-	httpClient *HTTPClient
-	logger     *lib.Logger
+	url         string
+	batchSize   int
+	auth        models.AuthConfig
+	httpClient  *HTTPClient
+	logger      *lib.Logger
+	MaxLineSize int // Maximum NDJSON line size in bytes; 0 uses models.DefaultMaxNDJSONLineSize
 }
 
 // FHIRUploadStats contains statistics from uploading an NDJSON file
@@ -79,11 +79,11 @@ func (c *FHIRClient) UploadNDJSON(filePath string, reader io.Reader) (*FHIRUploa
 		batchSize = 100 // default
 	}
 
-	scanner := bufio.NewScanner(reader)
-	// Increase buffer size for large resources
-	const maxScanTokenSize = 10 * 1024 * 1024 // 10MB
-	buf := make([]byte, maxScanTokenSize)
-	scanner.Buffer(buf, maxScanTokenSize)
+	maxLineSize := c.MaxLineSize
+	if maxLineSize <= 0 {
+		maxLineSize = models.DefaultMaxNDJSONLineSize
+	}
+	scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
 
 	var batch []json.RawMessage
 	stats := &FHIRUploadStats{}

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -2196,3 +2196,62 @@ jobs_dir: "` + jobsDir + `"
 
 	assert.Equal(t, "/custom/certs/ca.pem", config.TLS.CACertPath, "TLS CA cert path should expand env var")
 }
+
+// TestConfigLoading_MaxNDJSONLineSize verifies max_ndjson_line_size_mb is loaded
+func TestConfigLoading_MaxNDJSONLineSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+pipeline:
+  enabled_steps:
+    - local_import
+  max_ndjson_line_size_mb: 200
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, 200, config.Pipeline.MaxNDJSONLineSizeMB, "MaxNDJSONLineSizeMB should be loaded from config")
+	assert.Equal(t, 200*1024*1024, config.Pipeline.MaxNDJSONLineSize(), "MaxNDJSONLineSize() should return bytes")
+}
+
+// TestConfigLoading_MaxNDJSONLineSizeDefault verifies default when not specified
+func TestConfigLoading_MaxNDJSONLineSizeDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "Config should load without error")
+
+	assert.Equal(t, 0, config.Pipeline.MaxNDJSONLineSizeMB, "MaxNDJSONLineSizeMB should be 0 when not set")
+	assert.Equal(t, 100*1024*1024, config.Pipeline.MaxNDJSONLineSize(), "MaxNDJSONLineSize() should default to 100MB")
+}

--- a/tests/unit/ndjson_scanner_test.go
+++ b/tests/unit/ndjson_scanner_test.go
@@ -1,0 +1,180 @@
+package unit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+// TestNewNDJSONScanner_DefaultBuffer verifies the scanner handles lines larger than
+// the old 1MB limit (regression test for issue #195)
+func TestNewNDJSONScanner_DefaultBuffer(t *testing.T) {
+	// Create a FHIR Bundle JSON line that exceeds 1MB
+	largeBundle := generateLargeFHIRBundle(1500)
+	bundleJSON, err := json.Marshal(largeBundle)
+	require.NoError(t, err)
+	require.Greater(t, len(bundleJSON), 1024*1024, "Test bundle must exceed 1MB to test the fix")
+
+	reader := bytes.NewReader(bundleJSON)
+	scanner := lib.NewNDJSONScanner(reader)
+
+	// Should successfully scan the large line
+	assert.True(t, scanner.Scan(), "Scanner should handle lines > 1MB")
+	assert.NoError(t, scanner.Err())
+	assert.Equal(t, len(bundleJSON), len(scanner.Bytes()))
+}
+
+// TestNewNDJSONScannerWithMaxSize_CustomSize verifies custom buffer size works
+func TestNewNDJSONScannerWithMaxSize_CustomSize(t *testing.T) {
+	smallLine := []byte(`{"resourceType":"Patient","id":"1"}`)
+	reader := bytes.NewReader(smallLine)
+	scanner := lib.NewNDJSONScannerWithMaxSize(reader, 1024)
+
+	assert.True(t, scanner.Scan())
+	assert.NoError(t, scanner.Err())
+	assert.Equal(t, string(smallLine), scanner.Text())
+}
+
+// TestNewNDJSONScannerWithMaxSize_ExceedsLimit verifies scanner fails gracefully
+// when a line exceeds the configured max
+func TestNewNDJSONScannerWithMaxSize_ExceedsLimit(t *testing.T) {
+	maxSize := 4096
+	// Create a line larger than maxSize (no newline, so scanner must buffer it all)
+	largeLine := strings.Repeat("x", maxSize*2)
+	reader := bytes.NewReader([]byte(largeLine))
+	scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxSize)
+
+	// Should fail since line exceeds max
+	assert.False(t, scanner.Scan())
+	assert.Error(t, scanner.Err())
+	assert.Contains(t, scanner.Err().Error(), "token too long")
+}
+
+// TestDefaultMaxNDJSONLineSize verifies the constant is 100MB
+func TestDefaultMaxNDJSONLineSize(t *testing.T) {
+	assert.Equal(t, 100*1024*1024, lib.DefaultMaxNDJSONLineSize)
+}
+
+// TestReadNDJSON_LargeBundle verifies ReadNDJSON handles Bundles > 1MB
+// This is the core regression test for issue #195
+func TestReadNDJSON_LargeBundle(t *testing.T) {
+	largeBundle := generateLargeFHIRBundle(1500)
+	bundleJSON, err := json.Marshal(largeBundle)
+	require.NoError(t, err)
+	require.Greater(t, len(bundleJSON), 1024*1024, "Test bundle must exceed 1MB")
+
+	reader := bytes.NewReader(append(bundleJSON, '\n'))
+
+	var resources []lib.FHIRResource
+	lineCount, err := lib.ReadNDJSON(reader, func(r lib.FHIRResource) error {
+		resources = append(resources, r)
+		return nil
+	})
+
+	require.NoError(t, err, "ReadNDJSON should handle lines > 1MB (issue #195)")
+	assert.Equal(t, 1, lineCount)
+	assert.Len(t, resources, 1)
+
+	resourceType, err := resources[0].GetResourceType()
+	require.NoError(t, err)
+	assert.Equal(t, "Bundle", resourceType)
+}
+
+// TestCountResourcesInFile_LargeBundle verifies CountResourcesInFile works
+// with NDJSON files containing large Bundles (regression test for issue #195)
+func TestCountResourcesInFile_LargeBundle(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "large.ndjson")
+
+	// Write two resources: one large Bundle and one small Patient
+	largeBundle := generateLargeFHIRBundle(1500)
+	bundleJSON, err := json.Marshal(largeBundle)
+	require.NoError(t, err)
+	require.Greater(t, len(bundleJSON), 1024*1024)
+
+	smallPatient := map[string]any{
+		"resourceType": "Patient",
+		"id":           "patient-1",
+		"gender":       "male",
+	}
+	patientJSON, err := json.Marshal(smallPatient)
+	require.NoError(t, err)
+
+	content := append(bundleJSON, '\n')
+	content = append(content, patientJSON...)
+	content = append(content, '\n')
+
+	err = os.WriteFile(filePath, content, 0644)
+	require.NoError(t, err)
+
+	count, err := lib.CountResourcesInFile(filePath)
+	require.NoError(t, err, "CountResourcesInFile should handle large bundles (issue #195)")
+	assert.Equal(t, 2, count)
+}
+
+// generateLargeFHIRBundle creates a FHIR Bundle with enough entries to exceed 1MB.
+// Each entry is ~2KB, so 600 entries produce a ~1.2MB JSON line.
+func generateLargeFHIRBundle(numEntries int) map[string]any {
+	entries := make([]map[string]any, numEntries)
+	for i := 0; i < numEntries; i++ {
+		entries[i] = map[string]any{
+			"resource": map[string]any{
+				"resourceType": "Observation",
+				"id":           fmt.Sprintf("obs-%d", i),
+				"status":       "final",
+				"code": map[string]any{
+					"coding": []map[string]any{
+						{
+							"system":  "http://loinc.org",
+							"code":    fmt.Sprintf("%05d-%d", i, i%10),
+							"display": fmt.Sprintf("Test observation %d with a reasonably long display name to increase the overall size of this entry", i),
+						},
+					},
+					"text": fmt.Sprintf("Observation code text for entry number %d", i),
+				},
+				"valueQuantity": map[string]any{
+					"value":  42.0 + float64(i),
+					"unit":   "mg/dL",
+					"system": "http://unitsofmeasure.org",
+					"code":   "mg/dL",
+				},
+				"subject": map[string]any{
+					"reference": "Patient/patient-1",
+					"display":   "Test Patient One",
+				},
+				"encounter": map[string]any{
+					"reference": fmt.Sprintf("Encounter/encounter-%d", i),
+				},
+				"effectiveDateTime": "2024-01-15T10:30:00Z",
+				"issued":            "2024-01-15T10:35:00Z",
+				"performer": []map[string]any{
+					{
+						"reference": "Practitioner/practitioner-1",
+						"display":   "Dr. Test Physician",
+					},
+				},
+				"note": []map[string]any{
+					{
+						"text": strings.Repeat("Padding text for bundle size. ", 20),
+					},
+				},
+			},
+		}
+	}
+
+	return map[string]any{
+		"resourceType": "Bundle",
+		"id":           "large-bundle-1",
+		"type":         "collection",
+		"entry":        entries,
+	}
+}

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -185,7 +185,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, resources)
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 		assert.Equal(t, "1", result[0]["id"])
@@ -204,7 +204,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(content), 0644)
 		require.NoError(t, err)
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 	})
@@ -233,7 +233,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 		assert.Equal(t, "Patient", result[0]["resourceType"])
@@ -259,7 +259,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		// Should extract only the valid entry
 		assert.Len(t, result, 1)
@@ -280,7 +280,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -300,7 +300,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -316,14 +316,14 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		// Bundle without valid entries should result in empty resources
 		assert.Empty(t, result)
 	})
 
 	t.Run("returns error for nonexistent file", func(t *testing.T) {
-		_, err := pipeline.LoadResourcesFromFile("/nonexistent/path/file.ndjson", logger)
+		_, err := pipeline.LoadResourcesFromFile("/nonexistent/path/file.ndjson", logger, lib.DefaultMaxNDJSONLineSize)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open file")
 	})
@@ -340,7 +340,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(content), 0644)
 		require.NoError(t, err)
 
-		result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		// Should skip invalid line and continue
 		assert.Len(t, result, 2)
@@ -363,7 +363,7 @@ func TestLoadAllResources(t *testing.T) {
 			{"resourceType": "Patient", "id": "2"},
 		})
 
-		result, err := pipeline.LoadAllResources([]string{file1, file2}, logger)
+		result, err := pipeline.LoadAllResources([]string{file1, file2}, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 	})
@@ -375,13 +375,13 @@ func TestLoadAllResources(t *testing.T) {
 			{"resourceType": "Patient", "id": "1"},
 		})
 
-		_, err := pipeline.LoadAllResources([]string{file1, "/nonexistent/file.ndjson"}, logger)
+		_, err := pipeline.LoadAllResources([]string{file1, "/nonexistent/file.ndjson"}, logger, lib.DefaultMaxNDJSONLineSize)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load")
 	})
 
 	t.Run("handles empty file list", func(t *testing.T) {
-		result, err := pipeline.LoadAllResources([]string{}, logger)
+		result, err := pipeline.LoadAllResources([]string{}, logger, lib.DefaultMaxNDJSONLineSize)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -754,7 +754,7 @@ func TestLoadResourcesFromFile_ScannerError(t *testing.T) {
 	}
 	writeTestNDJSON(t, filePath, resources)
 
-	result, err := pipeline.LoadResourcesFromFile(filePath, logger)
+	result, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 }


### PR DESCRIPTION
## Summary
- Consolidates 4 inconsistent NDJSON scanner implementations (1MB, 10MB, 100MB, 100MB) into a shared `NewNDJSONScanner` utility in `internal/lib/fhir.go`
- Fixes `bufio.Scanner: token too long` errors when reading large FHIR Bundles (issue #195)
- Adds `pipeline.max_ndjson_line_size_mb` YAML config option (default: 100MB) so users can adjust the limit for their data
- Buffer starts at 64KB and grows on demand — no upfront 100MB allocation

Closes #195