### PR TITLE
refactor: use time.Duration for TORCH config time fields

### DIFF
--- a/.github/test/aether-direct-load.yaml
+++ b/.github/test/aether-direct-load.yaml
@@ -10,14 +10,14 @@ services:
     username: ""
     password: ""
 
-    # Maximum time to wait for extraction completion (in minutes)
-    extraction_timeout_minutes: 30
+    # Maximum time to wait for extraction completion (Go duration string, e.g. 30m)
+    extraction_timeout: PT30M
 
-    # Initial polling interval when checking extraction status (in seconds)
-    polling_interval_seconds: 5
+    # Initial polling interval when checking extraction status (Go duration string, e.g. 5s)
+    polling_interval: PT5S
 
     # Maximum polling interval (exponential backoff cap, in seconds)
-    max_polling_interval_seconds: 30
+    max_polling_interval: PT30S
 
   # Send step configuration - direct resource load to Blaze FHIR server
   send:

--- a/.github/test/aether-s3-upload.yaml
+++ b/.github/test/aether-s3-upload.yaml
@@ -10,14 +10,14 @@ services:
     username: ""
     password: ""
 
-    # Maximum time to wait for extraction completion (in minutes)
-    extraction_timeout_minutes: 30
+    # Maximum time to wait for extraction completion (Go duration string, e.g. 30m)
+    extraction_timeout: PT30M
 
-    # Initial polling interval when checking extraction status (in seconds)
-    polling_interval_seconds: 5
+    # Initial polling interval when checking extraction status (Go duration string, e.g. 5s)
+    polling_interval: PT5S
 
     # Maximum polling interval (exponential backoff cap, in seconds)
-    max_polling_interval_seconds: 30
+    max_polling_interval: PT30S
 
   # Send step configuration - S3 upload to MinIO
   send:

--- a/.github/test/aether.yaml
+++ b/.github/test/aether.yaml
@@ -10,14 +10,14 @@ services:
     username: ""
     password: ""
 
-    # Maximum time to wait for extraction completion (in minutes)
-    extraction_timeout_minutes: 30
+    # Maximum time to wait for extraction completion (Go duration string, e.g. 30m)
+    extraction_timeout: PT30M
 
-    # Initial polling interval when checking extraction status (in seconds)
-    polling_interval_seconds: 5
+    # Initial polling interval when checking extraction status (Go duration string, e.g. 5s)
+    polling_interval: PT5S
 
     # Maximum polling interval (exponential backoff cap, in seconds)
-    max_polling_interval_seconds: 30
+    max_polling_interval: PT30S
 
   # DIMP Pseudonymization Service
   dimp:

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -13,18 +13,27 @@ services:
     username: "test"
     password: "test"
 
-    # Maximum time to wait for extraction completion (in minutes)
-    # Default: 30 minutes (reasonable for typical cohort sizes)
-    extraction_timeout_minutes: 30
+    # Maximum time to wait for extraction completion
+    # Accepts ISO 8601 (e.g. PT30M) or Go format (e.g. 30m)
+    # Default: PT30M (30 minutes, reasonable for typical cohort sizes)
+    extraction_timeout: PT30M
 
-    # Initial polling interval when checking extraction status (in seconds)
-    # Default: 5 seconds
-    polling_interval_seconds: 5
+    # Initial polling interval when checking extraction status
+    # Default: PT5S
+    polling_interval: PT5S
 
-    # Maximum polling interval (exponential backoff cap, in seconds)
-    # Default: 30 seconds
-    max_polling_interval_seconds: 30
-  
+    # Maximum polling interval (exponential backoff cap)
+    # Default: PT30S
+    max_polling_interval: PT30S
+
+    # Number of retries waiting for files to become available after extraction
+    # Default: 10
+    # file_ready_retries: 10
+
+    # Interval between file availability checks
+    # Default: PT10S
+    # file_ready_interval: PT10S
+
   # DIMP Pseudonymization Service (optional)
   # Leave empty to skip pseudonymization step
   dimp:
@@ -90,8 +99,9 @@ services:
       - csv
 
     # Request timeout for the flattening service
-    # Default: 30m (30 minutes)
-    timeout: 30m
+    # Accepts ISO 8601 (e.g. PT30M) or Go format (e.g. 30m)
+    # Default: PT30M (30 minutes)
+    timeout: PT30M
 
     # Total memory budget in megabytes (MB) for streaming processing.
     # This budget is divided equally across attribute groups — each group flushes
@@ -161,8 +171,8 @@ services:
       # Use path-style addressing (required for MinIO and some S3-compatible stores)
       use_path_style: false
 
-      # Upload timeout (default: 30m)
-      timeout: 30m
+      # Upload timeout (default: PT30M)
+      timeout: PT30M
 
   # FHIR Validation Service (optional)
   # Validates FHIR resources against profiles before further processing

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -10,9 +10,9 @@ services:
     base_url: string
     username: string
     password: string
-    extraction_timeout_minutes: integer  # default: 30
-    polling_interval_seconds: integer    # default: 5
-    max_polling_interval_seconds: integer # default: 30
+    extraction_timeout: duration  # default: PT30M
+    polling_interval: duration    # default: PT5S
+    max_polling_interval: duration # default: PT30S
 
   dimp:
     url: string
@@ -22,7 +22,7 @@ services:
     service_url: string
     lookup_path: string
     formats: [string]                    # ["csv"]
-    timeout: duration                    # default: 30m
+    timeout: duration                    # default: PT30M
     batch_size_mb: integer               # default: 500
 
   send:
@@ -88,9 +88,9 @@ services:
     base_url: "https://torch.example.org"
     username: "${TORCH_USER}"
     password: "${TORCH_PASSWORD}"
-    extraction_timeout_minutes: 30
-    polling_interval_seconds: 5
-    max_polling_interval_seconds: 30
+    extraction_timeout: PT30M
+    polling_interval: PT5S
+    max_polling_interval: PT30S
 ```
 
 | Option | Type | Default | Description |
@@ -98,9 +98,11 @@ services:
 | `base_url` | string | - | TORCH server URL (required if torch step enabled) |
 | `username` | string | - | Authentication username |
 | `password` | string | - | Authentication password |
-| `extraction_timeout_minutes` | int | 30 | Max wait time for extraction. Also serves as the safety net for transient polling errors — polling retries until this timeout is exceeded. |
-| `polling_interval_seconds` | int | 5 | Initial status check interval |
-| `max_polling_interval_seconds` | int | 30 | Max interval (exponential backoff cap) |
+| `extraction_timeout` | duration | PT30M | Max wait time for extraction. Also serves as the safety net for transient polling errors — polling retries until this timeout is exceeded. |
+| `polling_interval` | duration | PT5S | Initial status check interval |
+| `max_polling_interval` | duration | PT30S | Max interval (exponential backoff cap) |
+| `file_ready_retries` | int | 10 | Number of retries for file availability check |
+| `file_ready_interval` | duration | PT10S | Interval between file availability checks |
 
 ### DIMP
 
@@ -129,7 +131,7 @@ services:
     lookup_path: "/config/flatten-lookup.json"
     formats:
       - csv
-    timeout: 30m
+    timeout: PT30M
 ```
 
 | Option | Type | Default | Description |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -32,8 +32,8 @@ services:
     base_url: "https://your-torch-server.org"
     username: "your-username"
     password: "your-password"
-    extraction_timeout_minutes: 30
-    polling_interval_seconds: 5
+    extraction_timeout: PT30M
+    polling_interval: PT5S
 ```
 
 ### DIMP
@@ -54,7 +54,7 @@ services:
     lookup_path: "/path/to/flatten-lookup.json"
     formats:
       - csv
-    timeout: 30m
+    timeout: PT30M
 ```
 
 ### Send

--- a/docs/guides/steps/torch-import.md
+++ b/docs/guides/steps/torch-import.md
@@ -22,9 +22,9 @@ services:
     base_url: "https://your-torch-server.org"
     username: "your-username"
     password: "your-password"
-    extraction_timeout_minutes: 30  # default
-    polling_interval_seconds: 5     # default
-    max_polling_interval_seconds: 30 # default
+    extraction_timeout: PT30M  # default
+    polling_interval: PT5S     # default
+    max_polling_interval: PT30S # default
 
 pipeline:
   enabled_steps:
@@ -54,6 +54,6 @@ URLs containing `/fhir/extraction/` or `/fhir/result/` are automatically recogni
 | `base_url` | string | - | TORCH server URL (required) |
 | `username` | string | - | Authentication username |
 | `password` | string | - | Authentication password |
-| `extraction_timeout_minutes` | int | 30 | Max wait time for extraction |
-| `polling_interval_seconds` | int | 5 | Initial status check interval |
-| `max_polling_interval_seconds` | int | 30 | Max interval (exponential backoff) |
+| `extraction_timeout` | duration | PT30M | Max wait time for extraction |
+| `polling_interval` | duration | PT5S | Initial status check interval |
+| `max_polling_interval` | duration | PT30S | Max interval (exponential backoff) |

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -50,8 +50,8 @@ services:
     base_url: "https://your-torch-server.org"
     username: "your-username"
     password: "your-password"
-    extraction_timeout_minutes: 60   # Default is 30
-    polling_interval_seconds: 10     # Default is 5
+    extraction_timeout: PT1H     # Default is PT30M
+    polling_interval: PT10S      # Default is PT5S
 ```
 
 For extractions that may take several days (e.g., large patient cohorts), set `extraction_timeout_minutes` accordingly:
@@ -111,7 +111,7 @@ pipeline:
     - dimp
 ```
 
-The `extraction_timeout_minutes` and polling interval settings also apply.
+The `extraction_timeout` and polling interval settings also apply.
 
 #### Comparison: CRTDL vs TORCH URL vs HTTP
 

--- a/internal/lib/duration.go
+++ b/internal/lib/duration.go
@@ -1,0 +1,66 @@
+package lib
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// iso8601Pattern matches ISO 8601 duration strings like PT30M, PT1H30M5S, P1DT12H
+var iso8601Pattern = regexp.MustCompile(`^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$`)
+
+// ParseDuration parses a duration string in either ISO 8601 format (e.g. "PT30M")
+// or Go format (e.g. "30m"). ISO 8601 is tried first; if it doesn't match,
+// Go's time.ParseDuration is used as fallback.
+func ParseDuration(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	if d, ok := parseISO8601Duration(s); ok {
+		return d, nil
+	}
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: must be ISO 8601 (e.g. PT30M) or Go format (e.g. 30m)", s)
+	}
+	return d, nil
+}
+
+// parseISO8601Duration attempts to parse an ISO 8601 duration string.
+// Returns the duration and true if successful, or zero and false if the string
+// is not in ISO 8601 format.
+func parseISO8601Duration(s string) (time.Duration, bool) {
+	matches := iso8601Pattern.FindStringSubmatch(s)
+	if matches == nil {
+		return 0, false
+	}
+
+	// Reject bare "P" or "PT" with no components
+	if matches[1] == "" && matches[2] == "" && matches[3] == "" && matches[4] == "" {
+		return 0, false
+	}
+
+	var d time.Duration
+
+	if matches[1] != "" {
+		days, _ := strconv.Atoi(matches[1])
+		d += time.Duration(days) * 24 * time.Hour
+	}
+	if matches[2] != "" {
+		hours, _ := strconv.Atoi(matches[2])
+		d += time.Duration(hours) * time.Hour
+	}
+	if matches[3] != "" {
+		minutes, _ := strconv.Atoi(matches[3])
+		d += time.Duration(minutes) * time.Minute
+	}
+	if matches[4] != "" {
+		seconds, _ := strconv.ParseFloat(matches[4], 64)
+		d += time.Duration(seconds * float64(time.Second))
+	}
+
+	return d, true
+}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -82,14 +82,14 @@ type ParquetConversionConfig struct {
 
 // TORCHConfig contains TORCH server connection and extraction behavior settings
 type TORCHConfig struct {
-	BaseURL                   string `yaml:"base_url" json:"base_url"`
-	Username                  string `yaml:"username" json:"username"`
-	Password                  string `yaml:"password" json:"password"`
-	ExtractionTimeoutMinutes  int    `yaml:"extraction_timeout_minutes" json:"extraction_timeout_minutes"`
-	PollingIntervalSeconds    int    `yaml:"polling_interval_seconds" json:"polling_interval_seconds"`
-	MaxPollingIntervalSeconds int    `yaml:"max_polling_interval_seconds" json:"max_polling_interval_seconds"`
-	FileReadyRetries          int    `yaml:"file_ready_retries" json:"file_ready_retries"`
-	FileReadyIntervalSeconds  int    `yaml:"file_ready_interval_seconds" json:"file_ready_interval_seconds"`
+	BaseURL            string        `yaml:"base_url" json:"base_url" mapstructure:"base_url"`
+	Username           string        `yaml:"username" json:"username" mapstructure:"username"`
+	Password           string        `yaml:"password" json:"password" mapstructure:"password"`
+	ExtractionTimeout  time.Duration `yaml:"extraction_timeout" json:"extraction_timeout" mapstructure:"extraction_timeout"`
+	PollingInterval    time.Duration `yaml:"polling_interval" json:"polling_interval" mapstructure:"polling_interval"`
+	MaxPollingInterval time.Duration `yaml:"max_polling_interval" json:"max_polling_interval" mapstructure:"max_polling_interval"`
+	FileReadyRetries   int           `yaml:"file_ready_retries" json:"file_ready_retries" mapstructure:"file_ready_retries"`
+	FileReadyInterval  time.Duration `yaml:"file_ready_interval" json:"file_ready_interval" mapstructure:"file_ready_interval"`
 }
 
 // SendMode defines the mode for sending data
@@ -359,14 +359,14 @@ func DefaultConfig() ProjectConfig {
 				URL: "",
 			},
 			TORCH: TORCHConfig{
-				BaseURL:                   "",
-				Username:                  "",
-				Password:                  "",
-				ExtractionTimeoutMinutes:  30,
-				PollingIntervalSeconds:    5,
-				MaxPollingIntervalSeconds: 30,
-				FileReadyRetries:          10,
-				FileReadyIntervalSeconds:  10,
+				BaseURL:            "",
+				Username:           "",
+				Password:           "",
+				ExtractionTimeout:  30 * time.Minute,
+				PollingInterval:    5 * time.Second,
+				MaxPollingInterval: 30 * time.Second,
+				FileReadyRetries:   10,
+				FileReadyInterval:  10 * time.Second,
 			},
 			Flattening:         DefaultFlatteningConfig(),
 			CRTDLPreprocessing: DefaultCRTDLPreprocessingConfig(),
@@ -402,17 +402,21 @@ func (c *TORCHConfig) Validate() error {
 
 	// Username and password are optional - TORCH may not require authentication in all environments
 
-	if c.ExtractionTimeoutMinutes <= 0 {
-		return fmt.Errorf("extraction_timeout_minutes must be > 0, got %d", c.ExtractionTimeoutMinutes)
+	if c.ExtractionTimeout <= 0 {
+		return fmt.Errorf("extraction_timeout must be > 0, got %s", c.ExtractionTimeout)
 	}
 
-	if c.PollingIntervalSeconds <= 0 || c.PollingIntervalSeconds > 60 {
-		return fmt.Errorf("polling_interval_seconds must be 1-60, got %d", c.PollingIntervalSeconds)
+	if c.PollingInterval < time.Second {
+		return fmt.Errorf("polling_interval must be >= 1s, got %s", c.PollingInterval)
 	}
 
-	if c.MaxPollingIntervalSeconds < c.PollingIntervalSeconds {
-		return fmt.Errorf("max_polling_interval_seconds (%d) must be >= polling_interval_seconds (%d)",
-			c.MaxPollingIntervalSeconds, c.PollingIntervalSeconds)
+	if c.MaxPollingInterval < c.PollingInterval {
+		return fmt.Errorf("max_polling_interval (%s) must be >= polling_interval (%s)",
+			c.MaxPollingInterval, c.PollingInterval)
+	}
+
+	if c.FileReadyInterval < 0 {
+		return fmt.Errorf("file_ready_interval must be >= 0, got %s", c.FileReadyInterval)
 	}
 
 	return nil

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -9,8 +9,25 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
+
+// getDuration reads a viper key as a string and parses it as a duration,
+// supporting both ISO 8601 (e.g. "PT30M") and Go format (e.g. "30m").
+// Returns zero duration if the key is not set or empty.
+func getDuration(key string) time.Duration {
+	s := viper.GetString(key)
+	if s == "" {
+		return 0
+	}
+	d, err := lib.ParseDuration(s)
+	if err != nil {
+		// Fall back to viper's built-in parsing for numeric values
+		return viper.GetDuration(key)
+	}
+	return d
+}
 
 // viperGetBoolPtr returns a *bool if the key is explicitly set in config, or nil otherwise.
 func viperGetBoolPtr(key string) *bool {
@@ -74,14 +91,14 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   ExpandEnvVars(viper.GetString("services.torch.base_url")),
-				Username:                  ExpandEnvVars(viper.GetString("services.torch.username")),
-				Password:                  ExpandEnvVars(viper.GetString("services.torch.password")),
-				ExtractionTimeoutMinutes:  viper.GetInt("services.torch.extraction_timeout_minutes"),
-				PollingIntervalSeconds:    viper.GetInt("services.torch.polling_interval_seconds"),
-				MaxPollingIntervalSeconds: viper.GetInt("services.torch.max_polling_interval_seconds"),
-				FileReadyRetries:          viper.GetInt("services.torch.file_ready_retries"),
-				FileReadyIntervalSeconds:  viper.GetInt("services.torch.file_ready_interval_seconds"),
+				BaseURL:            ExpandEnvVars(viper.GetString("services.torch.base_url")),
+				Username:           ExpandEnvVars(viper.GetString("services.torch.username")),
+				Password:           ExpandEnvVars(viper.GetString("services.torch.password")),
+				ExtractionTimeout:  getDuration("services.torch.extraction_timeout"),
+				PollingInterval:    getDuration("services.torch.polling_interval"),
+				MaxPollingInterval: getDuration("services.torch.max_polling_interval"),
+				FileReadyRetries:   viper.GetInt("services.torch.file_ready_retries"),
+				FileReadyInterval:  getDuration("services.torch.file_ready_interval"),
 			},
 			DIMP: models.DIMPConfig{
 				URL:                    ExpandEnvVars(viper.GetString("services.dimp.url")),
@@ -103,7 +120,7 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 				ServiceURL:  ExpandEnvVars(viper.GetString("services.flattening.service_url")),
 				LookupPath:  ExpandEnvVars(viper.GetString("services.flattening.lookup_path")),
 				Formats:     viper.GetStringSlice("services.flattening.formats"),
-				Timeout:     viper.GetDuration("services.flattening.timeout"),
+				Timeout:     getDuration("services.flattening.timeout"),
 				BatchSizeMB: viper.GetInt("services.flattening.batch_size_mb"),
 			},
 			Send: models.SendConfig{
@@ -128,7 +145,7 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 					AccessKeyID:     ExpandEnvVars(viper.GetString("services.send.s3.access_key_id")),
 					SecretAccessKey: ExpandEnvVars(viper.GetString("services.send.s3.secret_access_key")),
 					UsePathStyle:    viper.GetBool("services.send.s3.use_path_style"),
-					Timeout:         viper.GetDuration("services.send.s3.timeout"),
+					Timeout:         getDuration("services.send.s3.timeout"),
 				},
 			},
 			LocalImport: models.LocalImportConfig{
@@ -214,20 +231,20 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 			config.JobsDir = "./jobs"
 		}
 		// Apply TORCH defaults for missing values
-		if config.Services.TORCH.ExtractionTimeoutMinutes == 0 {
-			config.Services.TORCH.ExtractionTimeoutMinutes = 30
+		if config.Services.TORCH.ExtractionTimeout == 0 {
+			config.Services.TORCH.ExtractionTimeout = 30 * time.Minute
 		}
-		if config.Services.TORCH.PollingIntervalSeconds == 0 {
-			config.Services.TORCH.PollingIntervalSeconds = 5
+		if config.Services.TORCH.PollingInterval == 0 {
+			config.Services.TORCH.PollingInterval = 5 * time.Second
 		}
-		if config.Services.TORCH.MaxPollingIntervalSeconds == 0 {
-			config.Services.TORCH.MaxPollingIntervalSeconds = 30
+		if config.Services.TORCH.MaxPollingInterval == 0 {
+			config.Services.TORCH.MaxPollingInterval = 30 * time.Second
 		}
 		if config.Services.TORCH.FileReadyRetries == 0 {
 			config.Services.TORCH.FileReadyRetries = 10
 		}
-		if config.Services.TORCH.FileReadyIntervalSeconds == 0 {
-			config.Services.TORCH.FileReadyIntervalSeconds = 10
+		if config.Services.TORCH.FileReadyInterval == 0 {
+			config.Services.TORCH.FileReadyInterval = 10 * time.Second
 		}
 		// Apply DIMP Bundle split threshold default if not set
 		if config.Services.DIMP.BundleSplitThresholdMB == 0 {

--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -304,7 +304,7 @@ func (c *TORCHClient) PollExtractionStatus(extractionURL string, showProgress bo
 	c.logger.Info("Polling TORCH extraction status", "url", extractionURL)
 
 	// Setup polling configuration
-	pollConfig := NewPollConfig(c.config.ExtractionTimeoutMinutes, c.config.PollingIntervalSeconds, c.config.MaxPollingIntervalSeconds)
+	pollConfig := NewPollConfig(c.config)
 
 	// Start spinner for polling (duration unknown)
 	var spinner *ui.Spinner
@@ -701,10 +701,7 @@ func (c *TORCHClient) waitForFileAvailability(fileURL string) error {
 		return nil
 	}
 
-	interval := time.Duration(c.config.FileReadyIntervalSeconds) * time.Second
-	if interval <= 0 {
-		interval = 10 * time.Second
-	}
+	interval := c.config.FileReadyInterval
 
 	for attempt := 1; attempt <= c.config.FileReadyRetries; attempt++ {
 		available, err := c.checkFileAvailable(fileURL)

--- a/internal/services/torch_poller.go
+++ b/internal/services/torch_poller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 // PollConfig holds configuration for extraction polling
@@ -19,13 +20,13 @@ type PollConfig struct {
 	PollCount       int
 }
 
-// NewPollConfig creates polling configuration from client settings
-func NewPollConfig(timeoutMinutes, pollIntervalSeconds, maxPollIntervalSeconds int) *PollConfig {
+// NewPollConfig creates polling configuration from TORCH client settings
+func NewPollConfig(cfg models.TORCHConfig) *PollConfig {
 	return &PollConfig{
-		Timeout:         time.Duration(timeoutMinutes) * time.Minute,
+		Timeout:         cfg.ExtractionTimeout,
 		StartTime:       time.Now(),
-		PollInterval:    time.Duration(pollIntervalSeconds) * time.Second,
-		MaxPollInterval: time.Duration(maxPollIntervalSeconds) * time.Second,
+		PollInterval:    cfg.PollingInterval,
+		MaxPollInterval: cfg.MaxPollingInterval,
 		PollCount:       0,
 	}
 }

--- a/tests/contract/torch_service_test.go
+++ b/tests/contract/torch_service_test.go
@@ -88,12 +88,12 @@ func TestTORCHService_SubmitExtraction_Success(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
 
@@ -192,12 +192,12 @@ func TestTORCHService_PollStatus_InProgress(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  0, // Immediate timeout
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 1,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  0 * time.Minute, // Immediate timeout
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 1 * time.Second,
 	}
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
 
@@ -244,12 +244,12 @@ func TestTORCHService_PollStatus_Complete(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
 
@@ -282,12 +282,12 @@ func TestTORCHService_PollStatus_Failed(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
 
@@ -475,12 +475,12 @@ func TestTORCHService_EndToEnd_SubmitPollDownload(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
 

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -132,12 +132,12 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 		},
 		Pipeline: models.PipelineConfig{
@@ -240,12 +240,12 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 		},
 		Pipeline: models.PipelineConfig{
@@ -381,12 +381,12 @@ func TestPipeline_DirectTORCHURL_Download(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 		},
 		Pipeline: models.PipelineConfig{
@@ -475,12 +475,12 @@ func TestPipeline_DirectTORCHURL_EmptyResult(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 		},
 		Pipeline: models.PipelineConfig{
@@ -566,12 +566,12 @@ func TestPipeline_TORCHExtraction_PollingTimeout(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1, // Config value (will be overridden in direct client test)
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 2,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute, // Config value (will be overridden in direct client test)
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 2 * time.Second,
 			},
 		},
 		Retry: models.RetryConfig{
@@ -728,12 +728,12 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   torchServer.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            torchServer.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 			DIMP: models.DIMPConfig{
 				URL: dimpServer.URL + "/fhir",
@@ -954,12 +954,12 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
 				Enabled: true,
@@ -1130,12 +1130,12 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  5,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  5 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 		},
 		Pipeline: models.PipelineConfig{
@@ -1264,12 +1264,12 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidEnrichmentsPath(t *t
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
 				Enabled:         true,
@@ -1395,12 +1395,12 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
 				Enabled: false, // Disabled - should use original CRTDL
@@ -1473,12 +1473,12 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidCRTDL(t *testing.T) 
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
 				Enabled: true,
@@ -1624,12 +1624,12 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			TORCH: models.TORCHConfig{
-				BaseURL:                   server.URL,
-				Username:                  "testuser",
-				Password:                  "testpass",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 5,
+				BaseURL:            server.URL,
+				Username:           "testuser",
+				Password:           "testpass",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 5 * time.Second,
 			},
 			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
 				Enabled:     true,

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -461,9 +462,9 @@ services:
     base_url: "http://localhost:8080"
     username: "testuser"
     password: "testpass"
-    extraction_timeout_minutes: 30
-    polling_interval_seconds: 5
-    max_polling_interval_seconds: 30
+    extraction_timeout: PT30M
+    polling_interval: PT5S
+    max_polling_interval: PT30S
 
 pipeline:
   enabled_steps:
@@ -486,9 +487,9 @@ jobs_dir: "` + jobsDir + `"
 	assert.Equal(t, "http://localhost:8080", config.Services.TORCH.BaseURL)
 	assert.Equal(t, "testuser", config.Services.TORCH.Username)
 	assert.Equal(t, "testpass", config.Services.TORCH.Password)
-	assert.Equal(t, 30, config.Services.TORCH.ExtractionTimeoutMinutes)
-	assert.Equal(t, 5, config.Services.TORCH.PollingIntervalSeconds)
-	assert.Equal(t, 30, config.Services.TORCH.MaxPollingIntervalSeconds)
+	assert.Equal(t, 30*time.Minute, config.Services.TORCH.ExtractionTimeout)
+	assert.Equal(t, 5*time.Second, config.Services.TORCH.PollingInterval)
+	assert.Equal(t, 30*time.Second, config.Services.TORCH.MaxPollingInterval)
 
 	// Test validation passes with valid config
 	err = config.Services.TORCH.Validate()
@@ -608,7 +609,7 @@ services:
     base_url: "http://localhost:8080"
     username: "testuser"
     password: "testpass"
-    extraction_timeout_minutes: -1
+    extraction_timeout: -1m
 
 pipeline:
   enabled_steps:
@@ -624,7 +625,7 @@ jobs_dir: "` + jobsDir + `"
 	err := os.WriteFile(configFile, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	// LoadConfig validates config, zero timeout should cause error
+	// LoadConfig validates config, negative timeout should cause error
 	_, err = services.LoadConfig(configFile)
 	assert.Error(t, err, "Zero timeout should fail validation")
 	assert.Contains(t, err.Error(), "timeout")
@@ -642,7 +643,7 @@ services:
     base_url: "http://localhost:8080"
     username: "testuser"
     password: "testpass"
-    polling_interval_seconds: -1
+    polling_interval: -1s
 
 pipeline:
   enabled_steps:
@@ -676,8 +677,8 @@ services:
     base_url: "http://localhost:8080"
     username: "testuser"
     password: "testpass"
-    polling_interval_seconds: 10
-    max_polling_interval_seconds: 5
+    polling_interval: PT10S
+    max_polling_interval: PT5S
 
 pipeline:
   enabled_steps:
@@ -707,11 +708,11 @@ func TestTORCHConfig_WithDefaults(t *testing.T) {
 	assert.Equal(t, "", config.Services.TORCH.BaseURL, "BaseURL should default to empty")
 	assert.Equal(t, "", config.Services.TORCH.Username, "Username should default to empty")
 	assert.Equal(t, "", config.Services.TORCH.Password, "Password should default to empty")
-	assert.Equal(t, 30, config.Services.TORCH.ExtractionTimeoutMinutes, "Should default to 30 minutes")
-	assert.Equal(t, 5, config.Services.TORCH.PollingIntervalSeconds, "Should default to 5 seconds")
-	assert.Equal(t, 30, config.Services.TORCH.MaxPollingIntervalSeconds, "Should default to 30 seconds")
+	assert.Equal(t, 30*time.Minute, config.Services.TORCH.ExtractionTimeout, "Should default to 30 minutes")
+	assert.Equal(t, 5*time.Second, config.Services.TORCH.PollingInterval, "Should default to 5 seconds")
+	assert.Equal(t, 30*time.Second, config.Services.TORCH.MaxPollingInterval, "Should default to 30 seconds")
 	assert.Equal(t, 10, config.Services.TORCH.FileReadyRetries, "Should default to 10 retries")
-	assert.Equal(t, 10, config.Services.TORCH.FileReadyIntervalSeconds, "Should default to 10 seconds")
+	assert.Equal(t, 10*time.Second, config.Services.TORCH.FileReadyInterval, "Should default to 10 seconds")
 }
 
 func TestTORCHConfig_FileReadySettings(t *testing.T) {
@@ -726,11 +727,11 @@ services:
     base_url: "http://localhost:8080"
     username: "testuser"
     password: "testpass"
-    extraction_timeout_minutes: 30
-    polling_interval_seconds: 5
-    max_polling_interval_seconds: 30
+    extraction_timeout: PT30M
+    polling_interval: PT5S
+    max_polling_interval: PT30S
     file_ready_retries: 5
-    file_ready_interval_seconds: 3
+    file_ready_interval: PT3S
 
 pipeline:
   enabled_steps:
@@ -750,7 +751,7 @@ jobs_dir: "` + jobsDir + `"
 	require.NoError(t, err, "Config should load without error")
 
 	assert.Equal(t, 5, config.Services.TORCH.FileReadyRetries, "FileReadyRetries should be loaded")
-	assert.Equal(t, 3, config.Services.TORCH.FileReadyIntervalSeconds, "FileReadyIntervalSeconds should be loaded")
+	assert.Equal(t, 3*time.Second, config.Services.TORCH.FileReadyInterval, "FileReadyInterval should be loaded")
 }
 
 func TestTORCHConfig_FileReadySettingsDefault(t *testing.T) {
@@ -785,18 +786,18 @@ jobs_dir: "` + jobsDir + `"
 	require.NoError(t, err, "Config should load without error")
 
 	assert.Equal(t, 10, config.Services.TORCH.FileReadyRetries, "FileReadyRetries should default to 10")
-	assert.Equal(t, 10, config.Services.TORCH.FileReadyIntervalSeconds, "FileReadyIntervalSeconds should default to 10")
+	assert.Equal(t, 10*time.Second, config.Services.TORCH.FileReadyInterval, "FileReadyInterval should default to 10")
 }
 
 func TestTORCHConfig_ValidateMalformedURL(t *testing.T) {
 	// Test URL that causes url.Parse to fail (contains invalid characters)
 	config := models.TORCHConfig{
-		BaseURL:                   "http://[invalid",
-		Username:                  "user",
-		Password:                  "pass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    5,
-		MaxPollingIntervalSeconds: 30,
+		BaseURL:            "http://[invalid",
+		Username:           "user",
+		Password:           "pass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    5 * time.Second,
+		MaxPollingInterval: 30 * time.Second,
 	}
 
 	err := config.Validate()
@@ -804,20 +805,19 @@ func TestTORCHConfig_ValidateMalformedURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid TORCH base_url")
 }
 
-func TestTORCHConfig_ValidatePollingIntervalTooHigh(t *testing.T) {
-	// Test polling interval above maximum (>60)
+func TestTORCHConfig_ValidateLargePollingInterval(t *testing.T) {
+	// Arbitrarily large polling intervals are now allowed
 	config := models.TORCHConfig{
-		BaseURL:                   "http://localhost:8080",
-		Username:                  "user",
-		Password:                  "pass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    61, // Invalid: > 60
-		MaxPollingIntervalSeconds: 61,
+		BaseURL:            "http://localhost:8080",
+		Username:           "user",
+		Password:           "pass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    5 * time.Minute,
+		MaxPollingInterval: 5 * time.Minute,
 	}
 
 	err := config.Validate()
-	assert.Error(t, err, "Polling interval > 60 should fail validation")
-	assert.Contains(t, err.Error(), "polling_interval_seconds must be 1-60")
+	assert.NoError(t, err, "Large polling interval should be valid")
 }
 
 func TestTORCHConfig_ValidateEdgeCases(t *testing.T) {
@@ -830,50 +830,50 @@ func TestTORCHConfig_ValidateEdgeCases(t *testing.T) {
 		{
 			name: "Polling interval exactly 1 - valid",
 			config: models.TORCHConfig{
-				BaseURL:                   "http://localhost:8080",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    1,
-				MaxPollingIntervalSeconds: 1,
+				BaseURL:            "http://localhost:8080",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 1 * time.Second,
 			},
 			wantErr: false,
 		},
 		{
 			name: "Polling interval exactly 60 - valid",
 			config: models.TORCHConfig{
-				BaseURL:                   "http://localhost:8080",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    60,
-				MaxPollingIntervalSeconds: 60,
+				BaseURL:            "http://localhost:8080",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    60 * time.Second,
+				MaxPollingInterval: 60 * time.Second,
 			},
 			wantErr: false,
 		},
 		{
 			name: "Max polling equals min polling - valid",
 			config: models.TORCHConfig{
-				BaseURL:                   "http://localhost:8080",
-				ExtractionTimeoutMinutes:  1,
-				PollingIntervalSeconds:    10,
-				MaxPollingIntervalSeconds: 10,
+				BaseURL:            "http://localhost:8080",
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    10 * time.Second,
+				MaxPollingInterval: 10 * time.Second,
 			},
 			wantErr: false,
 		},
 		{
 			name: "HTTPS URL - valid",
 			config: models.TORCHConfig{
-				BaseURL:                   "https://torch.example.com",
-				ExtractionTimeoutMinutes:  30,
-				PollingIntervalSeconds:    5,
-				MaxPollingIntervalSeconds: 30,
+				BaseURL:            "https://torch.example.com",
+				ExtractionTimeout:  30 * time.Minute,
+				PollingInterval:    5 * time.Second,
+				MaxPollingInterval: 30 * time.Second,
 			},
 			wantErr: false,
 		},
 		{
 			name: "FTP URL - invalid scheme",
 			config: models.TORCHConfig{
-				BaseURL:                   "ftp://localhost",
-				ExtractionTimeoutMinutes:  30,
-				PollingIntervalSeconds:    5,
-				MaxPollingIntervalSeconds: 30,
+				BaseURL:            "ftp://localhost",
+				ExtractionTimeout:  30 * time.Minute,
+				PollingInterval:    5 * time.Second,
+				MaxPollingInterval: 30 * time.Second,
 			},
 			wantErr: true,
 			errMsg:  "must use http or https scheme",

--- a/tests/unit/config_validation_test.go
+++ b/tests/unit/config_validation_test.go
@@ -2,6 +2,7 @@ package unit
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -192,12 +193,12 @@ func TestProjectConfig_Validate(t *testing.T) {
 			config: models.ProjectConfig{
 				Services: models.ServiceConfig{
 					TORCH: models.TORCHConfig{
-						BaseURL:                   "http://localhost:8080",
-						Username:                  "testuser",
-						Password:                  "testpass",
-						ExtractionTimeoutMinutes:  30,
-						PollingIntervalSeconds:    5,
-						MaxPollingIntervalSeconds: 30,
+						BaseURL:            "http://localhost:8080",
+						Username:           "testuser",
+						Password:           "testpass",
+						ExtractionTimeout:  30 * time.Minute,
+						PollingInterval:    5 * time.Second,
+						MaxPollingInterval: 30 * time.Second,
 					},
 				},
 				Pipeline: models.PipelineConfig{

--- a/tests/unit/lib/duration_test.go
+++ b/tests/unit/lib/duration_test.go
@@ -1,0 +1,79 @@
+package lib_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+func TestParseDuration_ISO8601(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"PT30M", 30 * time.Minute},
+		{"PT5S", 5 * time.Second},
+		{"PT30S", 30 * time.Second},
+		{"PT10S", 10 * time.Second},
+		{"PT1H", 1 * time.Hour},
+		{"PT72H", 72 * time.Hour},
+		{"PT1H30M", 90 * time.Minute},
+		{"PT1H30M15S", time.Hour + 30*time.Minute + 15*time.Second},
+		{"P1D", 24 * time.Hour},
+		{"P3D", 72 * time.Hour},
+		{"P1DT12H", 36 * time.Hour},
+		{"P1DT2H30M", 26*time.Hour + 30*time.Minute},
+		{"PT0S", 0},
+		{"PT1.5S", 1500 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			d, err := lib.ParseDuration(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, d)
+		})
+	}
+}
+
+func TestParseDuration_GoFormat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"30m", 30 * time.Minute},
+		{"5s", 5 * time.Second},
+		{"1h", 1 * time.Hour},
+		{"1h30m", 90 * time.Minute},
+		{"500ms", 500 * time.Millisecond},
+		{"1m30s", 90 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			d, err := lib.ParseDuration(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, d)
+		})
+	}
+}
+
+func TestParseDuration_Empty(t *testing.T) {
+	d, err := lib.ParseDuration("")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), d)
+}
+
+func TestParseDuration_Invalid(t *testing.T) {
+	invalid := []string{"abc", "30", "PT", "P", "PTXM"}
+	for _, s := range invalid {
+		t.Run(s, func(t *testing.T) {
+			_, err := lib.ParseDuration(s)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -67,12 +67,12 @@ func TestTORCHClient_SubmitExtraction_Success(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  30,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  30 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -167,12 +167,12 @@ func TestTORCHClient_PollExtractionStatus_ImmediateSuccess(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -224,12 +224,12 @@ func TestTORCHClient_PollExtractionStatus_HTTP102Processing(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -288,12 +288,12 @@ func TestTORCHClient_PollExtractionStatus_WithOperationOutcomeDiagnostics(t *tes
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -351,12 +351,12 @@ func TestTORCHClient_PollExtractionStatus_DiagnosticsNotRepeated(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -394,12 +394,12 @@ func TestTORCHClient_PollExtractionStatus_EmptyOutput(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -422,12 +422,12 @@ func TestTORCHClient_PollExtractionStatus_Timeout(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  0, // Immediate timeout (converted to milliseconds)
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  0 * time.Minute, // Immediate timeout (converted to milliseconds)
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -458,12 +458,12 @@ func TestTORCHClient_PollExtractionStatus_ServerError(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  5,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 30,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  5 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 30 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -661,12 +661,12 @@ func TestTORCHClient_PollExtractionStatus_ExponentialBackoff(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,  // Start at 1 second
-		MaxPollingIntervalSeconds: 10, // Cap at 10 seconds
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,  // Start at 1 second
+		MaxPollingInterval: 10 * time.Second, // Cap at 10 seconds
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -853,12 +853,12 @@ func TestTORCHClient_ParseExtractionResult_FHIRFormat(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -891,12 +891,12 @@ func TestTORCHClient_ParseExtractionResult_SimpleFormat(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -918,12 +918,12 @@ func TestTORCHClient_ParseExtractionResult_InvalidJSON(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -1030,11 +1030,11 @@ func TestTORCHClient_WaitForFileAvailability_ImmediateSuccess(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                  server.URL,
-		Username:                 "testuser",
-		Password:                 "testpass",
-		FileReadyRetries:         1,
-		FileReadyIntervalSeconds: 1,
+		BaseURL:           server.URL,
+		Username:          "testuser",
+		Password:          "testpass",
+		FileReadyRetries:  1,
+		FileReadyInterval: 1 * time.Second,
 	}
 
 	tempDir := t.TempDir()
@@ -1080,11 +1080,11 @@ func TestTORCHClient_WaitForFileAvailability_RetryThenSuccess(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                  server.URL,
-		Username:                 "testuser",
-		Password:                 "testpass",
-		FileReadyRetries:         5,
-		FileReadyIntervalSeconds: 1,
+		BaseURL:           server.URL,
+		Username:          "testuser",
+		Password:          "testpass",
+		FileReadyRetries:  5,
+		FileReadyInterval: 1 * time.Second,
 	}
 
 	tempDir := t.TempDir()
@@ -1112,11 +1112,11 @@ func TestTORCHClient_WaitForFileAvailability_Timeout(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                  server.URL,
-		Username:                 "testuser",
-		Password:                 "testpass",
-		FileReadyRetries:         2,
-		FileReadyIntervalSeconds: 1,
+		BaseURL:           server.URL,
+		Username:          "testuser",
+		Password:          "testpass",
+		FileReadyRetries:  2,
+		FileReadyInterval: 1 * time.Second,
 	}
 
 	tempDir := t.TempDir()
@@ -1154,11 +1154,11 @@ func TestTORCHClient_WaitForFileAvailability_RangeFallback(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                  server.URL,
-		Username:                 "testuser",
-		Password:                 "testpass",
-		FileReadyRetries:         1,
-		FileReadyIntervalSeconds: 1,
+		BaseURL:           server.URL,
+		Username:          "testuser",
+		Password:          "testpass",
+		FileReadyRetries:  1,
+		FileReadyInterval: 1 * time.Second,
 	}
 
 	tempDir := t.TempDir()
@@ -1401,12 +1401,12 @@ func TestTORCHClient_PollExtractionStatus_HttpDoError(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(1*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  0, // Immediate timeout so the test completes quickly
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 1,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  0, // Immediate timeout so the test completes quickly
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 1 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -1441,12 +1441,12 @@ func TestTORCHClient_PollExtractionStatus_HttpDoErrorThenRecovers(t *testing.T) 
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(2*time.Second, models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 2,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)

--- a/tests/unit/torch_poller_test.go
+++ b/tests/unit/torch_poller_test.go
@@ -15,8 +15,17 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
+func newTestTORCHConfig(timeout, pollInterval, maxPollInterval time.Duration) models.TORCHConfig {
+	return models.TORCHConfig{
+		BaseURL:            "http://localhost:8080",
+		ExtractionTimeout:  timeout,
+		PollingInterval:    pollInterval,
+		MaxPollingInterval: maxPollInterval,
+	}
+}
+
 func TestNewPollConfig(t *testing.T) {
-	config := services.NewPollConfig(5, 2, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(5*time.Minute, 2*time.Second, 30*time.Second))
 
 	assert.NotNil(t, config)
 	assert.Equal(t, 5*time.Minute, config.Timeout)
@@ -27,7 +36,7 @@ func TestNewPollConfig(t *testing.T) {
 }
 
 func TestPollConfig_CheckTimeout_NotExceeded(t *testing.T) {
-	config := services.NewPollConfig(10, 1, 30) // 10 minute timeout
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 1*time.Second, 30*time.Second))
 	config.StartTime = time.Now()
 
 	// Should not timeout immediately
@@ -35,7 +44,7 @@ func TestPollConfig_CheckTimeout_NotExceeded(t *testing.T) {
 }
 
 func TestPollConfig_CheckTimeout_Exceeded(t *testing.T) {
-	config := services.NewPollConfig(1, 1, 30) // 1 minute timeout
+	config := services.NewPollConfig(newTestTORCHConfig(1*time.Minute, 1*time.Second, 30*time.Second))
 	config.StartTime = time.Now().Add(-2 * time.Minute)
 
 	// Should timeout
@@ -43,7 +52,7 @@ func TestPollConfig_CheckTimeout_Exceeded(t *testing.T) {
 }
 
 func TestPollConfig_GetElapsedTime(t *testing.T) {
-	config := services.NewPollConfig(10, 1, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 1*time.Second, 30*time.Second))
 	config.StartTime = time.Now().Add(-5 * time.Second)
 
 	elapsed := config.GetElapsedTime()
@@ -52,7 +61,7 @@ func TestPollConfig_GetElapsedTime(t *testing.T) {
 }
 
 func TestPollConfig_IncrementPollCount(t *testing.T) {
-	config := services.NewPollConfig(10, 1, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 1*time.Second, 30*time.Second))
 	assert.Equal(t, 0, config.PollCount)
 
 	config.IncrementPollCount()
@@ -63,7 +72,7 @@ func TestPollConfig_IncrementPollCount(t *testing.T) {
 }
 
 func TestPollConfig_UpdateInterval_BelowMax(t *testing.T) {
-	config := services.NewPollConfig(10, 2, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 2*time.Second, 30*time.Second))
 	initialInterval := config.PollInterval
 
 	config.UpdateInterval()
@@ -73,7 +82,7 @@ func TestPollConfig_UpdateInterval_BelowMax(t *testing.T) {
 }
 
 func TestPollConfig_UpdateInterval_AtMax(t *testing.T) {
-	config := services.NewPollConfig(10, 30, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 30*time.Second, 30*time.Second))
 	config.PollInterval = 30 * time.Second
 
 	config.UpdateInterval()
@@ -83,7 +92,7 @@ func TestPollConfig_UpdateInterval_AtMax(t *testing.T) {
 }
 
 func TestPollConfig_UpdateInterval_ReachesMax(t *testing.T) {
-	config := services.NewPollConfig(10, 20, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 20*time.Second, 30*time.Second))
 	config.PollInterval = 20 * time.Second
 
 	config.UpdateInterval()
@@ -111,7 +120,7 @@ func TestCalculateNextPollInterval(t *testing.T) {
 }
 
 func TestPollConfig_StateProgression(t *testing.T) {
-	config := services.NewPollConfig(5, 1, 10)
+	config := services.NewPollConfig(newTestTORCHConfig(5*time.Minute, 1*time.Second, 10*time.Second))
 	startTime := time.Now()
 	config.StartTime = startTime
 
@@ -166,7 +175,7 @@ func TestHandlePollResponse_Error(t *testing.T) {
 }
 
 func TestPollConfig_MultipleTimeouts(t *testing.T) {
-	config := services.NewPollConfig(1, 1, 30)
+	config := services.NewPollConfig(newTestTORCHConfig(1*time.Minute, 1*time.Second, 30*time.Second))
 	config.StartTime = time.Now().Add(-10 * time.Minute)
 
 	// Should timeout regardless of how many times we check
@@ -196,12 +205,12 @@ func TestCreatePollRequest_SuccessByVerifyingPollExecution(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
 	torchConfig := models.TORCHConfig{
-		BaseURL:                   server.URL,
-		Username:                  "testuser",
-		Password:                  "testpass",
-		ExtractionTimeoutMinutes:  1,
-		PollingIntervalSeconds:    1,
-		MaxPollingIntervalSeconds: 5,
+		BaseURL:            server.URL,
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
@@ -228,14 +237,14 @@ func TestHandlePollResponse_202AcceptedWithBody(t *testing.T) {
 }
 
 func TestPollConfig_LargeTimeoutValues(t *testing.T) {
-	config := services.NewPollConfig(1440, 60, 300) // 24 hours, 1 min interval, 5 min max
+	config := services.NewPollConfig(newTestTORCHConfig(24*time.Hour, 60*time.Second, 5*time.Minute))
 	assert.Equal(t, 24*time.Hour, config.Timeout)
 	assert.Equal(t, 60*time.Second, config.PollInterval)
 	assert.Equal(t, 5*time.Minute, config.MaxPollInterval)
 }
 
 func TestPollConfig_UpdateInterval_EdgeCase(t *testing.T) {
-	config := services.NewPollConfig(10, 1, 1)
+	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 1*time.Second, 1*time.Second))
 	config.PollInterval = 1 * time.Second
 	config.MaxPollInterval = 1 * time.Second
 


### PR DESCRIPTION
## Summary

- Replace `int`-based TORCH config time fields with `time.Duration` for human-readable config values (`"30m"`, `"5s"` instead of `4320`, `5`)
- Align TORCH config with the pattern already used by `FlatteningConfig.Timeout` and `S3Config.Timeout`
- Simplify `NewPollConfig` to accept `TORCHConfig` directly, eliminating the int→Duration conversion layer
- Remove upper bound on `polling_interval` (was capped at 60s), now only requires `>= 1s`
- Add `mapstructure` tags to all `TORCHConfig` fields for consistency with newer config structs
- Document previously undocumented `file_ready_retries` and `file_ready_interval` fields in example config and reference docs

**Breaking config change**: YAML config now uses Go duration strings instead of bare integers with unit-suffixed field names.

Closes #223