### PR TITLE
feat: copy effective CRTDL into job directory for all pipeline steps

### DIFF
--- a/.github/scripts/run-e2e-test.sh
+++ b/.github/scripts/run-e2e-test.sh
@@ -108,7 +108,7 @@ fi
 echo ""
 echo "Verifying CRTDL preprocessing..."
 
-# Check that enriched-crtdl.json was created
+# Check that enriched-crtdl.json was created (enrichments are enabled in e2e config)
 if docker compose exec -T aether-runner sh -c "test -f /app/jobs/$JOB_ID/enriched-crtdl.json"; then
     echo "✓ enriched-crtdl.json exists"
 

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -167,8 +167,17 @@ func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClien
 		// Submit enriched CRTDL content
 		extractionURL, err = torchClient.SubmitExtractionWithContent(enrichedContent)
 	} else {
-		// Submit original CRTDL file
-		extractionURL, err = torchClient.SubmitExtraction(job.InputSource)
+		// Copy original CRTDL to job directory so all steps use the same source
+		originalContent, readErr := os.ReadFile(job.InputSource)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read CRTDL file: %w", readErr)
+		}
+		if saveErr := saveCRTDLToJobDir(job, originalContent, "crtdl.json", logger); saveErr != nil {
+			return nil, saveErr
+		}
+
+		// Submit original CRTDL content directly (already in memory from the copy)
+		extractionURL, err = torchClient.SubmitExtractionWithContent(originalContent)
 	}
 
 	if err != nil {
@@ -248,14 +257,33 @@ func classifyImportError(err error, inputType models.InputType) models.ErrorType
 	return models.ErrorTypeNonTransient
 }
 
+// saveCRTDLToJobDir writes the CRTDL content to the job directory under the given
+// filename and updates job.InputSource so all downstream steps use this copy.
+func saveCRTDLToJobDir(job *models.PipelineJob, content []byte, filename string, logger *lib.Logger) error {
+	jobDir := services.GetJobDir(job.Config.JobsDir, job.JobID)
+	crtdlPath := filepath.Join(jobDir, filename)
+
+	if err := os.WriteFile(crtdlPath, content, 0644); err != nil {
+		return fmt.Errorf("failed to save CRTDL to job directory: %w", err)
+	}
+
+	job.InputSource = crtdlPath
+	logger.Info("CRTDL saved to job directory", "path", crtdlPath)
+	return nil
+}
+
 // preprocessCRTDL loads, enriches, and saves the CRTDL document for DIMP requirements.
 // Returns the serialized enriched CRTDL content ready for TORCH submission.
+// The effective CRTDL is saved to the job directory so that all downstream steps
+// (e.g. flattening) use the same CRTDL as TORCH:
+//   - enriched-crtdl.json when enrichments are applied
+//   - crtdl.json when no enrichments are configured
 //
 // Process:
 //  1. Parse original CRTDL from job input source
 //  2. Load enrichments from configuration (file or inline)
 //  3. Apply enrichments using EnrichCRTDL
-//  4. Save enriched CRTDL to job directory for debugging/auditing
+//  4. Save effective CRTDL to job directory
 //  5. Return serialized JSON content
 func preprocessCRTDL(job *models.PipelineJob, logger *lib.Logger) ([]byte, error) {
 	// 1. Parse original CRTDL
@@ -273,8 +301,14 @@ func preprocessCRTDL(job *models.PipelineJob, logger *lib.Logger) ([]byte, error
 
 	if len(enrichments) == 0 {
 		logger.Warn("CRTDL preprocessing enabled but no enrichments configured")
-		// Return original file content
-		return os.ReadFile(job.InputSource)
+		content, err := os.ReadFile(job.InputSource)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CRTDL file: %w", err)
+		}
+		if err := saveCRTDLToJobDir(job, content, "crtdl.json", logger); err != nil {
+			return nil, err
+		}
+		return content, nil
 	}
 
 	logger.Info("Applying CRTDL enrichments",
@@ -296,16 +330,9 @@ func preprocessCRTDL(job *models.PipelineJob, logger *lib.Logger) ([]byte, error
 		return nil, fmt.Errorf("failed to serialize enriched CRTDL: %w", err)
 	}
 
-	// 5. Save enriched CRTDL to job directory for debugging/auditing
-	jobDir := services.GetJobDir(job.Config.JobsDir, job.JobID)
-	enrichedPath := filepath.Join(jobDir, "enriched-crtdl.json")
-
-	if err := os.MkdirAll(jobDir, 0755); err != nil {
-		logger.Warn("Failed to create job directory for enriched CRTDL", "error", err)
-	} else if err := os.WriteFile(enrichedPath, enrichedContent, 0644); err != nil {
-		logger.Warn("Failed to save enriched CRTDL for debugging", "error", err, "path", enrichedPath)
-	} else {
-		logger.Info("Enriched CRTDL saved for debugging", "path", enrichedPath)
+	// 5. Save effective CRTDL to job directory
+	if err := saveCRTDLToJobDir(job, enrichedContent, "enriched-crtdl.json", logger); err != nil {
+		return nil, err
 	}
 
 	return enrichedContent, nil

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -1038,12 +1038,16 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 	assert.Contains(t, attributeRefs, "Patient.identifier:PseudonymisierterIdentifier", "Should have enriched PseudonymisierterIdentifier")
 	assert.Contains(t, attributeRefs, "Patient.birthDate", "Should have enriched birthDate")
 
-	// Verify enriched CRTDL was saved to job directory
-	enrichedPath := filepath.Join(jobsDir, job.JobID, "enriched-crtdl.json")
-	enrichedContent, err := os.ReadFile(enrichedPath)
-	require.NoError(t, err, "Enriched CRTDL should be saved to job directory")
-	assert.Contains(t, string(enrichedContent), "Patient.identifier:PseudonymisierterIdentifier",
-		"Saved enriched CRTDL should contain the enrichment attribute")
+	// Verify enriched CRTDL was saved to job directory as enriched-crtdl.json
+	crtdlJobPath := filepath.Join(jobsDir, job.JobID, "enriched-crtdl.json")
+	savedContent, err := os.ReadFile(crtdlJobPath)
+	require.NoError(t, err, "Enriched CRTDL should be saved to job directory as enriched-crtdl.json")
+	assert.Contains(t, string(savedContent), "Patient.identifier:PseudonymisierterIdentifier",
+		"Saved CRTDL should contain the enrichment attribute")
+
+	// Verify job.InputSource was updated to point to the job-local copy
+	assert.Equal(t, crtdlJobPath, updatedJob.InputSource,
+		"job.InputSource should point to enriched-crtdl.json in the job directory")
 
 	t.Logf("SUCCESS: CRTDL preprocessing enriched document before TORCH submission")
 	t.Logf("Original attributes: 2, Enriched attributes: 4")
@@ -1445,10 +1449,18 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 	// Original CRTDL only has 1 attribute
 	assert.Len(t, attributes, 1, "Original CRTDL should have only 1 attribute (no enrichment)")
 
-	// Verify NO enriched CRTDL file was saved (preprocessing was disabled)
-	enrichedPath := filepath.Join(jobsDir, job.JobID, "enriched-crtdl.json")
-	_, err = os.Stat(enrichedPath)
-	assert.True(t, os.IsNotExist(err), "Enriched CRTDL should NOT be saved when preprocessing is disabled")
+	// Verify original CRTDL was copied to job directory as crtdl.json
+	crtdlJobPath := filepath.Join(jobsDir, job.JobID, "crtdl.json")
+	savedContent, readErr := os.ReadFile(crtdlJobPath)
+	require.NoError(t, readErr, "CRTDL should be copied to job directory as crtdl.json")
+
+	originalContent, _ := os.ReadFile(crtdlPath)
+	assert.JSONEq(t, string(originalContent), string(savedContent),
+		"Copied CRTDL should match the original when preprocessing is disabled")
+
+	// Verify job.InputSource was updated to point to the job-local copy
+	assert.Equal(t, crtdlJobPath, updatedJob.InputSource,
+		"job.InputSource should point to crtdl.json in the job directory")
 }
 
 // TestPipeline_TORCHExtraction_PreprocessingError_InvalidCRTDL tests error handling when CRTDL parsing fails
@@ -1675,10 +1687,18 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, originalContent, decodedBytes, "When no enrichments configured, original file content should be submitted")
 
-	// Verify NO enriched CRTDL file was saved (no enrichments applied)
-	enrichedPath := filepath.Join(jobsDir, job.JobID, "enriched-crtdl.json")
-	_, err = os.Stat(enrichedPath)
-	assert.True(t, os.IsNotExist(err), "Enriched CRTDL should NOT be saved when no enrichments are applied")
+	// Verify original CRTDL was copied to job directory as crtdl.json (even with empty enrichments)
+	crtdlJobPath := filepath.Join(jobsDir, job.JobID, "crtdl.json")
+	savedContent, readErr := os.ReadFile(crtdlJobPath)
+	require.NoError(t, readErr, "CRTDL should be copied to job directory as crtdl.json")
 
-	t.Logf("SUCCESS: With empty enrichments, original CRTDL content was submitted")
+	originalFileContent, _ := os.ReadFile(crtdlPath)
+	assert.JSONEq(t, string(originalFileContent), string(savedContent),
+		"Copied CRTDL should match the original when no enrichments are applied")
+
+	// Verify job.InputSource was updated to point to the job-local copy
+	assert.Equal(t, crtdlJobPath, updatedJob.InputSource,
+		"job.InputSource should point to crtdl.json in the job directory")
+
+	t.Logf("SUCCESS: With empty enrichments, original CRTDL content was submitted and saved to job dir")
 }


### PR DESCRIPTION
## Summary

- Save the effective CRTDL (enriched or original) as `crtdl.json` in the job directory during the import step
- Update `job.InputSource` to point to the job-local copy so all downstream steps (e.g. flattening) use the same CRTDL that was sent to TORCH
- Jobs become self-contained — `pipeline continue` works even if the original CRTDL file is moved or deleted

Closes #242