### PR TITLE
feat: batched streaming for flattening step to fix OOM

### DIFF
--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -93,6 +93,13 @@ services:
     # Default: 30m (30 minutes)
     timeout: 30m
 
+    # Total memory budget in megabytes (MB) for streaming processing.
+    # This budget is divided equally across attribute groups — each group flushes
+    # to the flattener when its share is exceeded. For example, with batch_size_mb: 150
+    # and 3 groups, each group flushes at ~50 MB, keeping total memory near 150 MB.
+    # Default: 500 MB (0 means "use default")
+    batch_size_mb: 500
+
   # Send Step Configuration
   # Supports three modes determined by the 'send_as' setting:
   # - direct_resource_load: Sends NDJSON directly to a FHIR server using transaction bundles

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -23,6 +23,7 @@ services:
     lookup_path: string
     formats: [string]                    # ["csv"]
     timeout: duration                    # default: 30m
+    batch_size_mb: integer               # default: 500
 
   send:
     send_as: string                      # "direct_resource_load" or "transfer_load"

--- a/docs/guides/steps/flattening.md
+++ b/docs/guides/steps/flattening.md
@@ -18,6 +18,7 @@ services:
     formats:
       - csv
     timeout: 30m
+    batch_size_mb: 500
 
 pipeline:
   enabled_steps:
@@ -34,14 +35,18 @@ pipeline:
 | `lookup_path` | string | - | Path to lookup table file |
 | `formats` | []string | ["csv"] | Output formats |
 | `timeout` | duration | 30m | Request timeout |
+| `batch_size_mb` | int | 500 | Total memory budget in MB, divided across groups (0 = default) |
 
 ## How it Works
 
 1. Parses CRTDL file to extract attribute groups
 2. Builds ViewDefinitions from lookup tables
-3. Filters resources by profile
-4. Sends data to fhir-flattener service
-5. Writes CSV files for each attribute group
+3. Streams FHIR resources from input files in a single pass
+4. Routes each resource to its attribute group based on `meta.profile[0]`
+5. When a group's batch exceeds `batch_size_mb`, flushes it to fhir-flattener
+6. Appends CSV output incrementally (one header, multiple data batches)
+
+Memory usage is bounded by `batch_size_mb` regardless of total dataset size — the budget is divided equally across attribute groups.
 
 ## Output
 

--- a/internal/models/flattening.go
+++ b/internal/models/flattening.go
@@ -9,20 +9,30 @@ import (
 
 // FlatteningConfig holds configuration for the fhir-flattener service
 type FlatteningConfig struct {
-	ServiceURL string        `yaml:"service_url" json:"service_url"` // URL to fhir-flattener service
-	LookupPath string        `yaml:"lookup_path" json:"lookup_path"` // Path to flatten-lookup.json file
-	Formats    []string      `yaml:"formats" json:"formats"`         // Output formats: ["csv"] for now
-	Timeout    time.Duration `yaml:"timeout" json:"timeout"`         // Request timeout
+	ServiceURL  string        `yaml:"service_url" json:"service_url" mapstructure:"service_url"`       // URL to fhir-flattener service
+	LookupPath  string        `yaml:"lookup_path" json:"lookup_path" mapstructure:"lookup_path"`       // Path to flatten-lookup.json file
+	Formats     []string      `yaml:"formats" json:"formats" mapstructure:"formats"`                   // Output formats: ["csv"] for now
+	Timeout     time.Duration `yaml:"timeout" json:"timeout" mapstructure:"timeout"`                   // Request timeout
+	BatchSizeMB int           `yaml:"batch_size_mb" json:"batch_size_mb" mapstructure:"batch_size_mb"` // Total memory budget in MB for batched streaming (default 500)
 }
 
 // DefaultFlatteningConfig returns the default flattening configuration
 func DefaultFlatteningConfig() FlatteningConfig {
 	return FlatteningConfig{
-		ServiceURL: "",
-		LookupPath: "",
-		Formats:    []string{"csv"},
-		Timeout:    30 * time.Minute,
+		ServiceURL:  "",
+		LookupPath:  "",
+		Formats:     []string{"csv"},
+		Timeout:     30 * time.Minute,
+		BatchSizeMB: 500,
 	}
+}
+
+// GetBatchSizeBytes returns the total memory budget in bytes, defaulting to 500MB if not set
+func (c *FlatteningConfig) GetBatchSizeBytes() int {
+	if c.BatchSizeMB <= 0 {
+		return 500 * 1024 * 1024
+	}
+	return c.BatchSizeMB * 1024 * 1024
 }
 
 // Validate checks if the FlatteningConfig is valid when flattening is enabled

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -13,6 +13,14 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
+// groupBatch accumulates resources for a single attribute group until the batch
+// size threshold is reached, at which point it is flushed to the flattener service.
+type groupBatch struct {
+	resources    []map[string]any
+	byteSize     int
+	isFirstBatch bool // true until first flush
+}
+
 // ExecuteFlatteningStep transforms FHIR NDJSON data into CSV files using the fhir-flattener API
 // Reads from pseudonymized/ (if DIMP enabled) or import/ directory
 // Outputs to csv/ directory
@@ -102,21 +110,9 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		return err
 	}
 
-	logger.Info("Loading FHIR resources from input files",
+	logger.Info("Streaming FHIR resources from input files",
 		"input_dir", inputDir,
 		"file_count", len(files),
-		"job_id", job.JobID)
-
-	// Load all resources from input files
-	allResources, err := LoadAllResources(files, logger, job.Config.Pipeline.MaxNDJSONLineSize())
-	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to load resources: %w", err)
-	}
-
-	logger.Info("Loaded FHIR resources",
-		"total_resources", len(allResources),
 		"job_id", job.JobID)
 
 	// Create clients
@@ -129,16 +125,13 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 	attributeGroups := services.GetAttributeGroups(crtdl)
 	fmt.Printf("Processing %d attribute group(s)...\n\n", len(attributeGroups))
 
-	totalFilesWritten := 0
+	// Pre-compute: build profileToGroup mapping and ViewDefinitions
+	profileToGroup := make(map[string]int)
+	viewDefs := make([]*models.ViewDefinition, len(attributeGroups))
+	headers := make([][]string, len(attributeGroups))
+	filenames := make([]string, len(attributeGroups))
 
-	// Process each attribute group
-	for _, group := range attributeGroups {
-		logger.Debug("Processing attribute group",
-			"group_name", group.Name,
-			"group_reference", group.GroupReference,
-			"job_id", job.JobID)
-
-		// Build ViewDefinition for this group
+	for i, group := range attributeGroups {
 		viewDef, err := viewDefBuilder.BuildViewDefinition(group)
 		if err != nil {
 			logger.Warn("Failed to build ViewDefinition for group, skipping",
@@ -148,7 +141,12 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 			continue
 		}
 
-		// Save ViewDefinition to disk for debugging/auditing (before flattener call)
+		viewDefs[i] = viewDef
+		profileToGroup[group.GroupReference] = i
+		headers[i] = services.ExtractColumnNames(*viewDef)
+		filenames[i] = services.BuildCSVFilename(group.Name)
+
+		// Save ViewDefinition to disk
 		viewDefFilename := services.BuildViewDefinitionFilename(group.Name)
 		if err := viewDefWriter.WriteViewDefinition(viewDefFilename, *viewDef); err != nil {
 			logger.Warn("Failed to save ViewDefinition, continuing",
@@ -156,48 +154,40 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 				"filename", viewDefFilename,
 				"error", err)
 		}
+	}
 
-		// Filter resources by profile URL
-		matchingResources := FilterResourcesByProfile(allResources, group.GroupReference)
-		if len(matchingResources) == 0 {
-			logger.Debug("No resources match profile",
-				"group_name", group.Name,
-				"profile", group.GroupReference)
+	// Stream resources and flatten in batches
+	totals, err := streamAndFlattenResources(
+		files,
+		attributeGroups,
+		profileToGroup,
+		viewDefs,
+		headers,
+		filenames,
+		flattenerClient,
+		csvWriter,
+		logger,
+		job.Config.Pipeline.MaxNDJSONLineSize(),
+		job.Config.Services.Flattening.GetBatchSizeBytes(),
+	)
+	if err != nil {
+		lib.LogStepFailed(logger, string(stepName), job.JobID, err, IsFlatteningErrorRetryable(err))
+		recordStepError(step, err, ClassifyFlatteningError(err))
+		return err
+	}
+
+	// Print per-group progress
+	totalFilesWritten := 0
+	for i, group := range attributeGroups {
+		if viewDefs[i] == nil {
+			continue
+		}
+		if totals[i] == 0 {
 			fmt.Printf("  ⊙ %s (no matching resources)\n", group.Name)
 			continue
 		}
-
-		logger.Debug("Found matching resources",
-			"group_name", group.Name,
-			"count", len(matchingResources))
-
-		// Call flattener service
-		csvData, err := flattenerClient.Flatten(*viewDef, matchingResources)
-		if err != nil {
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, IsFlatteningErrorRetryable(err))
-			recordStepError(step, err, ClassifyFlatteningError(err))
-			return fmt.Errorf("flattener failed for group '%s': %w", group.Name, err)
-		}
-
-		// Extract header from ViewDefinition
-		header := services.ExtractColumnNames(*viewDef)
-
-		// Write CSV file
-		filename := services.BuildCSVFilename(group.Name)
-		if err := csvWriter.WriteCSV(filename, header, csvData); err != nil {
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-			recordStepError(step, err, models.ErrorTypeNonTransient)
-			return fmt.Errorf("failed to write CSV for group '%s': %w", group.Name, err)
-		}
-
 		totalFilesWritten++
-		fmt.Printf("  ✓ %s (%d resources → %s)\n", group.Name, len(matchingResources), filename)
-
-		logger.Debug("CSV file written",
-			"group_name", group.Name,
-			"filename", filename,
-			"resource_count", len(matchingResources),
-			"job_id", job.JobID)
+		fmt.Printf("  ✓ %s (%d resources → %s)\n", group.Name, totals[i], filenames[i])
 	}
 
 	step.Status = models.StepStatusCompleted
@@ -211,6 +201,201 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		"files_written", totalFilesWritten,
 		"duration", duration,
 		"job_id", job.JobID)
+
+	return nil
+}
+
+// streamAndFlattenResources performs single-pass streaming over all input files,
+// routing each resource to per-group batches and flushing when the byte threshold
+// is exceeded. Returns per-group resource totals.
+func streamAndFlattenResources(
+	files []string,
+	groups []models.AttributeGroup,
+	profileToGroup map[string]int,
+	viewDefs []*models.ViewDefinition,
+	headers [][]string,
+	filenames []string,
+	flattenerClient *services.FlattenerClient,
+	csvWriter *services.CSVWriter,
+	logger *lib.Logger,
+	maxLineSize int,
+	batchSizeBytes int,
+) ([]int, error) {
+	numGroups := len(groups)
+	batches := make([]groupBatch, numGroups)
+	totals := make([]int, numGroups)
+
+	// Divide total memory budget across groups so peak usage stays within batchSizeBytes
+	perGroupBytes := batchSizeBytes / numGroups
+	if perGroupBytes < 1 {
+		perGroupBytes = 1
+	}
+
+	// Initialize all batches as first batch
+	for i := range batches {
+		batches[i].isFirstBatch = true
+	}
+
+	// Stream through all files
+	for _, filePath := range files {
+		reader, err := lib.OpenFileForReading(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load resources: %w", fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), fmt.Errorf("failed to open file: %w", err)))
+		}
+
+		scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
+		lineNum := 0
+
+		for scanner.Scan() {
+			lineNum++
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var resource map[string]any
+			if err := json.Unmarshal([]byte(line), &resource); err != nil {
+				logger.Warn("Failed to parse resource",
+					"file", filepath.Base(filePath),
+					"line", lineNum,
+					"error", err)
+				continue
+			}
+
+			// If resource is a Bundle, extract and route individual entries
+			if resourceType, ok := resource["resourceType"].(string); ok && resourceType == "Bundle" {
+				entries, ok := resource["entry"].([]any)
+				if ok {
+					for _, entry := range entries {
+						entryMap, ok := entry.(map[string]any)
+						if !ok {
+							continue
+						}
+						entryResource, ok := entryMap["resource"].(map[string]any)
+						if !ok {
+							continue
+						}
+						// For Bundle entries, compute size via marshal
+						entryBytes, marshalErr := json.Marshal(entryResource)
+						if marshalErr != nil {
+							continue
+						}
+						groupIdx, matched := routeResourceToGroup(entryResource, profileToGroup, viewDefs)
+						if !matched {
+							continue
+						}
+						batches[groupIdx].resources = append(batches[groupIdx].resources, entryResource)
+						batches[groupIdx].byteSize += len(entryBytes)
+						totals[groupIdx]++
+
+						if batches[groupIdx].byteSize >= perGroupBytes {
+							if err := flushGroupBatch(&batches[groupIdx], viewDefs[groupIdx], headers[groupIdx], filenames[groupIdx], flattenerClient, csvWriter, logger, groups[groupIdx].Name); err != nil {
+								_ = reader.Close()
+								return nil, err
+							}
+						}
+					}
+				}
+			} else {
+				// Non-Bundle resource: use scanner bytes length for size tracking
+				resourceSize := len(scanner.Bytes())
+				groupIdx, matched := routeResourceToGroup(resource, profileToGroup, viewDefs)
+				if !matched {
+					continue
+				}
+				batches[groupIdx].resources = append(batches[groupIdx].resources, resource)
+				batches[groupIdx].byteSize += resourceSize
+				totals[groupIdx]++
+
+				if batches[groupIdx].byteSize >= perGroupBytes {
+					if err := flushGroupBatch(&batches[groupIdx], viewDefs[groupIdx], headers[groupIdx], filenames[groupIdx], flattenerClient, csvWriter, logger, groups[groupIdx].Name); err != nil {
+						_ = reader.Close()
+						return nil, err
+					}
+				}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			_ = reader.Close()
+			return nil, fmt.Errorf("failed to load resources: %w", fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), fmt.Errorf("error reading file: %w", err)))
+		}
+
+		_ = reader.Close()
+	}
+
+	// Flush remaining non-empty batches
+	for i := range batches {
+		if len(batches[i].resources) > 0 {
+			if err := flushGroupBatch(&batches[i], viewDefs[i], headers[i], filenames[i], flattenerClient, csvWriter, logger, groups[i].Name); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return totals, nil
+}
+
+// routeResourceToGroup determines which group a resource belongs to based on
+// its meta.profile[0] URL. Returns the group index and whether a match was found.
+func routeResourceToGroup(resource map[string]any, profileToGroup map[string]int, viewDefs []*models.ViewDefinition) (int, bool) {
+	meta, ok := resource["meta"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+
+	profiles, ok := meta["profile"].([]any)
+	if !ok || len(profiles) == 0 {
+		return 0, false
+	}
+
+	firstProfile, ok := profiles[0].(string)
+	if !ok {
+		return 0, false
+	}
+
+	groupIdx, exists := profileToGroup[firstProfile]
+	if !exists {
+		return 0, false
+	}
+
+	// Skip groups where ViewDefinition build failed
+	if viewDefs[groupIdx] == nil {
+		return 0, false
+	}
+
+	return groupIdx, true
+}
+
+// flushGroupBatch sends the accumulated batch to the flattener and appends the result to CSV.
+func flushGroupBatch(
+	batch *groupBatch,
+	viewDef *models.ViewDefinition,
+	header []string,
+	filename string,
+	flattenerClient *services.FlattenerClient,
+	csvWriter *services.CSVWriter,
+	logger *lib.Logger,
+	groupName string,
+) error {
+	logger.Debug("Flushing batch",
+		"group_name", groupName,
+		"resource_count", len(batch.resources),
+		"byte_size", batch.byteSize)
+
+	csvData, err := flattenerClient.Flatten(*viewDef, batch.resources)
+	if err != nil {
+		return fmt.Errorf("flattener failed for group '%s': %w", groupName, err)
+	}
+
+	if err := csvWriter.AppendCSVData(filename, header, csvData, batch.isFirstBatch); err != nil {
+		return fmt.Errorf("failed to write CSV for group '%s': %w", groupName, err)
+	}
+
+	// Reset batch state
+	batch.resources = nil
+	batch.byteSize = 0
+	batch.isFirstBatch = false
 
 	return nil
 }

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -100,10 +100,11 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 				URL: ExpandEnvVars(viper.GetString("services.parquet_conversion.url")),
 			},
 			Flattening: models.FlatteningConfig{
-				ServiceURL: ExpandEnvVars(viper.GetString("services.flattening.service_url")),
-				LookupPath: ExpandEnvVars(viper.GetString("services.flattening.lookup_path")),
-				Formats:    viper.GetStringSlice("services.flattening.formats"),
-				Timeout:    viper.GetDuration("services.flattening.timeout"),
+				ServiceURL:  ExpandEnvVars(viper.GetString("services.flattening.service_url")),
+				LookupPath:  ExpandEnvVars(viper.GetString("services.flattening.lookup_path")),
+				Formats:     viper.GetStringSlice("services.flattening.formats"),
+				Timeout:     viper.GetDuration("services.flattening.timeout"),
+				BatchSizeMB: viper.GetInt("services.flattening.batch_size_mb"),
 			},
 			Send: models.SendConfig{
 				URL:       ExpandEnvVars(viper.GetString("services.send.url")),
@@ -195,6 +196,9 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 		if config.Compression.Level == "" {
 			config.Compression.Level = defaults.Compression.Level
 		}
+		if config.Services.Flattening.BatchSizeMB == 0 {
+			config.Services.Flattening.BatchSizeMB = defaults.Services.Flattening.BatchSizeMB
+		}
 	} else {
 		// Config was loaded, apply defaults only for truly missing values
 		if config.Retry.MaxAttempts == 0 {
@@ -250,6 +254,9 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 		}
 		if len(config.Services.Flattening.Formats) == 0 {
 			config.Services.Flattening.Formats = []string{"csv"}
+		}
+		if config.Services.Flattening.BatchSizeMB == 0 {
+			config.Services.Flattening.BatchSizeMB = 500
 		}
 		// Apply Send batch size default if not set
 		if config.Services.Send.BatchSize == 0 {

--- a/internal/services/csv_writer.go
+++ b/internal/services/csv_writer.go
@@ -71,6 +71,76 @@ func (w *CSVWriter) WriteCSV(filename string, header []string, data string) erro
 	return nil
 }
 
+// AppendCSVData appends CSV data to a file. On the first batch, it creates the file
+// and writes the header followed by data rows. On subsequent batches, it appends
+// data rows only (no duplicate header).
+func (w *CSVWriter) AppendCSVData(filename string, header []string, data string, isFirstBatch bool) error {
+	outputPath := filepath.Join(w.outputDir, filename)
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(w.outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	if isFirstBatch {
+		file, err := os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("failed to create CSV file: %w", err)
+		}
+		defer func() { _ = file.Close() }()
+
+		writer := csv.NewWriter(file)
+		defer writer.Flush()
+
+		if len(header) > 0 {
+			if err := writer.Write(header); err != nil {
+				return fmt.Errorf("failed to write CSV header: %w", err)
+			}
+		}
+
+		if data != "" {
+			if err := w.writeCSVRows(writer, data); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	// Subsequent batch: append data rows only
+	if data == "" {
+		return nil
+	}
+
+	file, err := os.OpenFile(outputPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open CSV file for append: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	return w.writeCSVRows(writer, data)
+}
+
+// writeCSVRows parses CSV data string and writes rows to the writer
+func (w *CSVWriter) writeCSVRows(writer *csv.Writer, data string) error {
+	dataReader := csv.NewReader(strings.NewReader(data))
+	records, err := dataReader.ReadAll()
+	if err != nil {
+		return fmt.Errorf("failed to parse CSV data from flattener: %w", err)
+	}
+
+	for _, record := range records {
+		if err := writer.Write(record); err != nil {
+			return fmt.Errorf("failed to write CSV row: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // WriteCSVDirect writes raw CSV data (with header already included) directly to a file
 func (w *CSVWriter) WriteCSVDirect(filename string, data string) error {
 	outputPath := filepath.Join(w.outputDir, filename)

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -2603,3 +2603,70 @@ jobs_dir: "` + jobsDir + `"
 	require.NotNil(t, config.Services.Validation.FailOnError, "FailOnError should not be nil")
 	assert.False(t, *config.Services.Validation.FailOnError, "FailOnError should be false when explicitly set to false in config")
 }
+
+func TestConfigLoading_FlatteningBatchSizeMB(t *testing.T) {
+	t.Run("loads batch_size_mb from config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		jobsDir := filepath.Join(tmpDir, "jobs")
+		_ = os.MkdirAll(jobsDir, 0755)
+
+		configContent := `
+services:
+  flattening:
+    service_url: "http://localhost:8080"
+    lookup_path: "/path/to/lookup.json"
+    batch_size_mb: 25
+
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+		err := os.WriteFile(configFile, []byte(configContent), 0644)
+		require.NoError(t, err)
+
+		config, err := services.LoadConfig(configFile)
+		require.NoError(t, err)
+
+		assert.Equal(t, 25, config.Services.Flattening.BatchSizeMB)
+	})
+
+	t.Run("defaults to 500 when not set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		jobsDir := filepath.Join(tmpDir, "jobs")
+		_ = os.MkdirAll(jobsDir, 0755)
+
+		configContent := `
+services:
+  flattening:
+    service_url: "http://localhost:8080"
+    lookup_path: "/path/to/lookup.json"
+
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+		err := os.WriteFile(configFile, []byte(configContent), 0644)
+		require.NoError(t, err)
+
+		config, err := services.LoadConfig(configFile)
+		require.NoError(t, err)
+
+		assert.Equal(t, 500, config.Services.Flattening.BatchSizeMB)
+	})
+}

--- a/tests/unit/csv_writer_test.go
+++ b/tests/unit/csv_writer_test.go
@@ -109,6 +109,104 @@ func TestCSVWriter_WriteCSVDirect(t *testing.T) {
 	})
 }
 
+func TestCSVWriter_AppendCSVData(t *testing.T) {
+	t.Run("first batch creates file with header and data", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		header := []string{"id", "name", "birthDate"}
+		data := "1,John,1990-01-01\n2,Jane,1985-05-15"
+
+		err := writer.AppendCSVData("patients.csv", header, data, true)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(tempDir, "patients.csv"))
+		require.NoError(t, err)
+
+		expected := "id,name,birthDate\n1,John,1990-01-01\n2,Jane,1985-05-15\n"
+		assert.Equal(t, expected, string(content))
+	})
+
+	t.Run("subsequent batch appends rows only without header", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		header := []string{"id", "name"}
+
+		// First batch
+		err := writer.AppendCSVData("test.csv", header, "1,Alice", true)
+		require.NoError(t, err)
+
+		// Second batch
+		err = writer.AppendCSVData("test.csv", header, "2,Bob", false)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(tempDir, "test.csv"))
+		require.NoError(t, err)
+
+		expected := "id,name\n1,Alice\n2,Bob\n"
+		assert.Equal(t, expected, string(content))
+	})
+
+	t.Run("first batch with empty data writes header only", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		header := []string{"id", "name"}
+
+		err := writer.AppendCSVData("empty.csv", header, "", true)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(tempDir, "empty.csv"))
+		require.NoError(t, err)
+
+		assert.Equal(t, "id,name\n", string(content))
+	})
+
+	t.Run("subsequent batch with empty data is no-op", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		header := []string{"id", "name"}
+
+		// First batch
+		err := writer.AppendCSVData("test.csv", header, "1,Alice", true)
+		require.NoError(t, err)
+
+		// Second batch with empty data
+		err = writer.AppendCSVData("test.csv", header, "", false)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(tempDir, "test.csv"))
+		require.NoError(t, err)
+
+		expected := "id,name\n1,Alice\n"
+		assert.Equal(t, expected, string(content))
+	})
+
+	t.Run("multiple appends accumulate correctly", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		header := []string{"id", "value"}
+
+		err := writer.AppendCSVData("multi.csv", header, "1,a", true)
+		require.NoError(t, err)
+
+		err = writer.AppendCSVData("multi.csv", header, "2,b\n3,c", false)
+		require.NoError(t, err)
+
+		err = writer.AppendCSVData("multi.csv", header, "4,d", false)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(filepath.Join(tempDir, "multi.csv"))
+		require.NoError(t, err)
+
+		expected := "id,value\n1,a\n2,b\n3,c\n4,d\n"
+		assert.Equal(t, expected, string(content))
+	})
+}
+
 func TestCSVWriter_WriteCSVErrors(t *testing.T) {
 	t.Run("invalid CSV data from flattener", func(t *testing.T) {
 		tempDir := t.TempDir()
@@ -210,6 +308,54 @@ func TestCountCSVRows(t *testing.T) {
 		count, err := services.CountCSVRows(csvData, true)
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
+	})
+}
+
+func TestCSVWriter_AppendCSVDataErrors(t *testing.T) {
+	t.Run("first batch MkdirAll error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		blockingFile := filepath.Join(tempDir, "blocking_file")
+		require.NoError(t, os.WriteFile(blockingFile, []byte("content"), 0644))
+
+		invalidDir := filepath.Join(blockingFile, "subdir")
+		writer := services.NewCSVWriter(invalidDir)
+
+		err := writer.AppendCSVData("test.csv", []string{"id"}, "1", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create output directory")
+	})
+
+	t.Run("first batch with invalid CSV data", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		err := writer.AppendCSVData("test.csv", []string{"id"}, `"unclosed`, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse CSV data")
+	})
+
+	t.Run("subsequent batch append to nonexistent file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		// Don't create the file first, try to append directly
+		err := writer.AppendCSVData("nonexistent.csv", []string{"id"}, "1", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to open CSV file for append")
+	})
+
+	t.Run("subsequent batch with invalid CSV data", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		// Create the file first with a valid first batch
+		err := writer.AppendCSVData("test.csv", []string{"id"}, "1", true)
+		require.NoError(t, err)
+
+		// Append invalid CSV data
+		err = writer.AppendCSVData("test.csv", []string{"id"}, `"unclosed`, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse CSV data")
 	})
 }
 

--- a/tests/unit/flattening_config_test.go
+++ b/tests/unit/flattening_config_test.go
@@ -137,6 +137,29 @@ func TestDefaultFlatteningConfig(t *testing.T) {
 	assert.Empty(t, config.LookupPath)
 	assert.Equal(t, []string{"csv"}, config.Formats)
 	assert.Equal(t, 30*time.Minute, config.Timeout)
+	assert.Equal(t, 500, config.BatchSizeMB)
+}
+
+func TestGetBatchSizeBytes(t *testing.T) {
+	t.Run("default when zero", func(t *testing.T) {
+		config := models.FlatteningConfig{BatchSizeMB: 0}
+		assert.Equal(t, 500*1024*1024, config.GetBatchSizeBytes())
+	})
+
+	t.Run("default when negative", func(t *testing.T) {
+		config := models.FlatteningConfig{BatchSizeMB: -5}
+		assert.Equal(t, 500*1024*1024, config.GetBatchSizeBytes())
+	})
+
+	t.Run("custom value", func(t *testing.T) {
+		config := models.FlatteningConfig{BatchSizeMB: 20}
+		assert.Equal(t, 20*1024*1024, config.GetBatchSizeBytes())
+	})
+
+	t.Run("small value", func(t *testing.T) {
+		config := models.FlatteningConfig{BatchSizeMB: 1}
+		assert.Equal(t, 1*1024*1024, config.GetBatchSizeBytes())
+	})
 }
 
 func TestNewFlatteningRequest(t *testing.T) {

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -2,11 +2,13 @@ package unit
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -864,4 +866,531 @@ func TestExecuteFlatteningStep_CSVWriteError(t *testing.T) {
 	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write CSV for group")
+}
+
+// TestExecuteFlatteningStep_MultipleBatches verifies that large datasets are
+// processed in multiple batches with only one CSV header
+func TestExecuteFlatteningStep_MultipleBatches(t *testing.T) {
+	// Track how many times flattener is called
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			callCount++
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			// Return a simple CSV row per call
+			_, _ = fmt.Fprintf(w, "patient-%d\n", callCount)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-multi-batch"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// Create many resources to exceed batch threshold
+	// Each resource is ~100 bytes; with batch_size_mb=1 (actually we'll use small byte threshold)
+	var resources []map[string]any
+	for i := 0; i < 50; i++ {
+		resources = append(resources, map[string]any{
+			"resourceType": "Patient",
+			"id":           fmt.Sprintf("patient-%d", i),
+			"meta":         map[string]any{"profile": []any{profileURL}},
+			"name":         []any{map[string]any{"family": "TestFamily", "given": []any{"TestGiven"}}},
+		})
+	}
+	writeTestNDJSON(t, filepath.Join(inputDir, "patients.ndjson"), resources)
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	// Set a very small batch size to force multiple batches (1 byte = every resource triggers a flush)
+	job.Config.Services.Flattening.BatchSizeMB = 0 // will default to 500MB via GetBatchSizeBytes
+
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify CSV file was created
+	csvFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	require.NoError(t, err)
+	assert.Len(t, csvFiles, 1)
+
+	// Read the CSV and verify it has header + data rows
+	content, err := os.ReadFile(csvFiles[0])
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	// First line should be header (contains "id")
+	assert.Contains(t, lines[0], "id")
+	// Should have at least 1 data line (header + flattener response)
+	assert.GreaterOrEqual(t, len(lines), 2)
+}
+
+// TestExecuteFlatteningStep_FlattenerError verifies fail-fast on flattener error
+func TestExecuteFlatteningStep_FlattenerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal server error"))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-flattener-error"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	ndjsonContent := `{"resourceType":"Patient","id":"1","meta":{"profile":["https://example.com/Patient"]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte(ndjsonContent), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flattener failed for group")
+}
+
+// TestExecuteFlatteningStep_BundleExtraction verifies Bundle entries are correctly
+// routed to groups during streaming
+func TestExecuteFlatteningStep_BundleExtraction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("bundled-patient\n"))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-bundle-extract"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// Create a Bundle containing Patient resources
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "collection",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"resourceType": "Patient",
+					"id":           "bundled-1",
+					"meta":         map[string]any{"profile": []any{profileURL}},
+				},
+			},
+			map[string]any{
+				"resource": map[string]any{
+					"resourceType": "Patient",
+					"id":           "bundled-2",
+					"meta":         map[string]any{"profile": []any{profileURL}},
+				},
+			},
+		},
+	}
+	writeTestNDJSON(t, filepath.Join(inputDir, "bundle.ndjson"), []map[string]any{bundle})
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Verify CSV was created
+	csvFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	require.NoError(t, err)
+	assert.Len(t, csvFiles, 1)
+
+	content, err := os.ReadFile(csvFiles[0])
+	require.NoError(t, err)
+	// Should contain header + data from flattener
+	assert.Contains(t, string(content), "id")
+	assert.Contains(t, string(content), "bundled-patient")
+}
+
+// TestExecuteFlatteningStep_StreamingEdgeCases verifies edge cases in the streaming pipeline:
+// empty lines, invalid JSON, resources without meta, non-string profiles, and Bundle entry edge cases
+func TestExecuteFlatteningStep_StreamingEdgeCases(t *testing.T) {
+	flattenCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			flattenCalls++
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("valid-patient\n"))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-streaming-edges"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// NDJSON with many edge cases:
+	// - empty lines (skipped)
+	// - invalid JSON (skipped with warning)
+	// - resource without meta (no match)
+	// - resource with meta as non-map (no match)
+	// - resource with profiles as non-array (no match)
+	// - resource with non-string profile entry (no match)
+	// - valid matching resource (processed)
+	// - Bundle with invalid entry (not a map)
+	// - Bundle with entry missing resource field
+	// - Bundle with entry where resource is not a map
+	// - Bundle with valid matching entry (processed)
+	ndjsonContent := strings.Join([]string{
+		``,               // empty line
+		`{invalid json}`, // invalid JSON
+		`{"resourceType":"Patient","id":"no-meta"}`,                                                  // no meta
+		`{"resourceType":"Patient","id":"meta-string","meta":"not a map"}`,                           // meta not a map
+		`{"resourceType":"Patient","id":"profiles-string","meta":{"profile":"not an array"}}`,        // profiles not array
+		`{"resourceType":"Patient","id":"profile-int","meta":{"profile":[123]}}`,                     // non-string profile
+		`{"resourceType":"Patient","id":"empty-profiles","meta":{"profile":[]}}`,                     // empty profiles
+		fmt.Sprintf(`{"resourceType":"Patient","id":"valid","meta":{"profile":["%s"]}}`, profileURL), // valid match
+		fmt.Sprintf(`{"resourceType":"Bundle","type":"collection","entry":["not a map",{"fullUrl":"urn:1"},{"resource":"not a map"},{"resource":{"resourceType":"Patient","id":"bundle-valid","meta":{"profile":["%s"]}}}]}`, profileURL), // Bundle with edge cases
+	}, "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "edges.ndjson"), []byte(ndjsonContent), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Flattener should be called once (both valid resources in one batch)
+	assert.GreaterOrEqual(t, flattenCalls, 1)
+
+	// CSV should exist with data
+	csvFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	require.NoError(t, err)
+	assert.Len(t, csvFiles, 1)
+}
+
+// TestExecuteFlatteningStep_BatchFlushOnThreshold verifies that per-group batch flushing
+// works for both Bundle entries and non-Bundle resources
+func TestExecuteFlatteningStep_BatchFlushOnThreshold(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			callCount++
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, "row-%d\n", callCount)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-batch-flush"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// Create non-Bundle resources large enough to exceed the 1MB batch threshold.
+	// Each resource is ~10KB (padded with a large name), so ~110 resources ≈ 1.1MB.
+	longName := strings.Repeat("X", 10000)
+	var lines []string
+	for i := 0; i < 110; i++ {
+		lines = append(lines, fmt.Sprintf(`{"resourceType":"Patient","id":"p%d","meta":{"profile":["%s"]},"name":[{"family":"%s_%d"}]}`, i, profileURL, longName, i))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "patients.ndjson"), []byte(strings.Join(lines, "\n")), 0644))
+
+	// Also create a Bundle with entries large enough to trigger a mid-Bundle flush
+	var entries []string
+	for i := 0; i < 110; i++ {
+		entries = append(entries, fmt.Sprintf(`{"resource":{"resourceType":"Patient","id":"bp%d","meta":{"profile":["%s"]},"name":[{"family":"%s_%d"}]}}`, i, profileURL, longName, i))
+	}
+	bundleLine := fmt.Sprintf(`{"resourceType":"Bundle","type":"collection","entry":[%s]}`, strings.Join(entries, ","))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "bundle.ndjson"), []byte(bundleLine), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	job.Config.Services.Flattening.BatchSizeMB = 1 // 1MB threshold
+
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// Flattener should be called at least once
+	assert.GreaterOrEqual(t, callCount, 1)
+
+	// CSV should contain all data rows
+	csvFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	require.NoError(t, err)
+	assert.Len(t, csvFiles, 1)
+
+	content, err := os.ReadFile(csvFiles[0])
+	require.NoError(t, err)
+	contentLines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	// Header + at least callCount data rows
+	assert.GreaterOrEqual(t, len(contentLines), callCount+1)
+}
+
+// TestExecuteFlatteningStep_NilViewDefSkipped verifies that resources matching a group
+// whose ViewDefinition build failed (nil viewDef) are silently skipped
+func TestExecuteFlatteningStep_NilViewDefSkipped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should never be called — the only group has no valid ViewDefinition
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-nil-viewdef"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+
+	// CRTDL references a profile, but the lookup table has NO matching entry for it.
+	// This means the ViewDefinition build will fail, leaving viewDefs[0] == nil.
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	// Write lookup for a completely different profile
+	writeTestLookupTable(t, lookupPath, "https://example.com/Observation", "Observation")
+
+	// Resource that would match the group's profileURL — but viewDef is nil
+	ndjsonContent := fmt.Sprintf(`{"resourceType":"Patient","id":"1","meta":{"profile":["%s"]}}`, profileURL)
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte(ndjsonContent), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// No CSV should be created — ViewDefinition is nil, resource is skipped
+	csvFiles, _ := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	assert.Empty(t, csvFiles)
+}
+
+// TestExecuteFlatteningStep_BundleEntryUnmatchedProfile verifies that bundle entries
+// whose profile doesn't match any group are silently skipped
+func TestExecuteFlatteningStep_BundleEntryUnmatchedProfile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-bundle-unmatched"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// Bundle with entries that have an unmatched profile
+	bundle := `{"resourceType":"Bundle","type":"collection","entry":[{"resource":{"resourceType":"Patient","id":"1","meta":{"profile":["https://example.com/DifferentProfile"]}}}]}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "bundle.ndjson"), []byte(bundle), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	csvFiles, _ := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	assert.Empty(t, csvFiles)
+}
+
+// TestExecuteFlatteningStep_FlattenerErrorDuringFlush verifies fail-fast when the
+// flattener returns an error during a mid-stream batch flush (covers both bundle
+// and non-bundle flush error paths with reader cleanup)
+func TestExecuteFlatteningStep_FlattenerErrorDuringFlush(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("service error"))
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	longName := strings.Repeat("Y", 10000)
+
+	t.Run("non-bundle flush error", func(t *testing.T) {
+		jobID := "test-flush-error-nonbundle"
+		jobDir := filepath.Join(tempDir, "jobs", jobID)
+		inputDir := filepath.Join(jobDir, "import")
+		require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+		// Create enough non-Bundle resources to exceed 1MB batch threshold
+		var lines []string
+		for i := 0; i < 110; i++ {
+			lines = append(lines, fmt.Sprintf(`{"resourceType":"Patient","id":"p%d","meta":{"profile":["%s"]},"name":[{"family":"%s_%d"}]}`, i, profileURL, longName, i))
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(inputDir, "patients.ndjson"), []byte(strings.Join(lines, "\n")), 0644))
+
+		job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+		job.Config.Services.Flattening.BatchSizeMB = 1
+		logger := createFlatteningTestLogger()
+
+		err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "flattener failed for group")
+	})
+
+	t.Run("bundle flush error", func(t *testing.T) {
+		jobID := "test-flush-error-bundle"
+		jobDir := filepath.Join(tempDir, "jobs", jobID)
+		inputDir := filepath.Join(jobDir, "import")
+		require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+		// Create a Bundle with enough large entries to exceed 1MB
+		var entries []string
+		for i := 0; i < 110; i++ {
+			entries = append(entries, fmt.Sprintf(`{"resource":{"resourceType":"Patient","id":"bp%d","meta":{"profile":["%s"]},"name":[{"family":"%s_%d"}]}}`, i, profileURL, longName, i))
+		}
+		bundleLine := fmt.Sprintf(`{"resourceType":"Bundle","type":"collection","entry":[%s]}`, strings.Join(entries, ","))
+		require.NoError(t, os.WriteFile(filepath.Join(inputDir, "bundle.ndjson"), []byte(bundleLine), 0644))
+
+		job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+		job.Config.Services.Flattening.BatchSizeMB = 1
+		logger := createFlatteningTestLogger()
+
+		err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "flattener failed for group")
+	})
+}
+
+// TestExecuteFlatteningStep_OpenFileError verifies error handling when a file in the
+// input directory cannot be opened during streaming
+func TestExecuteFlatteningStep_OpenFileError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Cannot test permission errors as root")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-open-file-error"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// Create a file with no read permissions so OpenFileForReading fails
+	unreadable := filepath.Join(inputDir, "unreadable.ndjson")
+	require.NoError(t, os.WriteFile(unreadable, []byte(`{"resourceType":"Patient"}`), 0000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0644) })
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load resources")
+}
+
+// TestExecuteFlatteningStep_UnknownProfile verifies resources with unknown profiles
+// are silently skipped during streaming
+func TestExecuteFlatteningStep_UnknownProfile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should never be called if all resources have unknown profiles
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-unknown-profile"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "Patient", "https://example.com/Patient")
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
+
+	// Resources with a DIFFERENT profile that doesn't match any group
+	ndjsonContent := `{"resourceType":"Patient","id":"1","meta":{"profile":["https://example.com/UnknownProfile"]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte(ndjsonContent), 0644))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+
+	// No CSV should be written (no matching resources)
+	csvFiles, _ := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
+	assert.Empty(t, csvFiles)
 }


### PR DESCRIPTION
## Summary

Closes #225

- Replaces the OOM-prone `LoadAllResources()` approach in `ExecuteFlatteningStep` with single-pass streaming and per-group batch flushing
- Resources are routed to group accumulators via `meta.profile[0]` URL and flushed to the flattener when a configurable byte-size threshold is exceeded (default 10MB)
- Memory is now bounded by `O(num_groups × batch_size_mb)` instead of `O(total_resources)` — e.g. 15 groups × 10MB = 150MB max vs multi-GB before
- Adds `BatchSizeMB` config field (`services.flattening.batch_size_mb`) with `GetBatchSizeBytes()` helper
- Adds `AppendCSVData()` for incremental CSV writing across batches (header on first batch only)
- Preserves `LoadAllResources`, `LoadResourcesFromFile`, `FilterResourcesByProfile` for existing callers

### Configuration

```yaml
services:
  flattening:
    batch_size_mb: 10  # default, 0 also means "use default 10"
```