### PR TITLE
fix: make TORCH status polling resilient to transient HTTP errors

### DIFF
--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -97,7 +97,7 @@ services:
 | `base_url` | string | - | TORCH server URL (required if torch step enabled) |
 | `username` | string | - | Authentication username |
 | `password` | string | - | Authentication password |
-| `extraction_timeout_minutes` | int | 30 | Max wait time for extraction |
+| `extraction_timeout_minutes` | int | 30 | Max wait time for extraction. Also serves as the safety net for transient polling errors — polling retries until this timeout is exceeded. |
 | `polling_interval_seconds` | int | 5 | Initial status check interval |
 | `max_polling_interval_seconds` | int | 30 | Max interval (exponential backoff cap) |
 

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -54,6 +54,18 @@ services:
     polling_interval_seconds: 10     # Default is 5
 ```
 
+For extractions that may take several days (e.g., large patient cohorts), set `extraction_timeout_minutes` accordingly:
+
+```yaml
+services:
+  torch:
+    extraction_timeout_minutes: 4320  # 3 days
+```
+
+### Polling Resilience
+
+During status polling, transient HTTP errors (timeouts, connection resets) are treated as recoverable. If TORCH is temporarily unable to respond to status requests — for example, because it is saturated with CPU-intensive FHIR operations — aether logs a warning and continues polling with exponential backoff rather than failing the entire extraction. The `extraction_timeout_minutes` setting acts as the safety net: polling only stops when this overall timeout is exceeded.
+
 ### Direct TORCH URL Import
 
 If you already have a TORCH extraction or result URL, you can pass it directly to skip the CRTDL submission step:

--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -342,13 +342,13 @@ func (c *TORCHClient) PollExtractionStatus(extractionURL string, showProgress bo
 		// Send request
 		resp, err := c.httpClient.client.Do(req)
 		if err != nil {
-			c.logger.Error("TORCH polling failed", "error", err, "attempt", pollConfig.PollCount)
-			return nil, &TORCHError{
-				Operation:  "poll",
-				StatusCode: 0,
-				Message:    err.Error(),
-				ErrorType:  models.ErrorTypeTransient,
-			}
+			// Treat transient HTTP errors (timeouts, connection resets) as recoverable
+			// during polling — the extraction may still be running on the server.
+			// The overall extraction timeout provides the safety net.
+			c.logger.Warn("TORCH poll request failed, will retry", "error", err, "attempt", pollConfig.PollCount)
+			time.Sleep(pollConfig.PollInterval)
+			pollConfig.UpdateInterval()
+			continue
 		}
 
 		// Handle response

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -1383,11 +1383,13 @@ func TestTORCHClient_SubmitExtraction_HttpDoError(t *testing.T) {
 	// Error should be a TORCHError with transient error type
 }
 
-// TestTORCHClient_PollExtractionStatus_HttpDoError verifies error handling when poll request fails
-// (covers lines 230-239 in torch_client.go)
+// TestTORCHClient_PollExtractionStatus_HttpDoError verifies that transient HTTP errors
+// during polling are retried until the extraction timeout is reached.
 func TestTORCHClient_PollExtractionStatus_HttpDoError(t *testing.T) {
 	// Create server that immediately closes connection
+	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		hj, ok := w.(http.Hijacker)
 		if ok {
 			conn, _, _ := hj.Hijack()
@@ -1397,20 +1399,62 @@ func TestTORCHClient_PollExtractionStatus_HttpDoError(t *testing.T) {
 	defer server.Close()
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	httpClient := services.NewHTTPClient(1*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	torchConfig := models.TORCHConfig{
+		BaseURL:                   server.URL,
+		Username:                  "testuser",
+		Password:                  "testpass",
+		ExtractionTimeoutMinutes:  0, // Immediate timeout so the test completes quickly
+		PollingIntervalSeconds:    1,
+		MaxPollingIntervalSeconds: 1,
+	}
+
+	client := services.NewTORCHClient(torchConfig, httpClient, logger)
+	_, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+
+	assert.Error(t, err, "Should eventually fail with extraction timeout")
+	assert.ErrorIs(t, err, services.ErrExtractionTimeout)
+}
+
+// TestTORCHClient_PollExtractionStatus_HttpDoErrorThenRecovers verifies that transient HTTP errors
+// during polling are retried and polling succeeds once the server recovers.
+func TestTORCHClient_PollExtractionStatus_HttpDoErrorThenRecovers(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount <= 2 {
+			// First two requests: close connection to simulate transient error
+			hj, ok := w.(http.Hijacker)
+			if ok {
+				conn, _, _ := hj.Hijack()
+				_ = conn.Close()
+			}
+			return
+		}
+		// Third request: return completed result
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output": [{"type": "data", "url": "/downloads/result.ndjson"}]}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(2*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
 		BaseURL:                   server.URL,
 		Username:                  "testuser",
 		Password:                  "testpass",
 		ExtractionTimeoutMinutes:  1,
 		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		MaxPollingIntervalSeconds: 2,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
-	_, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+	fileURLs, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
 
-	assert.Error(t, err, "Should fail when poll request fails")
+	assert.NoError(t, err, "Should succeed after transient errors resolve")
+	assert.Len(t, fileURLs, 1, "Should return file URLs from successful response")
+	assert.Equal(t, 3, requestCount, "Should have retried through transient errors")
 }
 
 // TestTORCHClient_DownloadFile_HttpDoError verifies error handling when download request fails


### PR DESCRIPTION
## Summary

- **Polling resilience**: `PollExtractionStatus` now treats transient HTTP errors (timeouts, connection resets) as recoverable instead of failing immediately. It logs a warning, applies exponential backoff, and continues polling until the extraction timeout is reached.
- **Updated test**: `HttpDoError` test now verifies polling retries until `ErrExtractionTimeout`
- **New test**: `HttpDoErrorThenRecovers` verifies polling succeeds after transient errors resolve

Closes #221