### PR TITLE
Remove unused csv_conversion and parquet_conversion steps

### DIFF
--- a/.github/test/aether.yaml
+++ b/.github/test/aether.yaml
@@ -24,14 +24,6 @@ services:
     url: "http://fhir-pseudonymizer:8080/fhir"
     bundle_split_threshold_mb: 10
 
-  # CSV Conversion Service (not running in test environment)
-  csv_conversion:
-    url: ""
-
-  # Parquet Conversion Service (not running in test environment)
-  parquet_conversion:
-    url: ""
-
   # Flattening Service (FHIR to CSV transformation)
   flattening:
     service_url: "http://fhir-flattener:8000"
@@ -59,7 +51,7 @@ services:
 
 pipeline:
   # List of steps to execute in order
-  # Options: import, dimp, validation, csv_conversion, parquet_conversion
+  # Options: import, dimp, validation, flattening, wait, send
   # NOTE: 'import' must always be the first step
   enabled_steps:
     - torch
@@ -67,9 +59,6 @@ pipeline:
     - dimp
     - flattening
     - send
-    # - csv_conversion  # Commented out - service not running
-    # - parquet_conversion  # Commented out - service not running
-
 retry:
   # Maximum number of retry attempts for transient errors (network, 5xx)
   # Range: 1-10

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -78,9 +78,6 @@ Available Steps:
   import            - Import FHIR data from local or HTTP source
   dimp              - Pseudonymize data via DIMP service
   validation        - Validate FHIR data (placeholder)
-  csv_conversion    - Convert FHIR to CSV format
-  parquet_conversion - Convert FHIR to Parquet format
-
 Prerequisites:
   • The step must be enabled in project configuration
   • Prerequisite steps must be completed (e.g., import before dimp)
@@ -92,9 +89,6 @@ Examples:
 
   # Run DIMP pseudonymization step
   aether job run abc123 --step dimp
-
-  # Run CSV conversion step
-  aether job run abc123 --step csv_conversion
 
 Error Handling:
   • Transient errors (network, 5xx) are retried automatically
@@ -284,18 +278,16 @@ func runJobRun(cmd *cobra.Command, args []string) error {
 // validateStepName validates and converts step flag to StepName type
 func validateStepName(step string) (models.StepName, error) {
 	validSteps := map[string]models.StepName{
-		"torch":              models.StepTorchImport,
-		"local_import":       models.StepLocalImport,
-		"http_import":        models.StepHttpImport,
-		"dimp":               models.StepDIMP,
-		"validation":         models.StepValidation,
-		"csv_conversion":     models.StepCSVConversion,
-		"parquet_conversion": models.StepParquetConversion,
+		"torch":        models.StepTorchImport,
+		"local_import": models.StepLocalImport,
+		"http_import":  models.StepHttpImport,
+		"dimp":         models.StepDIMP,
+		"validation":   models.StepValidation,
 	}
 
 	stepName, ok := validSteps[step]
 	if !ok {
-		return "", fmt.Errorf("invalid step name '%s'. Valid steps: torch, local_import, http_import, dimp, validation, csv_conversion, parquet_conversion", step)
+		return "", fmt.Errorf("invalid step name '%s'. Valid steps: torch, local_import, http_import, dimp, validation", step)
 	}
 
 	return stepName, nil
@@ -372,12 +364,6 @@ func executeStepManually(job *models.PipelineJob, stepName models.StepName, conf
 
 	case models.StepValidation:
 		return fmt.Errorf("validation step not yet implemented")
-
-	case models.StepCSVConversion:
-		return fmt.Errorf("CSV conversion step not yet implemented")
-
-	case models.StepParquetConversion:
-		return fmt.Errorf("parquet conversion step not yet implemented")
 
 	default:
 		return fmt.Errorf("unknown step: %s", stepName)

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -239,14 +239,6 @@ func executeStep(job *models.PipelineJob, stepName models.StepName, config *mode
 		fmt.Printf("\n✓ Validation completed\n")
 		return nil
 
-	case models.StepCSVConversion:
-		fmt.Println("CSV conversion step not yet implemented - job will remain at this step")
-		return nil
-
-	case models.StepParquetConversion:
-		fmt.Println("Parquet conversion step not yet implemented - job will remain at this step")
-		return nil
-
 	case models.StepFlattening:
 		fmt.Println("Starting flattening step...")
 		if err := pipeline.ExecuteFlatteningStep(job, jobDir, logger); err != nil {

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -46,16 +46,6 @@ services:
     # Default: 10 MB
     bundle_split_threshold_mb: 10
 
-  # CSV Conversion Service (optional)
-  # Leave empty to skip CSV conversion
-  csv_conversion:
-    url: "http://localhost:9000/convert/csv"
-
-  # Parquet Conversion Service (optional)
-  # Leave empty to skip Parquet conversion
-  parquet_conversion:
-    url: "http://localhost:9000/convert/parquet"
-
   # CRTDL Preprocessing (optional)
   # Enriches CRTDL files with additional attributes required by DIMP before sending to TORCH.
   # This is needed when DIMP requires certain identifiers (e.g., PseudonymisierterIdentifier,
@@ -204,7 +194,7 @@ services:
 pipeline:
   # List of steps to execute in order
   # Import step options (must be first): torch, local_import, http_import
-  # Other step options: dimp, validation, csv_conversion, parquet_conversion, wait, flattening
+  # Other step options: dimp, validation, wait, flattening
   #
   # IMPORTANT: Only ONE import step should be enabled at a time!
   #   - torch: Use with CRTDL for TORCH extraction
@@ -243,8 +233,6 @@ pipeline:
     - dimp
     # - wait          # Uncomment to pause after pseudonymization
     - flattening      # Transform FHIR to CSV using fhir-flattener (CRTDL input only)
-    - csv_conversion
-    - parquet_conversion
     # - send           # Uncomment to send data to DSF transfer server
 
   # Maximum NDJSON line size in megabytes (MB)

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -68,7 +68,7 @@ Created: 2025-10-09 10:30:00
 Steps:
   ✓ import        - completed (13 files, 5.6 MB) [0 retries]
     dimp          - pending
-    csv_conversion - pending
+    flattening     - pending
 
 Total Files: 13
 Total Data: 5.6 MB

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -70,7 +70,7 @@ Integration tests for multi-step pipeline execution.
 #### TestPipelineMultiStep_StepSequencing
 Verifies that `GetNextStep()` returns steps in the correct order.
 
-- Tests that import → dimp → validation → csv_conversion works correctly
+- Tests that import → dimp → validation → flattening works correctly
 - Tests that the last step returns empty string (no more steps)
 
 #### TestPipelineMultiStep_OnlyImportEnabled
@@ -85,7 +85,7 @@ Verifies pipeline works correctly when only import is enabled.
 
 - Writes a YAML config with multiple steps
 - Loads config via `LoadConfig()`
-- Verifies ALL steps are present (import, dimp, csv_conversion)
+- Verifies ALL steps are present (import, dimp, flattening)
 - Verifies service URLs are loaded correctly
 
 #### TestPipelineMultiStep_JobStatePersistedBetweenSteps
@@ -104,14 +104,14 @@ Unit tests specifically for configuration loading (the root cause of the bug).
 #### TestConfigLoading_MultipleEnabledSteps ⭐
 **Critical regression test** - Verifies viper doesn't drop enabled steps when loading YAML.
 
-- Tests loading 5 enabled steps: import, dimp, validation, csv_conversion, parquet_conversion
-- Verifies ALL 5 steps are present in loaded config
+- Tests loading 4 enabled steps: import, dimp, validation, flattening
+- Verifies ALL 4 steps are present in loaded config
 - **This test would have caught the viper.Unmarshal bug**
 
 #### TestConfigLoading_ServiceURLs
 Verifies all service URLs are loaded correctly from YAML.
 
-- Tests DIMP URL, CSV URL, and Parquet URL
+- Tests DIMP URL and Flattening URL
 - Verifies exact values match what's in the config file
 
 #### TestConfigLoading_RetrySettings

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -134,7 +134,7 @@ aether job run <job-id> --step <step-name>
 **Options:**
 - `--step` - Step to execute (required)
 
-**Valid steps:** `torch`, `local_import`, `http_import`, `dimp`, `validation`, `csv_conversion`, `parquet_conversion`
+**Valid steps:** `torch`, `local_import`, `http_import`, `dimp`, `validation`
 
 **Examples:**
 ```bash

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -332,8 +332,6 @@ pipeline:
 | `flattening` | Transform to CSV (requires CRTDL) |
 | `send` | Upload to destination server |
 | `validation` | Validate FHIR data against profiles |
-| `csv_conversion` | Convert to CSV (placeholder) |
-| `parquet_conversion` | Convert to Parquet (placeholder) |
 
 **Rules:**
 - One import step must be first (torch, local_import, or http_import)

--- a/internal/lib/validation.go
+++ b/internal/lib/validation.go
@@ -12,15 +12,13 @@ import (
 // StepPrerequisites defines which steps must complete before a given step can run
 // Note: "import" is a placeholder representing any of the three import step types
 var StepPrerequisites = map[models.StepName][]models.StepName{
-	models.StepTorchImport:       {},         // No prerequisites - can always run
-	models.StepLocalImport:       {},         // No prerequisites - can always run
-	models.StepHttpImport:        {},         // No prerequisites - can always run
-	models.StepDIMP:              {"import"}, // Requires any import step to complete
-	models.StepValidation:        {"import"}, // Can validate after import (regardless of DIMP)
-	models.StepCSVConversion:     {"import"}, // Can convert original or pseudonymized data
-	models.StepParquetConversion: {"import"}, // Can convert original or pseudonymized data
-	models.StepWait:              {"import"}, // Wait requires at least one step to have run
-	models.StepSend:              {"import"}, // Send requires at least import to have run
+	models.StepTorchImport: {},         // No prerequisites - can always run
+	models.StepLocalImport: {},         // No prerequisites - can always run
+	models.StepHttpImport:  {},         // No prerequisites - can always run
+	models.StepDIMP:        {"import"}, // Requires any import step to complete
+	models.StepValidation:  {"import"}, // Can validate after import (regardless of DIMP)
+	models.StepWait:        {"import"}, // Wait requires at least one step to have run
+	models.StepSend:        {"import"}, // Send requires at least import to have run
 }
 
 // ValidateStepPrerequisites checks if all prerequisite steps have completed successfully

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -41,8 +41,6 @@ func DefaultCompressionConfig() CompressionConfig {
 // ServiceConfig contains connection details for external HTTP services
 type ServiceConfig struct {
 	DIMP               DIMPConfig               `yaml:"dimp" json:"dimp"`
-	CSVConversion      CSVConversionConfig      `yaml:"csv_conversion" json:"csv_conversion"`
-	ParquetConversion  ParquetConversionConfig  `yaml:"parquet_conversion" json:"parquet_conversion"`
 	TORCH              TORCHConfig              `yaml:"torch" json:"torch"`
 	Flattening         FlatteningConfig         `yaml:"flattening" json:"flattening"`
 	CRTDLPreprocessing CRTDLPreprocessingConfig `yaml:"crtdl_preprocessing" json:"crtdl_preprocessing" mapstructure:"crtdl_preprocessing"`
@@ -68,16 +66,6 @@ type LocalImportConfig struct {
 type DIMPConfig struct {
 	URL                    string `yaml:"url" json:"url"`
 	BundleSplitThresholdMB int    `yaml:"bundle_split_threshold_mb" json:"bundle_split_threshold_mb"` // Default 10MB - threshold for splitting large Bundles to prevent HTTP 413 errors
-}
-
-// CSVConversionConfig contains CSV conversion service settings
-type CSVConversionConfig struct {
-	URL string `yaml:"url" json:"url"`
-}
-
-// ParquetConversionConfig contains Parquet conversion service settings
-type ParquetConversionConfig struct {
-	URL string `yaml:"url" json:"url"`
 }
 
 // TORCHConfig contains TORCH server connection and extraction behavior settings
@@ -352,12 +340,6 @@ func DefaultConfig() ProjectConfig {
 				URL:                    "",
 				BundleSplitThresholdMB: 10, // 10MB default threshold for Bundle splitting
 			},
-			CSVConversion: CSVConversionConfig{
-				URL: "",
-			},
-			ParquetConversion: ParquetConversionConfig{
-				URL: "",
-			},
 			TORCH: TORCHConfig{
 				BaseURL:            "",
 				Username:           "",
@@ -451,10 +433,6 @@ func (c *ServiceConfig) HasServiceURL(step StepName) bool {
 	switch step {
 	case StepDIMP:
 		return c.DIMP.URL != ""
-	case StepCSVConversion:
-		return c.CSVConversion.URL != ""
-	case StepParquetConversion:
-		return c.ParquetConversion.URL != ""
 	case StepFlattening:
 		return c.Flattening.ServiceURL != ""
 	case StepSend:
@@ -469,10 +447,6 @@ func (c *ServiceConfig) GetServiceURL(step StepName) string {
 	switch step {
 	case StepDIMP:
 		return c.DIMP.URL
-	case StepCSVConversion:
-		return c.CSVConversion.URL
-	case StepParquetConversion:
-		return c.ParquetConversion.URL
 	case StepFlattening:
 		return c.Flattening.ServiceURL
 	case StepSend:

--- a/internal/models/step.go
+++ b/internal/models/step.go
@@ -20,16 +20,14 @@ type PipelineStep struct {
 type StepName string
 
 const (
-	StepTorchImport       StepName = "torch"        // TORCH import via CRTDL or direct TORCH URL
-	StepLocalImport       StepName = "local_import" // Import from local directory
-	StepHttpImport        StepName = "http_import"  // Import from HTTP URL
-	StepDIMP              StepName = "dimp"
-	StepValidation        StepName = "validation"
-	StepCSVConversion     StepName = "csv_conversion"
-	StepParquetConversion StepName = "parquet_conversion"
-	StepWait              StepName = "wait"       // Pause pipeline for user inspection/modification
-	StepFlattening        StepName = "flattening" // Transform FHIR data to CSV using fhir-flattener
-	StepSend              StepName = "send"       // Prepare and send data to DSF transfer server
+	StepTorchImport StepName = "torch"        // TORCH import via CRTDL or direct TORCH URL
+	StepLocalImport StepName = "local_import" // Import from local directory
+	StepHttpImport  StepName = "http_import"  // Import from HTTP URL
+	StepDIMP        StepName = "dimp"
+	StepValidation  StepName = "validation"
+	StepWait        StepName = "wait"       // Pause pipeline for user inspection/modification
+	StepFlattening  StepName = "flattening" // Transform FHIR data to CSV using fhir-flattener
+	StepSend        StepName = "send"       // Prepare and send data to DSF transfer server
 )
 
 // StepStatus defines the execution state of a pipeline step
@@ -70,7 +68,7 @@ const (
 // IsValidStepName checks if the step name is recognized
 func IsValidStepName(name StepName) bool {
 	switch name {
-	case StepTorchImport, StepLocalImport, StepHttpImport, StepDIMP, StepValidation, StepCSVConversion, StepParquetConversion, StepWait, StepFlattening, StepSend:
+	case StepTorchImport, StepLocalImport, StepHttpImport, StepDIMP, StepValidation, StepWait, StepFlattening, StepSend:
 		return true
 	default:
 		return false

--- a/internal/models/validation.go
+++ b/internal/models/validation.go
@@ -159,7 +159,7 @@ func (c *ProjectConfig) Validate() error {
 	for _, step := range c.Pipeline.EnabledSteps {
 		if !c.Services.HasServiceURL(step) {
 			switch step {
-			case StepDIMP, StepValidation, StepCSVConversion, StepParquetConversion, StepSend:
+			case StepDIMP, StepValidation, StepSend:
 				return fmt.Errorf("service URL required for enabled step '%s'", step)
 			}
 		}
@@ -192,17 +192,6 @@ func (c *ProjectConfig) Validate() error {
 			return fmt.Errorf("invalid validation url: %w", err)
 		}
 	}
-	if c.Services.CSVConversion.URL != "" {
-		if _, err := url.Parse(c.Services.CSVConversion.URL); err != nil {
-			return fmt.Errorf("invalid csv_conversion url: %w", err)
-		}
-	}
-	if c.Services.ParquetConversion.URL != "" {
-		if _, err := url.Parse(c.Services.ParquetConversion.URL); err != nil {
-			return fmt.Errorf("invalid parquet_conversion url: %w", err)
-		}
-	}
-
 	// Validate retry configuration
 	if c.Retry.MaxAttempts < 1 || c.Retry.MaxAttempts > 10 {
 		return errors.New("max_attempts must be between 1 and 10")
@@ -309,12 +298,6 @@ func (c *ProjectConfig) ValidateServiceConnectivity(transport *http.Transport) e
 			}
 			serviceURL = c.Services.GetServiceURL(StepSend)
 			serviceName = "Send"
-		case StepCSVConversion:
-			serviceURL = c.Services.CSVConversion.URL
-			serviceName = "CSV Conversion"
-		case StepParquetConversion:
-			serviceURL = c.Services.ParquetConversion.URL
-			serviceName = "Parquet Conversion"
 		default:
 			continue // Skip steps that don't require external services
 		}

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -110,12 +110,6 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 				BundleChunkSizeMB:     viper.GetInt("services.validation.bundle_chunk_size_mb"),
 				FailOnError:           viperGetBoolPtr("services.validation.fail_on_error"),
 			},
-			CSVConversion: models.CSVConversionConfig{
-				URL: ExpandEnvVars(viper.GetString("services.csv_conversion.url")),
-			},
-			ParquetConversion: models.ParquetConversionConfig{
-				URL: ExpandEnvVars(viper.GetString("services.parquet_conversion.url")),
-			},
 			Flattening: models.FlatteningConfig{
 				ServiceURL:  ExpandEnvVars(viper.GetString("services.flattening.service_url")),
 				LookupPath:  ExpandEnvVars(viper.GetString("services.flattening.lookup_path")),

--- a/internal/services/state.go
+++ b/internal/services/state.go
@@ -155,15 +155,13 @@ func EnsureJobDirs(jobsBaseDir string, jobID string) (map[models.StepName]string
 	jobDir := GetJobDir(jobsBaseDir, jobID)
 
 	dirs := map[models.StepName]string{
-		models.StepTorchImport:       filepath.Join(jobDir, "import"),
-		models.StepLocalImport:       filepath.Join(jobDir, "import"),
-		models.StepHttpImport:        filepath.Join(jobDir, "import"),
-		models.StepDIMP:              filepath.Join(jobDir, "pseudonymized"),
-		models.StepValidation:        filepath.Join(jobDir, "validation"),
-		models.StepCSVConversion:     filepath.Join(jobDir, "csv"),
-		models.StepParquetConversion: filepath.Join(jobDir, "parquet"),
-		models.StepFlattening:        filepath.Join(jobDir, "csv"),
-		models.StepSend:              filepath.Join(jobDir, "send"),
+		models.StepTorchImport: filepath.Join(jobDir, "import"),
+		models.StepLocalImport: filepath.Join(jobDir, "import"),
+		models.StepHttpImport:  filepath.Join(jobDir, "import"),
+		models.StepDIMP:        filepath.Join(jobDir, "pseudonymized"),
+		models.StepValidation:  filepath.Join(jobDir, "validation"),
+		models.StepFlattening:  filepath.Join(jobDir, "csv"),
+		models.StepSend:        filepath.Join(jobDir, "send"),
 	}
 
 	for _, dir := range dirs {
@@ -186,10 +184,8 @@ func GetJobOutputDir(jobsBaseDir string, jobID string, step models.StepName) str
 		return filepath.Join(jobDir, "pseudonymized")
 	case models.StepValidation:
 		return filepath.Join(jobDir, "validation")
-	case models.StepCSVConversion, models.StepFlattening:
+	case models.StepFlattening:
 		return filepath.Join(jobDir, "csv")
-	case models.StepParquetConversion:
-		return filepath.Join(jobDir, "parquet")
 	case models.StepSend:
 		return filepath.Join(jobDir, "send")
 	case models.StepWait:

--- a/tests/integration/job_list_test.go
+++ b/tests/integration/job_list_test.go
@@ -30,7 +30,7 @@ func TestJobList_MultipleJobs(t *testing.T) {
 	job2 := createTestJobWithState(t, jobsDir, models.JobStatusInProgress, models.StepDIMP)
 	time.Sleep(10 * time.Millisecond)
 
-	job3 := createTestJobWithState(t, jobsDir, models.JobStatusFailed, models.StepCSVConversion)
+	job3 := createTestJobWithState(t, jobsDir, models.JobStatusFailed, models.StepFlattening)
 	time.Sleep(10 * time.Millisecond)
 
 	job4 := createTestJobWithState(t, jobsDir, models.JobStatusPending, models.StepLocalImport)
@@ -172,7 +172,7 @@ func TestJobList_FilterByStatus(t *testing.T) {
 	// Create jobs with different statuses
 	completedJob := createTestJobWithState(t, jobsDir, models.JobStatusCompleted, models.StepLocalImport)
 	inProgressJob := createTestJobWithState(t, jobsDir, models.JobStatusInProgress, models.StepDIMP)
-	failedJob := createTestJobWithState(t, jobsDir, models.JobStatusFailed, models.StepCSVConversion)
+	failedJob := createTestJobWithState(t, jobsDir, models.JobStatusFailed, models.StepFlattening)
 	_ = createTestJobWithState(t, jobsDir, models.JobStatusPending, models.StepLocalImport)
 
 	// List all jobs
@@ -211,7 +211,7 @@ func TestJobList_FilterByStatus(t *testing.T) {
 func createTestJobWithState(t *testing.T, jobsDir string, status models.JobStatus, currentStep models.StepName) *models.PipelineJob {
 	config := models.ProjectConfig{
 		Pipeline: models.PipelineConfig{
-			EnabledSteps: []models.StepName{models.StepLocalImport, models.StepDIMP, models.StepCSVConversion},
+			EnabledSteps: []models.StepName{models.StepLocalImport, models.StepDIMP, models.StepFlattening},
 		},
 		Retry: models.RetryConfig{
 			MaxAttempts:      5,

--- a/tests/integration/pipeline_multistep_test.go
+++ b/tests/integration/pipeline_multistep_test.go
@@ -145,7 +145,7 @@ func TestPipelineMultiStep_StepSequencing(t *testing.T) {
 				models.StepLocalImport,
 				models.StepDIMP,
 				models.StepValidation,
-				models.StepCSVConversion,
+				models.StepFlattening,
 			},
 		},
 		JobsDir: jobsDir,
@@ -154,8 +154,8 @@ func TestPipelineMultiStep_StepSequencing(t *testing.T) {
 	// Test GetNextStep returns steps in order
 	assert.Equal(t, models.StepDIMP, config.Pipeline.GetNextStep(models.StepLocalImport))
 	assert.Equal(t, models.StepValidation, config.Pipeline.GetNextStep(models.StepDIMP))
-	assert.Equal(t, models.StepCSVConversion, config.Pipeline.GetNextStep(models.StepValidation))
-	assert.Equal(t, models.StepName(""), config.Pipeline.GetNextStep(models.StepCSVConversion), "Should return empty after last step")
+	assert.Equal(t, models.StepFlattening, config.Pipeline.GetNextStep(models.StepValidation))
+	assert.Equal(t, models.StepName(""), config.Pipeline.GetNextStep(models.StepFlattening), "Should return empty after last step")
 }
 
 // TestPipelineMultiStep_OnlyImportEnabled verifies pipeline works with only import
@@ -225,14 +225,15 @@ func TestPipelineMultiStep_ConfigLoadingPreservesSteps(t *testing.T) {
 services:
   dimp:
     url: "http://localhost:8080"
-  csv_conversion:
-    url: "http://localhost:9000"
+  flattening:
+    service_url: "http://localhost:8000"
+    lookup_path: "/tmp/lookup.json"
 
 pipeline:
   enabled_steps:
     - local_import
     - dimp
-    - csv_conversion
+    - flattening
 
 retry:
   max_attempts: 5
@@ -255,11 +256,11 @@ jobs_dir: "` + jobsDir + `"
 	assert.Len(t, config.Pipeline.EnabledSteps, 3, "Should have 3 enabled steps")
 	assert.Equal(t, models.StepLocalImport, config.Pipeline.EnabledSteps[0])
 	assert.Equal(t, models.StepDIMP, config.Pipeline.EnabledSteps[1])
-	assert.Equal(t, models.StepCSVConversion, config.Pipeline.EnabledSteps[2])
+	assert.Equal(t, models.StepFlattening, config.Pipeline.EnabledSteps[2])
 
 	// Verify service URLs are loaded
 	assert.Equal(t, "http://localhost:8080", config.Services.DIMP.URL)
-	assert.Equal(t, "http://localhost:9000", config.Services.CSVConversion.URL)
+	assert.Equal(t, "http://localhost:8000", config.Services.Flattening.ServiceURL)
 }
 
 // TestPipelineMultiStep_JobStatePersistedBetweenSteps verifies job state

--- a/tests/integration/pipeline_resume_test.go
+++ b/tests/integration/pipeline_resume_test.go
@@ -32,7 +32,7 @@ func TestPipelineResume_AfterImportComplete(t *testing.T) {
 			EnabledSteps: []models.StepName{
 				models.StepLocalImport,
 				models.StepDIMP,
-				models.StepCSVConversion,
+				models.StepFlattening,
 			},
 		},
 		Retry: models.RetryConfig{
@@ -45,8 +45,9 @@ func TestPipelineResume_AfterImportComplete(t *testing.T) {
 			DIMP: models.DIMPConfig{
 				URL: "http://localhost:8083/fhir",
 			},
-			CSVConversion: models.CSVConversionConfig{
-				URL: "http://localhost:9000/convert/csv",
+			Flattening: models.FlatteningConfig{
+				ServiceURL: "http://localhost:8000",
+				LookupPath: "/tmp/lookup.json",
 			},
 		},
 	}
@@ -112,7 +113,7 @@ func TestPipelineResume_AfterImportComplete(t *testing.T) {
 	assert.Equal(t, 3, len(reloadedJob.Config.Pipeline.EnabledSteps), "Config should preserve all enabled steps")
 	assert.Equal(t, models.StepLocalImport, reloadedJob.Config.Pipeline.EnabledSteps[0])
 	assert.Equal(t, models.StepDIMP, reloadedJob.Config.Pipeline.EnabledSteps[1])
-	assert.Equal(t, models.StepCSVConversion, reloadedJob.Config.Pipeline.EnabledSteps[2])
+	assert.Equal(t, models.StepFlattening, reloadedJob.Config.Pipeline.EnabledSteps[2])
 }
 
 // TestPipelineResume_AfterFailedStep tests resuming after a step failure
@@ -184,7 +185,7 @@ func TestPipelineResume_MultipleStepsCompleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify: Current step is CSV conversion
-	assert.Equal(t, string(models.StepCSVConversion), reloadedJob.CurrentStep, "Should advance to CSV conversion")
+	assert.Equal(t, string(models.StepFlattening), reloadedJob.CurrentStep, "Should advance to flattening")
 
 	// Verify: Previous steps are completed
 	importStep, _ := models.GetStepByName(*reloadedJob, models.StepLocalImport)
@@ -207,9 +208,9 @@ func TestPipelineResume_CompletedJob(t *testing.T) {
 	updatedJob := models.ReplaceStep(*job, models.CompleteStep(dimpStep, 10, 512000))
 	job = &updatedJob
 
-	// Complete CSV conversion
-	csvStep, _ := models.GetStepByName(*job, models.StepCSVConversion)
-	updatedJob2 := models.ReplaceStep(*job, models.CompleteStep(csvStep, 10, 256000))
+	// Complete flattening
+	flatteningStep, _ := models.GetStepByName(*job, models.StepFlattening)
+	updatedJob2 := models.ReplaceStep(*job, models.CompleteStep(flatteningStep, 10, 256000))
 	job = &updatedJob2
 
 	// Mark job as completed
@@ -255,7 +256,7 @@ func createCompletedImportJob(t *testing.T, jobsDir string, fileCount int) *mode
 			EnabledSteps: []models.StepName{
 				models.StepLocalImport,
 				models.StepDIMP,
-				models.StepCSVConversion,
+				models.StepFlattening,
 			},
 		},
 		Retry: models.RetryConfig{

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -27,18 +27,16 @@ func TestConfigLoading_MultipleEnabledSteps(t *testing.T) {
 services:
   dimp:
     url: "http://localhost:32861/fhir"
-  csv_conversion:
-    url: "http://localhost:9000/csv"
-  parquet_conversion:
-    url: "http://localhost:9000/parquet"
+  flattening:
+    service_url: "http://localhost:8000"
+    lookup_path: "/tmp/lookup.json"
 
 pipeline:
   enabled_steps:
     - local_import
     - dimp
     - validation
-    - csv_conversion
-    - parquet_conversion
+    - flattening
 
 retry:
   max_attempts: 5
@@ -54,12 +52,11 @@ jobs_dir: "` + jobsDir + `"
 	require.NoError(t, err, "Config should load without error")
 
 	// Verify ALL steps are loaded
-	assert.Len(t, config.Pipeline.EnabledSteps, 5, "Should have 5 enabled steps")
+	assert.Len(t, config.Pipeline.EnabledSteps, 4, "Should have 4 enabled steps")
 	assert.Equal(t, models.StepLocalImport, config.Pipeline.EnabledSteps[0])
 	assert.Equal(t, models.StepDIMP, config.Pipeline.EnabledSteps[1])
 	assert.Equal(t, models.StepValidation, config.Pipeline.EnabledSteps[2])
-	assert.Equal(t, models.StepCSVConversion, config.Pipeline.EnabledSteps[3])
-	assert.Equal(t, models.StepParquetConversion, config.Pipeline.EnabledSteps[4])
+	assert.Equal(t, models.StepFlattening, config.Pipeline.EnabledSteps[3])
 }
 
 // TestConfigLoading_ServiceURLs verifies all service URLs are loaded correctly
@@ -70,17 +67,15 @@ func TestConfigLoading_ServiceURLs(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	expectedDIMPUrl := "http://dimp.example.com:8080/fhir"
-	expectedCSVUrl := "http://csv.example.com:9000/convert"
-	expectedParquetUrl := "http://parquet.example.com:9001/convert"
+	expectedFlatteningUrl := "http://flattener.example.com:8000"
 
 	configContent := `
 services:
   dimp:
     url: "` + expectedDIMPUrl + `"
-  csv_conversion:
-    url: "` + expectedCSVUrl + `"
-  parquet_conversion:
-    url: "` + expectedParquetUrl + `"
+  flattening:
+    service_url: "` + expectedFlatteningUrl + `"
+    lookup_path: "/tmp/lookup.json"
 
 pipeline:
   enabled_steps:
@@ -101,8 +96,7 @@ jobs_dir: "` + jobsDir + `"
 
 	// Verify all service URLs are loaded exactly as specified
 	assert.Equal(t, expectedDIMPUrl, config.Services.DIMP.URL, "DIMP URL should be loaded correctly")
-	assert.Equal(t, expectedCSVUrl, config.Services.CSVConversion.URL, "CSV URL should be loaded correctly")
-	assert.Equal(t, expectedParquetUrl, config.Services.ParquetConversion.URL, "Parquet URL should be loaded correctly")
+	assert.Equal(t, expectedFlatteningUrl, config.Services.Flattening.ServiceURL, "Flattening URL should be loaded correctly")
 }
 
 // TestConfigLoading_RetrySettings verifies retry configuration is loaded
@@ -179,8 +173,6 @@ func TestConfigLoading_EmptyServiceURLs(t *testing.T) {
 	configContent := `
 services:
   dimp_url: ""
-  csv_conversion_url: ""
-  parquet_conversion_url: ""
 
 pipeline:
   enabled_steps:
@@ -200,8 +192,6 @@ jobs_dir: "` + jobsDir + `"
 	require.NoError(t, err)
 
 	assert.Empty(t, config.Services.DIMP.URL, "Empty DIMP URL should remain empty")
-	assert.Empty(t, config.Services.CSVConversion.URL, "Empty CSV URL should remain empty")
-	assert.Empty(t, config.Services.ParquetConversion.URL, "Empty Parquet URL should remain empty")
 }
 
 // TestConfigLoading_PartialServiceURLs verifies mixed empty and non-empty URLs
@@ -215,10 +205,6 @@ func TestConfigLoading_PartialServiceURLs(t *testing.T) {
 services:
   dimp:
     url: "http://localhost:32861/fhir"
-  csv_conversion:
-    url: ""
-  parquet_conversion:
-    url: "http://localhost:9001/parquet"
 
 pipeline:
   enabled_steps:
@@ -239,8 +225,6 @@ jobs_dir: "` + jobsDir + `"
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://localhost:32861/fhir", config.Services.DIMP.URL, "DIMP URL should be loaded")
-	assert.Empty(t, config.Services.CSVConversion.URL, "Empty CSV URL should remain empty")
-	assert.Equal(t, "http://localhost:9001/parquet", config.Services.ParquetConversion.URL, "Parquet URL should be loaded")
 }
 
 // TestConfigLoading_NoConfigFile verifies error when specific config file doesn't exist
@@ -267,18 +251,16 @@ func TestConfigLoading_StepOrder(t *testing.T) {
 services:
   dimp:
     url: "http://localhost:32861/fhir"
-  csv_conversion:
-    url: "http://localhost:9000/csv"
-  parquet_conversion:
-    url: "http://localhost:9001/parquet"
+  flattening:
+    service_url: "http://localhost:8000"
+    lookup_path: "/tmp/lookup.json"
 
 pipeline:
   enabled_steps:
     - local_import
     - validation
     - dimp
-    - parquet_conversion
-    - csv_conversion
+    - flattening
 
 retry:
   max_attempts: 5
@@ -294,12 +276,11 @@ jobs_dir: "` + jobsDir + `"
 	require.NoError(t, err)
 
 	// Verify steps are in the exact order specified in YAML
-	require.Len(t, config.Pipeline.EnabledSteps, 5)
+	require.Len(t, config.Pipeline.EnabledSteps, 4)
 	assert.Equal(t, models.StepLocalImport, config.Pipeline.EnabledSteps[0])
 	assert.Equal(t, models.StepValidation, config.Pipeline.EnabledSteps[1])
 	assert.Equal(t, models.StepDIMP, config.Pipeline.EnabledSteps[2])
-	assert.Equal(t, models.StepParquetConversion, config.Pipeline.EnabledSteps[3])
-	assert.Equal(t, models.StepCSVConversion, config.Pipeline.EnabledSteps[4])
+	assert.Equal(t, models.StepFlattening, config.Pipeline.EnabledSteps[3])
 }
 
 // TestConfigLoading_MinimalConfig verifies minimal valid config loads
@@ -331,8 +312,6 @@ jobs_dir: "` + jobsDir + `"
 	assert.Len(t, config.Pipeline.EnabledSteps, 1)
 	assert.Equal(t, models.StepLocalImport, config.Pipeline.EnabledSteps[0])
 	assert.Empty(t, config.Services.DIMP.URL)
-	assert.Empty(t, config.Services.CSVConversion.URL)
-	assert.Empty(t, config.Services.ParquetConversion.URL)
 }
 
 // TestConfigValidation_InvalidDIMPUrl verifies invalid DIMP service URL is rejected
@@ -346,10 +325,6 @@ func TestConfigValidation_InvalidDIMPUrl(t *testing.T) {
 services:
   dimp:
     url: "http://[invalid:url"
-  csv_conversion:
-    url: ""
-  parquet_conversion:
-    url: ""
 
 pipeline:
   enabled_steps:
@@ -370,80 +345,6 @@ jobs_dir: "` + jobsDir + `"
 	assert.Error(t, err, "Invalid DIMP URL should fail during config loading")
 	assert.Nil(t, config)
 	assert.Contains(t, err.Error(), "invalid dimp url")
-}
-
-// TestConfigValidation_InvalidCSVUrl verifies invalid CSV conversion service URL is rejected
-func TestConfigValidation_InvalidCSVUrl(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	jobsDir := filepath.Join(tmpDir, "jobs")
-	_ = os.MkdirAll(jobsDir, 0755)
-
-	configContent := `
-services:
-  dimp:
-    url: ""
-  csv_conversion:
-    url: "invalid://url format:"
-  parquet_conversion:
-    url: ""
-
-pipeline:
-  enabled_steps:
-    - local_import
-
-retry:
-  max_attempts: 3
-  initial_backoff_ms: 500
-  max_backoff_ms: 10000
-
-jobs_dir: "` + jobsDir + `"
-`
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
-	require.NoError(t, err)
-
-	// LoadConfig validates during loading, so it should fail with invalid URL
-	config, err := services.LoadConfig(configFile)
-	assert.Error(t, err, "Invalid CSV conversion URL should fail during config loading")
-	assert.Nil(t, config)
-	assert.Contains(t, err.Error(), "invalid csv_conversion url")
-}
-
-// TestConfigValidation_InvalidParquetUrl verifies invalid Parquet conversion service URL is rejected
-func TestConfigValidation_InvalidParquetUrl(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	jobsDir := filepath.Join(tmpDir, "jobs")
-	_ = os.MkdirAll(jobsDir, 0755)
-
-	configContent := `
-services:
-  dimp:
-    url: ""
-  csv_conversion:
-    url: ""
-  parquet_conversion:
-    url: "http://[invalid:url"
-
-pipeline:
-  enabled_steps:
-    - local_import
-
-retry:
-  max_attempts: 3
-  initial_backoff_ms: 500
-  max_backoff_ms: 10000
-
-jobs_dir: "` + jobsDir + `"
-`
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
-	require.NoError(t, err)
-
-	// LoadConfig validates during loading, so it should fail with invalid URL
-	config, err := services.LoadConfig(configFile)
-	assert.Error(t, err, "Invalid Parquet conversion URL should fail during config loading")
-	assert.Nil(t, config)
-	assert.Contains(t, err.Error(), "invalid parquet_conversion url")
 }
 
 // Unit tests for TORCHConfig validation
@@ -902,12 +803,6 @@ func TestGetServiceURL(t *testing.T) {
 			DIMP: models.DIMPConfig{
 				URL: "http://dimp.example.com:8080",
 			},
-			CSVConversion: models.CSVConversionConfig{
-				URL: "http://csv.example.com:9000",
-			},
-			ParquetConversion: models.ParquetConversionConfig{
-				URL: "http://parquet.example.com:9001",
-			},
 			Flattening: models.FlatteningConfig{
 				ServiceURL: "http://flattener.example.com:8000",
 			},
@@ -924,12 +819,6 @@ func TestGetServiceURL(t *testing.T) {
 
 	// Test DIMP URL
 	assert.Equal(t, "http://dimp.example.com:8080", config.Services.GetServiceURL(models.StepDIMP))
-
-	// Test CSV URL
-	assert.Equal(t, "http://csv.example.com:9000", config.Services.GetServiceURL(models.StepCSVConversion))
-
-	// Test Parquet URL
-	assert.Equal(t, "http://parquet.example.com:9001", config.Services.GetServiceURL(models.StepParquetConversion))
 
 	// Test Flattening URL
 	assert.Equal(t, "http://flattener.example.com:8000", config.Services.GetServiceURL(models.StepFlattening))
@@ -971,7 +860,7 @@ func TestGetNextStep(t *testing.T) {
 				models.StepLocalImport,
 				models.StepValidation,
 				models.StepDIMP,
-				models.StepCSVConversion,
+				models.StepFlattening,
 			},
 		},
 	}
@@ -983,13 +872,10 @@ func TestGetNextStep(t *testing.T) {
 	assert.Equal(t, models.StepDIMP, config.Pipeline.GetNextStep(models.StepValidation))
 
 	// Test getting next step from DIMP
-	assert.Equal(t, models.StepCSVConversion, config.Pipeline.GetNextStep(models.StepDIMP))
+	assert.Equal(t, models.StepFlattening, config.Pipeline.GetNextStep(models.StepDIMP))
 
 	// Test getting next step from last step (should return empty)
-	assert.Equal(t, models.StepName(""), config.Pipeline.GetNextStep(models.StepCSVConversion))
-
-	// Test getting next step for non-existent step (should return empty)
-	assert.Equal(t, models.StepName(""), config.Pipeline.GetNextStep(models.StepParquetConversion))
+	assert.Equal(t, models.StepName(""), config.Pipeline.GetNextStep(models.StepFlattening))
 }
 
 // TestHasServiceURL verifies service URL presence checks
@@ -1014,38 +900,6 @@ func TestHasServiceURL(t *testing.T) {
 				DIMP: models.DIMPConfig{URL: ""},
 			},
 			step:   models.StepDIMP,
-			hasURL: false,
-		},
-		{
-			name: "CSV Conversion with URL",
-			config: models.ServiceConfig{
-				CSVConversion: models.CSVConversionConfig{URL: "http://csv.example.com"},
-			},
-			step:   models.StepCSVConversion,
-			hasURL: true,
-		},
-		{
-			name: "CSV Conversion without URL",
-			config: models.ServiceConfig{
-				CSVConversion: models.CSVConversionConfig{URL: ""},
-			},
-			step:   models.StepCSVConversion,
-			hasURL: false,
-		},
-		{
-			name: "Parquet Conversion with URL",
-			config: models.ServiceConfig{
-				ParquetConversion: models.ParquetConversionConfig{URL: "http://parquet.example.com"},
-			},
-			step:   models.StepParquetConversion,
-			hasURL: true,
-		},
-		{
-			name: "Parquet Conversion without URL",
-			config: models.ServiceConfig{
-				ParquetConversion: models.ParquetConversionConfig{URL: ""},
-			},
-			step:   models.StepParquetConversion,
 			hasURL: false,
 		},
 		{
@@ -1081,9 +935,6 @@ func TestConfigValidation_MissingServiceURLForEnabledStep(t *testing.T) {
 			config: models.ProjectConfig{
 				Services: models.ServiceConfig{
 					DIMP: models.DIMPConfig{URL: ""},
-					CSVConversion: models.CSVConversionConfig{
-						URL: "http://csv.example.com",
-					},
 				},
 				Pipeline: models.PipelineConfig{
 					EnabledSteps: []models.StepName{
@@ -1099,51 +950,6 @@ func TestConfigValidation_MissingServiceURLForEnabledStep(t *testing.T) {
 				JobsDir: "/tmp/jobs",
 			},
 			errorText: "service URL required for enabled step 'dimp'",
-		},
-		{
-			name: "CSV Conversion enabled without URL",
-			config: models.ProjectConfig{
-				Services: models.ServiceConfig{
-					DIMP: models.DIMPConfig{
-						URL: "http://dimp.example.com",
-					},
-					CSVConversion: models.CSVConversionConfig{URL: ""},
-				},
-				Pipeline: models.PipelineConfig{
-					EnabledSteps: []models.StepName{
-						models.StepLocalImport,
-						models.StepCSVConversion,
-					},
-				},
-				Retry: models.RetryConfig{
-					MaxAttempts:      5,
-					InitialBackoffMs: 1000,
-					MaxBackoffMs:     30000,
-				},
-				JobsDir: "/tmp/jobs",
-			},
-			errorText: "service URL required for enabled step 'csv_conversion'",
-		},
-		{
-			name: "Parquet Conversion enabled without URL",
-			config: models.ProjectConfig{
-				Services: models.ServiceConfig{
-					ParquetConversion: models.ParquetConversionConfig{URL: ""},
-				},
-				Pipeline: models.PipelineConfig{
-					EnabledSteps: []models.StepName{
-						models.StepLocalImport,
-						models.StepParquetConversion,
-					},
-				},
-				Retry: models.RetryConfig{
-					MaxAttempts:      5,
-					InitialBackoffMs: 1000,
-					MaxBackoffMs:     30000,
-				},
-				JobsDir: "/tmp/jobs",
-			},
-			errorText: "service URL required for enabled step 'parquet_conversion'",
 		},
 	}
 
@@ -1164,34 +970,16 @@ func TestValidateServiceConnectivity_AllServicesAvailable(t *testing.T) {
 	}))
 	defer dimpServer.Close()
 
-	csvServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer csvServer.Close()
-
-	parquetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer parquetServer.Close()
-
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			DIMP: models.DIMPConfig{
 				URL: dimpServer.URL,
-			},
-			CSVConversion: models.CSVConversionConfig{
-				URL: csvServer.URL,
-			},
-			ParquetConversion: models.ParquetConversionConfig{
-				URL: parquetServer.URL,
 			},
 		},
 		Pipeline: models.PipelineConfig{
 			EnabledSteps: []models.StepName{
 				models.StepLocalImport,
 				models.StepDIMP,
-				models.StepCSVConversion,
-				models.StepParquetConversion,
 			},
 		},
 		Retry: models.RetryConfig{
@@ -1242,18 +1030,10 @@ func TestValidateServiceConnectivity_WithCustomTransport(t *testing.T) {
 
 // TestValidateServiceConnectivity_DIMMServiceUnreachable verifies error when DIMP service is unreachable
 func TestValidateServiceConnectivity_DIMMServiceUnreachable(t *testing.T) {
-	csvServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer csvServer.Close()
-
 	config := models.ProjectConfig{
 		Services: models.ServiceConfig{
 			DIMP: models.DIMPConfig{
 				URL: "http://localhost:9999", // Unreachable
-			},
-			CSVConversion: models.CSVConversionConfig{
-				URL: csvServer.URL,
 			},
 		},
 		Pipeline: models.PipelineConfig{
@@ -1274,78 +1054,6 @@ func TestValidateServiceConnectivity_DIMMServiceUnreachable(t *testing.T) {
 	err := config.ValidateServiceConnectivity(nil)
 	assert.Error(t, err, "Should fail when DIMP service is unreachable")
 	assert.Contains(t, err.Error(), "DIMP")
-}
-
-// TestValidateServiceConnectivity_CSVServiceUnreachable verifies error when CSV service is unreachable
-func TestValidateServiceConnectivity_CSVServiceUnreachable(t *testing.T) {
-	dimpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer dimpServer.Close()
-
-	config := models.ProjectConfig{
-		Services: models.ServiceConfig{
-			DIMP: models.DIMPConfig{
-				URL: dimpServer.URL,
-			},
-			CSVConversion: models.CSVConversionConfig{
-				URL: "http://localhost:9998", // Unreachable
-			},
-		},
-		Pipeline: models.PipelineConfig{
-			EnabledSteps: []models.StepName{
-				models.StepLocalImport,
-				models.StepCSVConversion,
-			},
-		},
-		Retry: models.RetryConfig{
-			MaxAttempts:      5,
-			InitialBackoffMs: 1000,
-			MaxBackoffMs:     30000,
-		},
-		JobsDir: "/tmp/jobs",
-	}
-
-	// ValidateServiceConnectivity should fail when CSV service is unreachable
-	err := config.ValidateServiceConnectivity(nil)
-	assert.Error(t, err, "Should fail when CSV conversion service is unreachable")
-	assert.Contains(t, err.Error(), "CSV Conversion")
-}
-
-// TestValidateServiceConnectivity_ParquetServiceUnreachable verifies error when Parquet service is unreachable
-func TestValidateServiceConnectivity_ParquetServiceUnreachable(t *testing.T) {
-	dimpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer dimpServer.Close()
-
-	config := models.ProjectConfig{
-		Services: models.ServiceConfig{
-			DIMP: models.DIMPConfig{
-				URL: dimpServer.URL,
-			},
-			ParquetConversion: models.ParquetConversionConfig{
-				URL: "http://localhost:9997", // Unreachable
-			},
-		},
-		Pipeline: models.PipelineConfig{
-			EnabledSteps: []models.StepName{
-				models.StepLocalImport,
-				models.StepParquetConversion,
-			},
-		},
-		Retry: models.RetryConfig{
-			MaxAttempts:      5,
-			InitialBackoffMs: 1000,
-			MaxBackoffMs:     30000,
-		},
-		JobsDir: "/tmp/jobs",
-	}
-
-	// ValidateServiceConnectivity should fail when Parquet service is unreachable
-	err := config.ValidateServiceConnectivity(nil)
-	assert.Error(t, err, "Should fail when Parquet conversion service is unreachable")
-	assert.Contains(t, err.Error(), "Parquet Conversion")
 }
 
 // TestValidateServiceConnectivity_SendServiceAvailable verifies connectivity check with Send service available

--- a/tests/unit/config_service_test.go
+++ b/tests/unit/config_service_test.go
@@ -279,10 +279,6 @@ services:
   dimp:
     url: "http://dimp:8080"
     bundle_split_threshold_mb: 20
-  csv_conversion:
-    url: "http://csv:8080"
-  parquet_conversion:
-    url: "http://parquet:8080"
 `
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
 
@@ -294,8 +290,6 @@ services:
 	// Verify all services loaded
 	assert.Equal(t, "http://dimp:8080", config.Services.DIMP.URL)
 	assert.Equal(t, 20, config.Services.DIMP.BundleSplitThresholdMB)
-	assert.Equal(t, "http://csv:8080", config.Services.CSVConversion.URL)
-	assert.Equal(t, "http://parquet:8080", config.Services.ParquetConversion.URL)
 }
 
 // TestLoadConfig_ExplicitDIMPURL tests that explicit DIMP URL is preserved from config

--- a/tests/unit/lib/validation_test.go
+++ b/tests/unit/lib/validation_test.go
@@ -129,10 +129,6 @@ func TestValidation_PipelineSequence(t *testing.T) {
 	canRun, _ = lib.CanRunStep(job, models.StepDIMP)
 	assert.True(t, canRun)
 
-	// Complete DIMP
-	dimpStep, _ := models.GetStepByName(job, models.StepDIMP)
-	dimpStep = models.CompleteStep(dimpStep, 10, 900)
-	job = models.ReplaceStep(job, dimpStep)
 }
 
 // Helper: Create a test job with given steps

--- a/tests/unit/lib/validation_test.go
+++ b/tests/unit/lib/validation_test.go
@@ -45,31 +45,6 @@ func TestValidateStepPrerequisites_DIMPAllowedAfterImport(t *testing.T) {
 	assert.Equal(t, models.StepName(""), prerequisite)
 }
 
-func TestValidateStepPrerequisites_CSVRequiresImport(t *testing.T) {
-	job := createTestJob([]models.StepName{models.StepLocalImport, models.StepCSVConversion})
-
-	// Import not completed
-	prerequisite, canRun := lib.ValidateStepPrerequisites(job, models.StepCSVConversion)
-
-	assert.False(t, canRun)
-	assert.Equal(t, models.StepName("import"), prerequisite) // Returns "import" placeholder
-}
-
-func TestValidateStepPrerequisites_CSVAllowedAfterImport(t *testing.T) {
-	job := createTestJob([]models.StepName{models.StepLocalImport, models.StepCSVConversion})
-
-	// Mark import as completed
-	importStep, _ := models.GetStepByName(job, models.StepLocalImport)
-	importStep = models.CompleteStep(importStep, 5, 500)
-	job = models.ReplaceStep(job, importStep)
-
-	// CSV conversion should be allowed
-	prerequisite, canRun := lib.ValidateStepPrerequisites(job, models.StepCSVConversion)
-
-	assert.True(t, canRun)
-	assert.Equal(t, models.StepName(""), prerequisite)
-}
-
 func TestValidateStepPrerequisites_ValidationRequiresImport(t *testing.T) {
 	job := createTestJob([]models.StepName{models.StepLocalImport, models.StepValidation})
 
@@ -123,18 +98,6 @@ func TestGetStepDependencies_DIMP(t *testing.T) {
 	assert.Equal(t, models.StepName("import"), deps[0]) // Returns "import" placeholder
 }
 
-func TestGetStepDependencies_CSV(t *testing.T) {
-	deps := lib.GetStepDependencies(models.StepCSVConversion)
-	require.Len(t, deps, 1)
-	assert.Equal(t, models.StepName("import"), deps[0]) // Returns "import" placeholder
-}
-
-func TestGetStepDependencies_Parquet(t *testing.T) {
-	deps := lib.GetStepDependencies(models.StepParquetConversion)
-	require.Len(t, deps, 1)
-	assert.Equal(t, models.StepName("import"), deps[0]) // Returns "import" placeholder
-}
-
 func TestGetStepDependencies_UnknownStep(t *testing.T) {
 	deps := lib.GetStepDependencies(models.StepName("nonexistent"))
 	assert.Empty(t, deps)
@@ -142,12 +105,11 @@ func TestGetStepDependencies_UnknownStep(t *testing.T) {
 
 // Integration test: Full pipeline flow
 func TestValidation_PipelineSequence(t *testing.T) {
-	// Full pipeline: Import -> DIMP -> CSV -> Parquet
+	// Full pipeline: Import -> DIMP -> Flattening
 	job := createTestJob([]models.StepName{
 		models.StepLocalImport,
 		models.StepDIMP,
-		models.StepCSVConversion,
-		models.StepParquetConversion,
+		models.StepFlattening,
 	})
 
 	// Initially, only import can run
@@ -158,35 +120,19 @@ func TestValidation_PipelineSequence(t *testing.T) {
 	assert.False(t, canRun)
 	assert.Equal(t, models.StepName("import"), prereq) // Returns "import" placeholder
 
-	canRun, prereq = lib.CanRunStep(job, models.StepCSVConversion)
-	assert.False(t, canRun)
-	assert.Equal(t, models.StepName("import"), prereq) // Returns "import" placeholder
-
 	// Complete import
 	importStep, _ := models.GetStepByName(job, models.StepLocalImport)
 	importStep = models.CompleteStep(importStep, 10, 1000)
 	job = models.ReplaceStep(job, importStep)
 
-	// Now DIMP and CSV can run
+	// Now DIMP can run
 	canRun, _ = lib.CanRunStep(job, models.StepDIMP)
 	assert.True(t, canRun)
 
-	canRun, _ = lib.CanRunStep(job, models.StepCSVConversion)
-	assert.True(t, canRun)
-
-	canRun, _ = lib.CanRunStep(job, models.StepParquetConversion)
-	assert.True(t, canRun)
-
-	// Complete DIMP (CSV and Parquet should still be allowed)
+	// Complete DIMP
 	dimpStep, _ := models.GetStepByName(job, models.StepDIMP)
 	dimpStep = models.CompleteStep(dimpStep, 10, 900)
 	job = models.ReplaceStep(job, dimpStep)
-
-	canRun, _ = lib.CanRunStep(job, models.StepCSVConversion)
-	assert.True(t, canRun) // Still allowed (doesn't depend on DIMP)
-
-	canRun, _ = lib.CanRunStep(job, models.StepParquetConversion)
-	assert.True(t, canRun)
 }
 
 // Helper: Create a test job with given steps

--- a/tests/unit/state_persistence_test.go
+++ b/tests/unit/state_persistence_test.go
@@ -27,9 +27,7 @@ func TestGetJobOutputDir(t *testing.T) {
 		{models.StepTorchImport, "/tmp/jobs/test-job-123/import"},
 		{models.StepHttpImport, "/tmp/jobs/test-job-123/import"},
 		{models.StepDIMP, "/tmp/jobs/test-job-123/pseudonymized"},
-		{models.StepCSVConversion, "/tmp/jobs/test-job-123/csv"},
 		{models.StepFlattening, "/tmp/jobs/test-job-123/csv"},
-		{models.StepParquetConversion, "/tmp/jobs/test-job-123/parquet"},
 		{models.StepSend, "/tmp/jobs/test-job-123/send"},
 		{models.StepWait, "/tmp/jobs/test-job-123"},
 		{models.StepValidation, "/tmp/jobs/test-job-123/validation"},
@@ -201,7 +199,7 @@ func TestStatePersistence_MultipleSteps(t *testing.T) {
 	job.Config.Pipeline.EnabledSteps = []models.StepName{
 		models.StepLocalImport,
 		models.StepDIMP,
-		models.StepCSVConversion,
+		models.StepFlattening,
 	}
 
 	job.Steps = []models.PipelineStep{
@@ -221,7 +219,7 @@ func TestStatePersistence_MultipleSteps(t *testing.T) {
 			BytesProcessed: 512000,
 		},
 		{
-			Name:           models.StepCSVConversion,
+			Name:           models.StepFlattening,
 			Status:         models.StepStatusPending,
 			FilesProcessed: 0,
 			BytesProcessed: 0,


### PR DESCRIPTION
## Summary

- Removes all traces of the never-implemented `csv_conversion` and `parquet_conversion` pipeline steps
- These placeholder steps are fully superseded by the `flattening` step which handles FHIR-to-CSV transformation via fhir-flattener
- Clean removal across 21 files: models, services, CLI, validation, config, tests, and docs (-456 lines)

Closes #241