### PR TITLE
fix: override Renovate ignorePaths to include .github/test/ compose files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,14 @@
     ":maintainLockFilesWeekly",
     "customManagers:githubActionsVersions"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/__fixtures__/**"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary
- Override `ignorePaths` inherited from `:ignoreModulesAndTests` (via `config:best-practices` → `config:recommended`) to remove `**/test/**` and `**/tests/**` patterns
- These patterns caused Renovate to skip Docker images in `.github/test/torch/compose.yaml` and `.github/test/flattener/compose.yaml` entirely
- The removed patterns are irrelevant for a Go project (Go tests use `_test.go` files alongside source, not separate directories with dependency manifests)

Closes #207