### PR TITLE
fix: restrict Renovate torch updates to stable and alpha releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,14 @@
       ],
       "versioning": "semver",
       "ignoreUnstable": false
+    },
+    {
+      "description": "Only allow stable releases and alpha pre-releases for torch (exclude test/dev tags)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/medizininformatik-initiative/torch"
+      ],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-alpha\\.\\d+)?$/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Adds `allowedVersions` regex to Renovate config for the torch Docker image
- Only permits stable releases (`X.Y.Z`) and alpha pre-releases (`X.Y.Z-alpha.N`)
- Excludes `test*`, `beta*`, `rc*`, and other unintended pre-release tags

## Context
Renovate was proposing `1.0.0-test4` instead of `1.0.0-alpha.18` because semver orders pre-release identifiers lexicographically (`"test" > "alpha"`). This caused PR #236 and the previously merged PR #220.

After merging, PR #236 should be closed — Renovate will then create a new PR for `alpha.18`.