### PR TITLE
Add CVE checking with govulncheck

### DIFF
--- a/.github/workflows/_vuln.yaml
+++ b/.github/workflows/_vuln.yaml
@@ -25,5 +25,8 @@ jobs:
           go-version: '1.26.1'
           cache: true
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
       - name: Run govulncheck
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        run: govulncheck ./...

--- a/.github/workflows/_vuln.yaml
+++ b/.github/workflows/_vuln.yaml
@@ -1,0 +1,29 @@
+name: Vulnerability Check
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version: '1.26.1'
+          cache: true
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/_vuln.yaml
+++ b/.github/workflows/_vuln.yaml
@@ -20,13 +20,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        env:
+          # renovate: datasource=github-releases depName=golang/vuln
+          GOVULNCHECK_VERSION: v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,11 @@ jobs:
       contents: read
       security-events: write
 
+  vuln:
+    name: Vulnerability Check
+    uses: ./.github/workflows/_vuln.yaml
+    secrets: inherit
+
   tests:
     name: Tests
     needs: [lint]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 PLATFORMS := linux darwin
 ARCHITECTURES := amd64 arm64
 
-.PHONY: all build build-all build-linux build-mac build-mac-arm build-windows build-windows-arm clean test test-unit test-integration test-contract coverage fmt vet install help release
+.PHONY: all build build-all build-linux build-mac build-mac-arm build-windows build-windows-arm clean test test-unit test-integration test-contract coverage fmt vet vuln install help release
 
 # Default target
 all: clean fmt vet test build
@@ -151,6 +151,15 @@ fmt:
 vet:
 	@echo "Running go vet..."
 	$(GOCMD) vet ./...
+
+## vuln: Run govulncheck for known vulnerabilities
+vuln:
+	@echo "Running govulncheck..."
+	@if command -v govulncheck > /dev/null; then \
+		govulncheck ./...; \
+	else \
+		echo "govulncheck not installed. Install with: go install golang.org/x/vuln/cmd/govulncheck@latest"; \
+	fi
 
 ## lint: Run golangci-lint (requires golangci-lint installed)
 lint:


### PR DESCRIPTION
## Summary
- Add Go dependency vulnerability scanning to the CI pipeline using the official `govulncheck` tool
- New reusable workflow `_vuln.yaml` follows existing patterns (SHA-pinned actions, harden-runner, minimal permissions)
- Runs in parallel with lint and CodeQL — does not block the test/release critical path
- Add `make vuln` target for local developer use

Closes #245