### PR TITLE
feat(pipeline)!: require CRTDL as positional arg; decouple from InputType (closes #286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs_dir: "./jobs"
 ### Run a Pipeline
 
 ```bash
-aether pipeline start your-query.crtdl
+aether pipeline start your-crtdl.json
 ```
 
 ### Check Status

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -59,7 +59,7 @@ Examples:
   watch -n 5 aether job list
 
 Typical Workflow:
-  1. Start pipeline:  aether pipeline start query.crtdl
+  1. Start pipeline:  aether pipeline start crtdl.json
   2. List jobs:       aether job list
   3. Get job ID from list
   4. Check status:    aether pipeline status <job-id>`,

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -59,7 +59,7 @@ Examples:
   watch -n 5 aether job list
 
 Typical Workflow:
-  1. Start pipeline:  aether pipeline start /data
+  1. Start pipeline:  aether pipeline start query.crtdl
   2. List jobs:       aether job list
   3. Get job ID from list
   4. Check status:    aether pipeline status <job-id>`,

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -16,6 +16,8 @@ import (
 var (
 	noProgress     bool
 	localImportDir string // CLI flag for local import directory override
+	crtdlFile      string // CLI flag attaching a CRTDL to any job (issue #286)
+	allowHTTPCRTDL bool   // CLI flag acknowledging http_import + CRTDL semantic mismatch
 	// errPipelinePaused is returned when the pipeline pauses at a wait step
 	errPipelinePaused = errors.New("pipeline paused at wait step")
 )
@@ -45,7 +47,10 @@ Input can be a CRTDL file, local directory, HTTP URL, or TORCH result URL:
   • HTTP URL: downloads a single NDJSON file directly
   • Local directory: imports files from disk (via --dir flag or config)
 
-CRTDL file is required if the flattening step is enabled.
+CRTDL file is required if the flattening step is enabled. It can be attached
+either as the positional argument (for torch) or via --crtdl (for any import
+step). Combining http_import with a CRTDL requires --allow-http-crtdl since
+HTTP data may not match the CRTDL query.
 
 Examples:
   # Extract data using CRTDL query via TORCH
@@ -65,6 +70,13 @@ Examples:
 
   # Download from HTTP URL
   aether pipeline start https://example.com/fhir/Patient.ndjson
+
+  # HTTP import piped through flattening (acknowledges data/CRTDL mismatch)
+  aether pipeline start https://example.com/fhir/Patient.ndjson \
+      --crtdl query.crtdl --allow-http-crtdl
+
+  # Local import with CRTDL via flag (alternative to positional)
+  aether pipeline start --dir /path/to/data --crtdl query.crtdl
 
   # Direct TORCH URL (skip extraction, poll and download results)
   aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
@@ -150,6 +162,8 @@ func init() {
 
 	pipelineStartCmd.Flags().BoolVar(&noProgress, "no-progress", false, "Disable progress indicators")
 	pipelineStartCmd.Flags().StringVar(&localImportDir, "dir", "", "Directory for local import (overrides config)")
+	pipelineStartCmd.Flags().StringVar(&crtdlFile, "crtdl", "", "CRTDL file path (attach independently of input source; required for flattening with http_import/local_import)")
+	pipelineStartCmd.Flags().BoolVar(&allowHTTPCRTDL, "allow-http-crtdl", false, "Acknowledge that combining http_import with a CRTDL may not match the endpoint's data")
 }
 
 // validateImportStepMatch ensures the step name is compatible with the input type
@@ -343,16 +357,37 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	crtdlRequired := config.Pipeline.IsStepEnabled(models.StepFlattening) ||
 		config.Pipeline.IsStepEnabled(models.StepTorchImport)
 
+	// A CRTDL may be attached via --crtdl or via a positional CRTDL file
+	// (detected below). Resolve whether one is "provided at all" before
+	// per-step validation runs.
+	positionalIsCRTDL := false
+	if inputSource != "" {
+		if t, err := lib.DetectInputType(inputSource); err == nil && t == models.InputTypeCRTDL {
+			positionalIsCRTDL = true
+		}
+	}
+	crtdlProvided := crtdlFile != "" || positionalIsCRTDL
+
 	// Validate CRTDL requirement
-	if crtdlRequired && inputSource == "" {
-		return fmt.Errorf("CRTDL file required as positional argument when flattening or torch steps are enabled\n\nUsage: aether pipeline start <query.crtdl> [--dir /path/to/data]")
+	if crtdlRequired && !crtdlProvided {
+		return fmt.Errorf("CRTDL file required when flattening or torch steps are enabled\n\nProvide one via:\n  1. Positional arg (torch): aether pipeline start <query.crtdl>\n  2. --crtdl flag (http/local):  aether pipeline start <input> --crtdl <query.crtdl>")
 	}
 
 	// Validate local_import directory is configured when local_import step is enabled
 	if config.Pipeline.IsStepEnabled(models.StepLocalImport) && !config.Pipeline.IsStepEnabled(models.StepTorchImport) {
-		if config.Services.LocalImport.Dir == "" && inputSource == "" {
+		// For local_import, the positional arg is only a source dir when it's
+		// NOT a CRTDL. A CRTDL positional provides nothing for local_import's
+		// source dir requirement.
+		hasSourceDir := config.Services.LocalImport.Dir != "" || (inputSource != "" && !positionalIsCRTDL)
+		if !hasSourceDir {
 			return fmt.Errorf("local_import step enabled but no directory specified\n\nProvide directory via:\n  1. --dir flag: aether pipeline start [crtdl-file] --dir /path/to/data\n  2. Config file: services.local_import.dir in aether.yaml")
 		}
+	}
+
+	// Gate: http_import + CRTDL requires explicit acknowledgement that HTTP
+	// data may not semantically match the CRTDL query.
+	if crtdlFile != "" && config.Pipeline.IsStepEnabled(models.StepHttpImport) && !allowHTTPCRTDL {
+		return fmt.Errorf("combining http_import with a CRTDL requires --allow-http-crtdl\n\nThe HTTP endpoint's data may not match the CRTDL query.\nPass --allow-http-crtdl to acknowledge and proceed")
 	}
 
 	fmt.Println("Validating service connectivity...")
@@ -369,7 +404,7 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	logger := lib.NewLogger(logLevel)
 
 	logger.Info("Creating new pipeline job", "input", inputSource, "localImportDir", config.Services.LocalImport.Dir)
-	job, err := pipeline.CreateJob(inputSource, *config, logger)
+	job, err := pipeline.CreateJob(inputSource, crtdlFile, *config, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create job: %w", err)
 	}
@@ -545,7 +580,7 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Idempotent — reconciles state if the original `pipeline start` crashed
-	// between writing the prepared CRTDL and persisting the new InputSource.
+	// between writing the prepared CRTDL and persisting the new CRTDLPath.
 	if err := pipeline.PrepareCRTDL(job, logger); err != nil {
 		return fmt.Errorf("failed to prepare CRTDL: %w", err)
 	}

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -54,27 +54,27 @@ data may not match the CRTDL query.
 
 Examples:
   # Extract data using CRTDL query via TORCH
-  aether pipeline start query.crtdl
+  aether pipeline start crtdl.json
 
   # Local import with CRTDL for flattening (data dir from config)
-  aether pipeline start query.crtdl
+  aether pipeline start crtdl.json
 
   # Local import with CRTDL (data dir as positional)
-  aether pipeline start query.crtdl /path/to/fhir/data
+  aether pipeline start crtdl.json /path/to/fhir/data
 
   # Local import with CRTDL (data dir via flag)
-  aether pipeline start query.crtdl --dir /path/to/fhir/data
+  aether pipeline start crtdl.json --dir /path/to/fhir/data
 
   # HTTP import piped through flattening (acknowledges data/CRTDL mismatch)
-  aether pipeline start query.crtdl https://example.com/fhir/Patient.ndjson \
+  aether pipeline start crtdl.json https://example.com/fhir/Patient.ndjson \
       --allow-http-crtdl
 
   # Direct TORCH URL (skip extraction, poll and download results)
-  aether pipeline start query.crtdl \
+  aether pipeline start crtdl.json \
       "https://torch.example.com/fhir/extraction/result-123"
 
   # Start without progress indicators
-  aether pipeline start query.crtdl --no-progress`,
+  aether pipeline start crtdl.json --no-progress`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runPipelineStart,
 }

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -16,7 +16,6 @@ import (
 var (
 	noProgress     bool
 	localImportDir string // CLI flag for local import directory override
-	crtdlFile      string // CLI flag attaching a CRTDL to any job (issue #286)
 	allowHTTPCRTDL bool   // CLI flag acknowledging http_import + CRTDL semantic mismatch
 	// errPipelinePaused is returned when the pipeline pauses at a wait step
 	errPipelinePaused = errors.New("pipeline paused at wait step")
@@ -36,21 +35,22 @@ Available subcommands:
 
 // pipelineStartCmd represents the pipeline start command
 var pipelineStartCmd = &cobra.Command{
-	Use:   "start [input]",
+	Use:   "start <crtdl> [input]",
 	Short: "Start a new pipeline job",
 	Long: `Start a new Data Use Process pipeline job.
 
-Input can be a CRTDL file, local directory, HTTP URL, or TORCH result URL:
-  • CRTDL file: submits extraction to TORCH, then downloads results
-  • TORCH URL: polls an existing extraction and downloads results
-    (auto-detected when URL contains /fhir/extraction/ or /fhir/result/)
-  • HTTP URL: downloads a single NDJSON file directly
-  • Local directory: imports files from disk (via --dir flag or config)
+The CRTDL file is always required as the first positional argument. The
+optional second positional is the input source for the enabled import step:
+  • omitted (torch_import): CRTDL is submitted to TORCH for extraction
+  • omitted (local_import): data dir is read from --dir or config
+  • local directory path (local_import): files imported from disk
+  • HTTP(S) URL (http_import): single NDJSON file downloaded
+  • TORCH result URL (torch_import): auto-detected when the URL contains
+    /fhir/extraction/ or /fhir/result/; extraction is skipped and results
+    are polled directly
 
-CRTDL file is required if the flattening step is enabled. It can be attached
-either as the positional argument (for torch) or via --crtdl (for any import
-step). Combining http_import with a CRTDL requires --allow-http-crtdl since
-HTTP data may not match the CRTDL query.
+Combining http_import with a CRTDL requires --allow-http-crtdl since HTTP
+data may not match the CRTDL query.
 
 Examples:
   # Extract data using CRTDL query via TORCH
@@ -59,31 +59,23 @@ Examples:
   # Local import with CRTDL for flattening (data dir from config)
   aether pipeline start query.crtdl
 
-  # Local import with CRTDL for flattening (data dir via flag)
+  # Local import with CRTDL (data dir as positional)
+  aether pipeline start query.crtdl /path/to/fhir/data
+
+  # Local import with CRTDL (data dir via flag)
   aether pipeline start query.crtdl --dir /path/to/fhir/data
 
-  # Local import without flattening (uses config dir)
-  aether pipeline start
-
-  # Local import without flattening (uses flag dir)
-  aether pipeline start --dir /path/to/fhir/data
-
-  # Download from HTTP URL
-  aether pipeline start https://example.com/fhir/Patient.ndjson
-
   # HTTP import piped through flattening (acknowledges data/CRTDL mismatch)
-  aether pipeline start https://example.com/fhir/Patient.ndjson \
-      --crtdl query.crtdl --allow-http-crtdl
-
-  # Local import with CRTDL via flag (alternative to positional)
-  aether pipeline start --dir /path/to/data --crtdl query.crtdl
+  aether pipeline start query.crtdl https://example.com/fhir/Patient.ndjson \
+      --allow-http-crtdl
 
   # Direct TORCH URL (skip extraction, poll and download results)
-  aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+  aether pipeline start query.crtdl \
+      "https://torch.example.com/fhir/extraction/result-123"
 
   # Start without progress indicators
   aether pipeline start query.crtdl --no-progress`,
-	Args: cobra.MaximumNArgs(1),
+	Args: cobra.RangeArgs(1, 2),
 	RunE: runPipelineStart,
 }
 
@@ -162,7 +154,6 @@ func init() {
 
 	pipelineStartCmd.Flags().BoolVar(&noProgress, "no-progress", false, "Disable progress indicators")
 	pipelineStartCmd.Flags().StringVar(&localImportDir, "dir", "", "Directory for local import (overrides config)")
-	pipelineStartCmd.Flags().StringVar(&crtdlFile, "crtdl", "", "CRTDL file path (attach independently of input source; required for flattening with http_import/local_import)")
 	pipelineStartCmd.Flags().BoolVar(&allowHTTPCRTDL, "allow-http-crtdl", false, "Acknowledge that combining http_import with a CRTDL may not match the endpoint's data")
 }
 
@@ -337,10 +328,18 @@ func executeStep(job *models.PipelineJob, stepName models.StepName, config *mode
 }
 
 func runPipelineStart(cmd *cobra.Command, args []string) error {
-	// Get positional argument if provided
+	// First positional is always the CRTDL; second (optional) is the input
+	// source for the enabled import step.
+	crtdlPath := args[0]
 	var inputSource string
-	if len(args) > 0 {
-		inputSource = args[0]
+	if len(args) > 1 {
+		inputSource = args[1]
+	}
+
+	if t, err := lib.DetectInputType(crtdlPath); err != nil {
+		return fmt.Errorf("invalid CRTDL argument %q: %w", crtdlPath, err)
+	} else if t != models.InputTypeCRTDL {
+		return fmt.Errorf("first argument must be a CRTDL file, got %s: %q", t, crtdlPath)
 	}
 
 	config, err := services.LoadConfig(cfgFile)
@@ -353,40 +352,17 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 		config.Services.LocalImport.Dir = localImportDir
 	}
 
-	// Determine if CRTDL is required based on enabled steps
-	crtdlRequired := config.Pipeline.IsStepEnabled(models.StepFlattening) ||
-		config.Pipeline.IsStepEnabled(models.StepTorchImport)
-
-	// A CRTDL may be attached via --crtdl or via a positional CRTDL file
-	// (detected below). Resolve whether one is "provided at all" before
-	// per-step validation runs.
-	positionalIsCRTDL := false
-	if inputSource != "" {
-		if t, err := lib.DetectInputType(inputSource); err == nil && t == models.InputTypeCRTDL {
-			positionalIsCRTDL = true
-		}
-	}
-	crtdlProvided := crtdlFile != "" || positionalIsCRTDL
-
-	// Validate CRTDL requirement
-	if crtdlRequired && !crtdlProvided {
-		return fmt.Errorf("CRTDL file required when flattening or torch steps are enabled\n\nProvide one via:\n  1. Positional arg (torch): aether pipeline start <query.crtdl>\n  2. --crtdl flag (http/local):  aether pipeline start <input> --crtdl <query.crtdl>")
-	}
-
 	// Validate local_import directory is configured when local_import step is enabled
 	if config.Pipeline.IsStepEnabled(models.StepLocalImport) && !config.Pipeline.IsStepEnabled(models.StepTorchImport) {
-		// For local_import, the positional arg is only a source dir when it's
-		// NOT a CRTDL. A CRTDL positional provides nothing for local_import's
-		// source dir requirement.
-		hasSourceDir := config.Services.LocalImport.Dir != "" || (inputSource != "" && !positionalIsCRTDL)
+		hasSourceDir := config.Services.LocalImport.Dir != "" || inputSource != ""
 		if !hasSourceDir {
-			return fmt.Errorf("local_import step enabled but no directory specified\n\nProvide directory via:\n  1. --dir flag: aether pipeline start [crtdl-file] --dir /path/to/data\n  2. Config file: services.local_import.dir in aether.yaml")
+			return fmt.Errorf("local_import step enabled but no directory specified\n\nProvide directory via:\n  1. Positional: aether pipeline start <crtdl> /path/to/data\n  2. --dir flag: aether pipeline start <crtdl> --dir /path/to/data\n  3. Config file: services.local_import.dir in aether.yaml")
 		}
 	}
 
 	// Gate: http_import + CRTDL requires explicit acknowledgement that HTTP
 	// data may not semantically match the CRTDL query.
-	if crtdlFile != "" && config.Pipeline.IsStepEnabled(models.StepHttpImport) && !allowHTTPCRTDL {
+	if config.Pipeline.IsStepEnabled(models.StepHttpImport) && !allowHTTPCRTDL {
 		return fmt.Errorf("combining http_import with a CRTDL requires --allow-http-crtdl\n\nThe HTTP endpoint's data may not match the CRTDL query.\nPass --allow-http-crtdl to acknowledge and proceed")
 	}
 
@@ -403,8 +379,8 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	}
 	logger := lib.NewLogger(logLevel)
 
-	logger.Info("Creating new pipeline job", "input", inputSource, "localImportDir", config.Services.LocalImport.Dir)
-	job, err := pipeline.CreateJob(inputSource, crtdlFile, *config, logger)
+	logger.Info("Creating new pipeline job", "crtdl", crtdlPath, "input", inputSource, "localImportDir", config.Services.LocalImport.Dir)
+	job, err := pipeline.CreateJob(inputSource, crtdlPath, *config, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create job: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ Quick Start:
        cp config/aether.example.yaml aether.yaml
 
   2. Start a pipeline:
-       aether pipeline start query.crtdl
+       aether pipeline start crtdl.json
 
   3. Check status:
        aether pipeline status <job-id>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ Quick Start:
        cp config/aether.example.yaml aether.yaml
 
   2. Start a pipeline:
-       aether pipeline start /data/torch/output
+       aether pipeline start query.crtdl
 
   3. Check status:
        aether pipeline status <job-id>

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -20,15 +20,21 @@ aether [global-options] <command> [command-options]
 Start a new pipeline job.
 
 ```bash
-aether pipeline start [input] [options]
+aether pipeline start <crtdl> [input] [options]
 ```
 
 **Arguments:**
-- `[input]` - CRTDL file, TORCH URL, or HTTP URL. CRTDL file required if flattening enabled. TORCH URLs (containing `/fhir/extraction/` or `/fhir/result/`) skip extraction submission.
+- `<crtdl>` - CRTDL file path. Required for every pipeline run.
+- `[input]` - Optional import-step input:
+  - omitted: torch_import submits the CRTDL; local_import uses `--dir`/config
+  - local directory (local_import)
+  - HTTP(S) URL (http_import)
+  - TORCH result URL (torch_import; auto-detected from URL shape)
 
 **Options:**
 - `--no-progress` - Disable progress indicators
 - `--dir PATH` - Directory for local import (overrides config)
+- `--allow-http-crtdl` - Acknowledge that HTTP data may not match the CRTDL query (required when `http_import` is enabled)
 
 **Examples:**
 ```bash
@@ -36,19 +42,16 @@ aether pipeline start [input] [options]
 aether pipeline start query.crtdl
 
 # Direct TORCH URL (skip extraction, poll and download results)
-aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+aether pipeline start query.crtdl "https://torch.example.com/fhir/extraction/result-123"
 
-# Local import with CRTDL for flattening
+# Local import with CRTDL for flattening (dir from flag)
 aether pipeline start query.crtdl --dir /path/to/data
 
-# Local import without CRTDL (uses config directory)
-aether pipeline start
+# Local import with CRTDL for flattening (dir as positional)
+aether pipeline start query.crtdl /path/to/data
 
-# Local import with directory override
-aether pipeline start --dir /path/to/data
-
-# HTTP download (single file)
-aether pipeline start https://example.com/fhir/data.ndjson
+# HTTP download piped through flattening
+aether pipeline start query.crtdl https://example.com/fhir/data.ndjson --allow-http-crtdl
 
 # Disable progress bars
 aether pipeline start query.crtdl --no-progress

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -20,11 +20,11 @@ aether [global-options] <command> [command-options]
 Start a new pipeline job.
 
 ```bash
-aether pipeline start <crtdl> [input] [options]
+aether pipeline start .json> [input] [options]
 ```
 
 **Arguments:**
-- `<crtdl>` - CRTDL file path. Required for every pipeline run.
+- `.json>` - CRTDL file path. Required for every pipeline run.
 - `[input]` - Optional import-step input:
   - omitted: torch_import submits the CRTDL; local_import uses `--dir`/config
   - local directory (local_import)
@@ -34,27 +34,27 @@ aether pipeline start <crtdl> [input] [options]
 **Options:**
 - `--no-progress` - Disable progress indicators
 - `--dir PATH` - Directory for local import (overrides config)
-- `--allow-http-crtdl` - Acknowledge that HTTP data may not match the CRTDL query (required when `http_import` is enabled)
+- `--allow-http.json` - Acknowledge that HTTP data may not match the CRTDL query (required when `http_import` is enabled)
 
 **Examples:**
 ```bash
 # TORCH extraction with CRTDL
-aether pipeline start query.crtdl
+aether pipeline start crtdl.json
 
 # Direct TORCH URL (skip extraction, poll and download results)
-aether pipeline start query.crtdl "https://torch.example.com/fhir/extraction/result-123"
+aether pipeline start crtdl.json "https://torch.example.com/fhir/extraction/result-123"
 
 # Local import with CRTDL for flattening (dir from flag)
-aether pipeline start query.crtdl --dir /path/to/data
+aether pipeline start crtdl.json --dir /path/to/data
 
 # Local import with CRTDL for flattening (dir as positional)
-aether pipeline start query.crtdl /path/to/data
+aether pipeline start crtdl.json /path/to/data
 
 # HTTP download piped through flattening
-aether pipeline start query.crtdl https://example.com/fhir/data.ndjson --allow-http-crtdl
+aether pipeline start crtdl.json https://example.com/fhir/data.ndjson --allow-http.json
 
 # Disable progress bars
-aether pipeline start query.crtdl --no-progress
+aether pipeline start crtdl.json --no-progress
 ```
 
 ### aether pipeline status

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -48,7 +48,7 @@ services:
   local_import:
     dir: string
 
-  crtdl_preprocessing:
+ .json_preprocessing:
     enabled: boolean                       # default: false
     enrichments_path: string               # Path to external JSON file
     enrichments:                           # Inline enrichment rules
@@ -240,7 +240,7 @@ Enriches CRTDL documents with additional attributes before sending to TORCH. Thi
 
 ```yaml
 services:
-  crtdl_preprocessing:
+ .json_preprocessing:
     enabled: true
     enrichments:
       - group_reference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert"

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -199,7 +199,7 @@ This enables:
 ### TORCH Integration
 
 ```
-User Command (with .crtdl file)
+User Command (with .json file)
     ↓
 Aether (torch import step) → TORCH Server
     ├─→ Submit CRTDL query

--- a/docs/development/coding-guidelines.md
+++ b/docs/development/coding-guidelines.md
@@ -453,7 +453,7 @@ func ProcessEntries(entries []Entry) []Entry {
 
 ```go
 // ✅ Good
-if err := validateCRTDL(crtdl); err != nil {
+if err := validateCRTDL.json); err != nil {
     return fmt.Errorf("invalid CRTDL query: %w", err)
 }
 
@@ -490,7 +490,7 @@ func (e *ValidationError) Error() string {
 // Usage
 if !IsValidInput(input) {
     return &ValidationError{
-        Field:   "crtdl",
+        Field:   .json",
         Message: "cohort criteria missing",
     }
 }

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -270,7 +270,7 @@ go test -race ./...
 
 ```bash
 # Enable debug logging
-AETHER_LOG_LEVEL=debug ./bin/aether pipeline start test.crtdl
+AETHER_LOG_LEVEL=debug ./bin/aether pipeline start test.json
 
 # Run with CPU profile
 go test -cpuprofile=cpu.prof ./...

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -102,7 +102,7 @@ for _, tc := range testCases {
 // Define interface-based mock
 type mockTORCHClient struct{}
 
-func (m *mockTORCHClient) Extract(ctx context.Context, crtdl string) (io.Reader, error) {
+func (m *mockTORCHClient) Extract(ctx context.Context,.json string) (io.Reader, error) {
     return strings.NewReader("sample data"), nil
 }
 
@@ -166,7 +166,7 @@ func TestTORCHIntegration(t *testing.T) {
     client := services.NewTORCHClient("http://localhost:8080")
 
     // Test with real CRTDL query
-    result, err := client.Extract(context.Background(), "queries/test.crtdl")
+    result, err := client.Extract(context.Background(), "queries/test.json.json")
     assert.NoError(t, err)
     assert.NotNil(t, result)
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -29,7 +29,7 @@ Replace URLs and credentials with your actual server details.
 ## 2. Run a Pipeline
 
 ```bash
-aether pipeline start your-query.crtdl
+aether pipeline start your-crtdl.json
 ```
 
 Aether will:

--- a/docs/guides/dimp.md
+++ b/docs/guides/dimp.md
@@ -28,7 +28,7 @@ jobs_dir: "./jobs"
 ## Running Pseudonymization
 
 ```bash
-aether pipeline start your-query.crtdl
+aether pipeline start your-crtdl.json
 ```
 
 Aether will:
@@ -54,7 +54,7 @@ CRTDL preprocessing automatically enriches your CRTDL with the required attribut
 
 ```yaml
 services:
-  crtdl_preprocessing:
+ .json_preprocessing:
     enabled: true
     enrichments:
       - group_reference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert"
@@ -71,7 +71,7 @@ services:
 
 The `create_if_not_exists` option creates the group in the CRTDL if it doesn't already exist. This is useful for groups like `PatientPseudonymisiert` that may not be part of the original research query but are needed by DIMP.
 
-Enrichment rules can also be loaded from an external JSON file. See [CRTDL Preprocessing](../api-reference/config-reference.md#crtdl-preprocessing) in the configuration reference for details.
+Enrichment rules can also be loaded from an external JSON file. See [CRTDL Preprocessing](../api-reference/config-reference.md.json-preprocessing) in the configuration reference for details.
 
 ## Large Bundles
 

--- a/docs/guides/steps/local-import.md
+++ b/docs/guides/steps/local-import.md
@@ -24,7 +24,7 @@ aether pipeline start
 aether pipeline start --dir /other/path
 
 # With CRTDL for flattening
-aether pipeline start query.crtdl --dir /path/to/data
+aether pipeline start crtdl.json --dir /path/to/data
 ```
 
 ## Configuration Options

--- a/docs/guides/steps/torch-import.md
+++ b/docs/guides/steps/torch-import.md
@@ -36,7 +36,7 @@ pipeline:
 ### With CRTDL file
 
 ```bash
-aether pipeline start query.crtdl
+aether pipeline start crtdl.json
 ```
 
 ### With TORCH URL

--- a/docs/guides/steps/wait.md
+++ b/docs/guides/steps/wait.md
@@ -29,7 +29,7 @@ pipeline:
 
 ```bash
 # Pipeline pauses automatically at wait step
-aether pipeline start query.crtdl
+aether pipeline start crtdl.json
 
 # Check status - shows "waiting"
 aether pipeline status <job-id>

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -29,7 +29,7 @@ pipeline:
 ## Running a TORCH Query
 
 ```bash
-aether pipeline start your-query.crtdl
+aether pipeline start your-crtdl.json
 ```
 
 Aether will show progress as it:
@@ -117,7 +117,7 @@ The `extraction_timeout` and polling interval settings also apply.
 
 | | CRTDL | TORCH URL | HTTP URL |
 |---|---|---|---|
-| Input example | `query.crtdl` | `https://torch/fhir/result/123` | `https://example.com/data.ndjson` |
+| Input example | `crtdl.json` | `https://torch/fhir/result/123` | `https://example.com/data.ndjson` |
 | Submits extraction | Yes | No | No |
 | Polls for completion | Yes | Yes | No |
 | Downloads multiple files | Yes | Yes | No (single file) |

--- a/internal/lib/validation.go
+++ b/internal/lib/validation.go
@@ -98,13 +98,13 @@ func DetectInputType(inputSource string) (models.InputType, error) {
 		return models.InputTypeHTTP, nil
 	}
 
-	if strings.HasSuffix(inputSource, ".crtdl") || strings.HasSuffix(inputSource, ".json") {
+	if strings.HasSuffix(inputSource, ".json") {
 		isCRTDL, _ := IsCRTDLFileWithHint(inputSource)
 		if isCRTDL {
 			return models.InputTypeCRTDL, nil
 		}
-		// If it's a JSON/CRTDL file but not valid CRTDL, default to local type
-		// CRTDL validation errors will be caught during job creation, not during detection
+		// JSON file that isn't a valid CRTDL — fall through to local type.
+		// CRTDL validation errors are surfaced later during job creation.
 		return models.InputTypeLocal, nil
 	}
 

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -9,6 +9,7 @@ type PipelineJob struct {
 	UpdatedAt          time.Time      `json:"updated_at"`
 	InputSource        string         `json:"input_source"`                   // Local path, HTTP(S) URL, or CRTDL file
 	InputType          InputType      `json:"input_type"`                     // "local_directory" | "http_url" | "crtdl_file" | "torch_result_url"
+	CRTDLPath          string         `json:"crtdl_path,omitempty"`           // Optional CRTDL file, decoupled from InputSource (see issue #286)
 	TORCHExtractionURL string         `json:"torch_extraction_url,omitempty"` // Content-Location URL for TORCH polling/resume
 	CurrentStep        string         `json:"current_step"`                   // Current pipeline step
 	Status             JobStatus      `json:"status"`                         // Job execution status

--- a/internal/models/validation.go
+++ b/internal/models/validation.go
@@ -19,10 +19,11 @@ func (j *PipelineJob) Validate() error {
 		return err
 	}
 
-	// Validate InputSource is not empty (unless using local_import with config directory)
+	// Validate InputSource is not empty (unless a CRTDL is attached, or using
+	// local_import with a config directory).
 	if j.InputSource == "" {
-		// Allow empty InputSource for local_import when config directory is set
-		if j.InputType != InputTypeLocal || j.Config.Services.LocalImport.Dir == "" {
+		localFromConfig := j.InputType == InputTypeLocal && j.Config.Services.LocalImport.Dir != ""
+		if j.CRTDLPath == "" && !localFromConfig {
 			return errors.New("input_source is required")
 		}
 	}

--- a/internal/pipeline/crtdl_prep.go
+++ b/internal/pipeline/crtdl_prep.go
@@ -12,21 +12,22 @@ import (
 )
 
 // PrepareCRTDL ensures every pipeline step uses the same effective CRTDL.
-// For CRTDL inputs it copies (or enriches) the file into the job directory
-// and repoints job.InputSource at the saved file. The call is a no-op for
-// non-CRTDL inputs and idempotent when InputSource already lives in jobDir.
+// When a CRTDL is attached to the job (via positional CRTDL input or --crtdl)
+// it copies (or enriches) the file into the job directory and repoints
+// job.CRTDLPath at the saved file. The call is a no-op when no CRTDL is
+// attached and idempotent when CRTDLPath already lives in jobDir.
 //
 // With CRTDLPreprocessing enabled and at least one enrichment configured,
 // the result is written as enriched-crtdl.json. Otherwise the original is
 // copied verbatim as crtdl.json.
 func PrepareCRTDL(job *models.PipelineJob, logger *lib.Logger) error {
-	if job.InputType != models.InputTypeCRTDL {
+	if job.CRTDLPath == "" {
 		return nil
 	}
 
 	jobDir := services.GetJobDir(job.Config.JobsDir, job.JobID)
-	if isPreparedCRTDLPath(job.InputSource, jobDir) {
-		logger.Debug("CRTDL already prepared, skipping", "path", job.InputSource)
+	if isPreparedCRTDLPath(job.CRTDLPath, jobDir) {
+		logger.Debug("CRTDL already prepared, skipping", "path", job.CRTDLPath)
 		return nil
 	}
 
@@ -35,9 +36,9 @@ func PrepareCRTDL(job *models.PipelineJob, logger *lib.Logger) error {
 		return copyOriginalCRTDL(job, jobDir, logger)
 	}
 
-	logger.Info("CRTDL preprocessing enabled, enriching CRTDL", "source", job.InputSource)
+	logger.Info("CRTDL preprocessing enabled, enriching CRTDL", "source", job.CRTDLPath)
 
-	originalDoc, err := services.ParseCRTDL(job.InputSource)
+	originalDoc, err := services.ParseCRTDL(job.CRTDLPath)
 	if err != nil {
 		return fmt.Errorf("failed to parse CRTDL: %w", err)
 	}
@@ -72,9 +73,9 @@ func PrepareCRTDL(job *models.PipelineJob, logger *lib.Logger) error {
 	return saveCRTDL(job, jobDir, "enriched-crtdl.json", enrichedContent, logger)
 }
 
-// copyOriginalCRTDL copies job.InputSource verbatim into jobDir/crtdl.json.
+// copyOriginalCRTDL copies job.CRTDLPath verbatim into jobDir/crtdl.json.
 func copyOriginalCRTDL(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	content, err := os.ReadFile(job.InputSource)
+	content, err := os.ReadFile(job.CRTDLPath)
 	if err != nil {
 		return fmt.Errorf("failed to read CRTDL file: %w", err)
 	}
@@ -95,13 +96,13 @@ func isPreparedCRTDLPath(path, jobDir string) bool {
 	return false
 }
 
-// saveCRTDL writes content to jobDir/filename and repoints job.InputSource.
+// saveCRTDL writes content to jobDir/filename and repoints job.CRTDLPath.
 func saveCRTDL(job *models.PipelineJob, jobDir, filename string, content []byte, logger *lib.Logger) error {
 	crtdlPath := filepath.Join(jobDir, filename)
 	if err := os.WriteFile(crtdlPath, content, 0644); err != nil {
 		return fmt.Errorf("failed to save CRTDL to job directory: %w", err)
 	}
-	job.InputSource = crtdlPath
+	job.CRTDLPath = crtdlPath
 	logger.Info("CRTDL saved to job directory", "path", crtdlPath)
 	return nil
 }

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -47,16 +47,17 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		return err
 	}
 
-	// CRTDL file is required for flattening
-	if job.InputType != models.InputTypeCRTDL {
-		err := fmt.Errorf("flattening step requires CRTDL input (got %s)", job.InputType)
+	// CRTDL file is required for flattening. It may come from the positional
+	// arg (for torch) or from --crtdl (for http_import/local_import).
+	if job.CRTDLPath == "" {
+		err := fmt.Errorf("flattening step requires a CRTDL file: pass one as the positional input or via --crtdl")
 		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
 		recordStepError(step, err, models.ErrorTypeNonTransient)
 		return err
 	}
 
 	// Load CRTDL document
-	crtdlPath := job.InputSource
+	crtdlPath := job.CRTDLPath
 	logger.Debug("Loading CRTDL file", "path", crtdlPath)
 	crtdl, err := services.ParseCRTDL(crtdlPath)
 	if err != nil {

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -150,7 +150,7 @@ func failImportStep(job *models.PipelineJob, err error, errorType models.ErrorTy
 func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClient *services.HTTPClient, logger *lib.Logger, showProgress bool, compress bool, compressionLevel string) ([]models.FHIRDataFile, error) {
 	torchClient := services.NewTORCHClient(job.Config.Services.TORCH, httpClient, logger)
 
-	extractionURL, err := torchClient.SubmitExtraction(job.InputSource)
+	extractionURL, err := torchClient.SubmitExtraction(job.CRTDLPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to submit TORCH extraction: %w", err)
 	}

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -66,21 +66,9 @@ func ExecuteImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *
 		}
 
 	case models.StepTorchImport:
-		// TORCH import requires CRTDL or TORCH URL
-		switch job.InputType {
-		case models.InputTypeCRTDL:
-			// Validate CRTDL source
-			if err := services.ValidateImportSource(job.InputSource, models.InputTypeCRTDL); err != nil {
-				updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
-				lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
-				return &updatedJob, err
-			}
-
-			logger.Info("Extracting data from TORCH using CRTDL", "source", job.InputSource, "compress", compress)
-			importedFiles, err = executeTORCHExtraction(job, importDir, httpClient, logger, showProgress, compress, compressionLevel)
-
-		case models.InputTypeTORCHURL:
-			// Validate TORCH URL
+		// TORCH result URL: poll directly, skip extraction submission.
+		// Otherwise: submit the attached CRTDL for extraction.
+		if job.InputType == models.InputTypeTORCHURL {
 			if err := services.ValidateImportSource(job.InputSource, models.InputTypeTORCHURL); err != nil {
 				updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
 				lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
@@ -89,9 +77,15 @@ func ExecuteImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *
 
 			logger.Info("Downloading from TORCH result URL", "source", job.InputSource, "compress", compress)
 			importedFiles, err = executeTORCHDownload(job, importDir, httpClient, logger, showProgress, compress, compressionLevel)
+		} else {
+			if err := services.ValidateImportSource(job.CRTDLPath, models.InputTypeCRTDL); err != nil {
+				updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
+				lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
+				return &updatedJob, err
+			}
 
-		default:
-			err = fmt.Errorf("torch import requires CRTDL file or TORCH URL, got input type: %s", job.InputType)
+			logger.Info("Extracting data from TORCH using CRTDL", "crtdl", job.CRTDLPath, "compress", compress)
+			importedFiles, err = executeTORCHExtraction(job, importDir, httpClient, logger, showProgress, compress, compressionLevel)
 		}
 
 	default:
@@ -101,7 +95,7 @@ func ExecuteImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *
 	// Handle errors
 	if err != nil {
 		// Classify error type
-		errorType := classifyImportError(err, job.InputType)
+		errorType := classifyImportError(err, currentStep)
 		updatedJob := failImportStep(job, err, errorType, 0)
 		lib.LogStepFailed(logger, string(currentStep), job.JobID, err, errorType == models.ErrorTypeTransient)
 		return &updatedJob, err
@@ -145,7 +139,7 @@ func failImportStep(job *models.PipelineJob, err error, errorType models.ErrorTy
 
 // executeTORCHExtraction submits the (already prepared) CRTDL to TORCH,
 // polls until extraction completes, and downloads the resulting NDJSON
-// files. PrepareCRTDL ensures job.InputSource points at the effective CRTDL
+// files. PrepareCRTDL ensures job.CRTDLPath points at the effective CRTDL
 // shared by every downstream pipeline step.
 func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClient *services.HTTPClient, logger *lib.Logger, showProgress bool, compress bool, compressionLevel string) ([]models.FHIRDataFile, error) {
 	torchClient := services.NewTORCHClient(job.Config.Services.TORCH, httpClient, logger)
@@ -202,7 +196,7 @@ func executeTORCHDownload(job *models.PipelineJob, importDir string, httpClient 
 }
 
 // classifyImportError determines if an import error is transient or non-transient
-func classifyImportError(err error, inputType models.InputType) models.ErrorType {
+func classifyImportError(err error, step models.StepName) models.ErrorType {
 	if err == nil {
 		return models.ErrorTypeNonTransient
 	}
@@ -212,8 +206,8 @@ func classifyImportError(err error, inputType models.InputType) models.ErrorType
 		return torchErr.ErrorType
 	}
 
-	// For HTTP downloads and TORCH operations, network errors are transient
-	if inputType == models.InputTypeHTTP || inputType == models.InputTypeCRTDL || inputType == models.InputTypeTORCHURL {
+	// Network-capable steps: network errors are transient
+	if step == models.StepHttpImport || step == models.StepTorchImport {
 		if lib.IsNetworkError(err) {
 			return models.ErrorTypeTransient
 		}

--- a/internal/pipeline/job.go
+++ b/internal/pipeline/job.go
@@ -9,14 +9,23 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
-// CreateJob initializes a new pipeline job
-// inputSource can be:
-//   - CRTDL file path (required if flattening or torch enabled)
-//   - HTTP(S) URL (for http_import)
-//   - Empty string (for local_import using config.Services.LocalImport.Dir)
+// CreateJob initializes a new pipeline job.
 //
-// Returns the created job with generated UUID and initialized steps
-func CreateJob(inputSource string, config models.ProjectConfig, logger *lib.Logger) (*models.PipelineJob, error) {
+// inputSource can be:
+//   - CRTDL file path (required if torch_import enabled)
+//   - HTTP(S) URL (for http_import)
+//   - TORCH result URL (auto-detected)
+//   - Local directory path (for local_import)
+//   - Empty string (local_import uses config.Services.LocalImport.Dir)
+//
+// crtdlPath attaches a CRTDL to the job independently of inputSource, so
+// http_import and local_import can feed flattening. For torch jobs where the
+// positional input already IS the CRTDL, pass "" — CreateJob backfills it.
+// A non-empty crtdlPath that conflicts with a CRTDL positional input is an
+// error.
+//
+// Returns the created job with generated UUID and initialized steps.
+func CreateJob(inputSource string, crtdlPath string, config models.ProjectConfig, logger *lib.Logger) (*models.PipelineJob, error) {
 	// Generate unique job ID with human-readable timestamp prefix
 	jobID := models.GenerateJobID()
 
@@ -37,12 +46,23 @@ func CreateJob(inputSource string, config models.ProjectConfig, logger *lib.Logg
 		logger.Info("Detected input type", "type", inputType, "source", inputSource)
 	}
 
-	// Validate CRTDL syntax if input is CRTDL file
+	// Resolve effective CRTDL path: positional-CRTDL provides one implicitly;
+	// an explicit crtdlPath flag provides one for any input type. Conflicting
+	// values (both set, different paths) are rejected.
+	effectiveCRTDL := crtdlPath
 	if inputType == models.InputTypeCRTDL {
-		if err := lib.ValidateCRTDLSyntax(inputSource); err != nil {
+		if effectiveCRTDL != "" && effectiveCRTDL != inputSource {
+			return nil, fmt.Errorf("conflicting CRTDL sources: positional arg %q and --crtdl %q differ", inputSource, effectiveCRTDL)
+		}
+		effectiveCRTDL = inputSource
+	}
+
+	// Validate CRTDL syntax whenever one is attached (regardless of source)
+	if effectiveCRTDL != "" {
+		if err := lib.ValidateCRTDLSyntax(effectiveCRTDL); err != nil {
 			return nil, fmt.Errorf("CRTDL validation failed: %w", err)
 		}
-		logger.Info("CRTDL syntax validation passed")
+		logger.Info("CRTDL syntax validation passed", "path", effectiveCRTDL)
 	}
 
 	// Determine initial step based on enabled import step in config
@@ -74,6 +94,7 @@ func CreateJob(inputSource string, config models.ProjectConfig, logger *lib.Logg
 		UpdatedAt:          time.Now(),
 		InputSource:        inputSource,
 		InputType:          inputType,
+		CRTDLPath:          effectiveCRTDL,
 		TORCHExtractionURL: "",                  // Will be set during TORCH extraction if applicable
 		CurrentStep:        string(initialStep), // Set based on input type
 		Status:             models.JobStatusPending,

--- a/internal/pipeline/job.go
+++ b/internal/pipeline/job.go
@@ -11,18 +11,16 @@ import (
 
 // CreateJob initializes a new pipeline job.
 //
-// inputSource can be:
-//   - CRTDL file path (required if torch_import enabled)
+// crtdlPath is the CRTDL file attached to the job; every job carries a CRTDL
+// so it is normally non-empty (the "" case is kept only for tests that
+// exercise non-CRTDL paths).
+//
+// inputSource is the import-step input:
 //   - HTTP(S) URL (for http_import)
 //   - TORCH result URL (auto-detected)
 //   - Local directory path (for local_import)
-//   - Empty string (local_import uses config.Services.LocalImport.Dir)
-//
-// crtdlPath attaches a CRTDL to the job independently of inputSource, so
-// http_import and local_import can feed flattening. For torch jobs where the
-// positional input already IS the CRTDL, pass "" — CreateJob backfills it.
-// A non-empty crtdlPath that conflicts with a CRTDL positional input is an
-// error.
+//   - Empty string: torch_import submits the CRTDL to TORCH, or local_import
+//     falls back to config.Services.LocalImport.Dir
 //
 // Returns the created job with generated UUID and initialized steps.
 func CreateJob(inputSource string, crtdlPath string, config models.ProjectConfig, logger *lib.Logger) (*models.PipelineJob, error) {
@@ -34,7 +32,8 @@ func CreateJob(inputSource string, crtdlPath string, config models.ProjectConfig
 	var err error
 
 	if inputSource == "" {
-		// No input source provided - local_import will use config.Services.LocalImport.Dir
+		// No input source provided - torch_import submits the CRTDL, or
+		// local_import uses config.Services.LocalImport.Dir.
 		inputType = models.InputTypeLocal
 		logger.Info("No input source provided, using local import from config", "dir", config.Services.LocalImport.Dir)
 	} else {
@@ -46,23 +45,12 @@ func CreateJob(inputSource string, crtdlPath string, config models.ProjectConfig
 		logger.Info("Detected input type", "type", inputType, "source", inputSource)
 	}
 
-	// Resolve effective CRTDL path: positional-CRTDL provides one implicitly;
-	// an explicit crtdlPath flag provides one for any input type. Conflicting
-	// values (both set, different paths) are rejected.
-	effectiveCRTDL := crtdlPath
-	if inputType == models.InputTypeCRTDL {
-		if effectiveCRTDL != "" && effectiveCRTDL != inputSource {
-			return nil, fmt.Errorf("conflicting CRTDL sources: positional arg %q and --crtdl %q differ", inputSource, effectiveCRTDL)
-		}
-		effectiveCRTDL = inputSource
-	}
-
-	// Validate CRTDL syntax whenever one is attached (regardless of source)
-	if effectiveCRTDL != "" {
-		if err := lib.ValidateCRTDLSyntax(effectiveCRTDL); err != nil {
+	// Validate CRTDL syntax whenever one is attached
+	if crtdlPath != "" {
+		if err := lib.ValidateCRTDLSyntax(crtdlPath); err != nil {
 			return nil, fmt.Errorf("CRTDL validation failed: %w", err)
 		}
-		logger.Info("CRTDL syntax validation passed", "path", effectiveCRTDL)
+		logger.Info("CRTDL syntax validation passed", "path", crtdlPath)
 	}
 
 	// Determine initial step based on enabled import step in config
@@ -94,7 +82,7 @@ func CreateJob(inputSource string, crtdlPath string, config models.ProjectConfig
 		UpdatedAt:          time.Now(),
 		InputSource:        inputSource,
 		InputType:          inputType,
-		CRTDLPath:          effectiveCRTDL,
+		CRTDLPath:          crtdlPath,
 		TORCHExtractionURL: "",                  // Will be set during TORCH extraction if applicable
 		CurrentStep:        string(initialStep), // Set based on input type
 		Status:             models.JobStatusPending,

--- a/internal/services/crtdl_parser.go
+++ b/internal/services/crtdl_parser.go
@@ -106,8 +106,8 @@ func GetMustHaveAttributes(group *models.AttributeGroup) []models.Attribute {
 	return mustHave
 }
 
-// IsCRTDLFile checks if a file path looks like a CRTDL file
-// CRTDL files typically have .crtdl extension
+// IsCRTDLFile checks if a file path looks like a CRTDL file by extension.
+// CRTDL files use the .json extension.
 func IsCRTDLFile(path string) bool {
-	return len(path) > 6 && path[len(path)-6:] == ".crtdl"
+	return len(path) > 5 && path[len(path)-5:] == ".json"
 }

--- a/internal/services/importer.go
+++ b/internal/services/importer.go
@@ -26,8 +26,8 @@ func ImportFromLocalDirectory(sourcePath string, destinationDir string, logger *
 	if !sourceInfo.IsDir() {
 		fileExt := strings.ToLower(filepath.Ext(sourcePath))
 		switch fileExt {
-		case ".json", ".crtdl":
-			return nil, fmt.Errorf("source path is a JSON/CRTDL file, not a directory: %s. For CRTDL input, the file should have been detected as InputTypeCRTDL. This suggests the CRTDL file is invalid or missing required fields", sourcePath)
+		case ".json":
+			return nil, fmt.Errorf("source path is a JSON file, not a directory: %s. For CRTDL input, the file should have been detected as InputTypeCRTDL. This suggests the CRTDL file is invalid or missing required fields", sourcePath)
 		default:
 			return nil, fmt.Errorf("source path is not a directory: %s", sourcePath)
 		}
@@ -189,8 +189,8 @@ func ValidateImportSource(sourcePath string, inputType models.InputType) error {
 			fileExt := strings.ToLower(filepath.Ext(sourcePath))
 			var hint string
 			switch fileExt {
-			case ".json", ".crtdl":
-				hint = "\n\nThis appears to be a JSON/CRTDL file. Possible issues:\n  - File may not have valid CRTDL structure (missing cohortDefinition or dataExtraction)\n  - File may be using FHIR Parameters format instead of flat CRTDL format\n\nRun with verbose logging to see detailed validation errors."
+			case ".json":
+				hint = "\n\nThis appears to be a JSON file. Possible issues:\n  - File may not have valid CRTDL structure (missing cohortDefinition or dataExtraction)\n  - File may be using FHIR Parameters format instead of flat CRTDL format\n\nRun with verbose logging to see detailed validation errors."
 			case ".ndjson":
 				hint = "\n\nThis is an NDJSON file. Please provide the directory containing it, not the file itself."
 			}

--- a/internal/services/state.go
+++ b/internal/services/state.go
@@ -69,6 +69,13 @@ func LoadJobState(jobsBaseDir string, jobID string) (*models.PipelineJob, error)
 		return nil, fmt.Errorf("failed to parse job state: %w", err)
 	}
 
+	// Backfill CRTDLPath for jobs saved before issue #286: when the positional
+	// input was a CRTDL, InputSource held the CRTDL path. Preserve that linkage
+	// so flattening still works on pre-existing jobs.
+	if job.CRTDLPath == "" && job.InputType == models.InputTypeCRTDL {
+		job.CRTDLPath = job.InputSource
+	}
+
 	if err := job.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid job state loaded from disk: %w", err)
 	}

--- a/tests/contract/torch_service_test.go
+++ b/tests/contract/torch_service_test.go
@@ -71,7 +71,7 @@ func TestTORCHService_SubmitExtraction_Success(t *testing.T) {
 
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -122,7 +122,7 @@ func TestTORCHService_SubmitExtraction_InvalidCRTDL(t *testing.T) {
 
 	// Create temp invalid CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "invalid.crtdl")
+	crtdlPath := filepath.Join(tempDir, "invalid.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
@@ -152,7 +152,7 @@ func TestTORCHService_SubmitExtraction_Unauthorized(t *testing.T) {
 
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{"inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
@@ -458,7 +458,7 @@ func TestTORCHService_EndToEnd_SubmitPollDownload(t *testing.T) {
 
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",

--- a/tests/integration/job_list_test.go
+++ b/tests/integration/job_list_test.go
@@ -226,7 +226,7 @@ func createTestJobWithState(t *testing.T, jobsDir string, status models.JobStatu
 	createTestFHIRFile(t, sourceDir)
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
-	job, err := pipeline.CreateJob(sourceDir, config, logger)
+	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	// Update job to desired state

--- a/tests/integration/pipeline_crtdl_enrichment_test.go
+++ b/tests/integration/pipeline_crtdl_enrichment_test.go
@@ -32,7 +32,7 @@ func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
 
 	// Original CRTDL — Patient group has no identifier attribute. This is
 	// the exact misconfiguration described in issue #323.
-	crtdlPath := filepath.Join(tempDir, "query.crtdl")
+	crtdlPath := filepath.Join(tempDir, "crtdl.json")
 	crtdl := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",

--- a/tests/integration/pipeline_crtdl_enrichment_test.go
+++ b/tests/integration/pipeline_crtdl_enrichment_test.go
@@ -80,7 +80,7 @@ func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// CreateJob must repoint CRTDLPath at the enriched CRTDL inside jobDir.

--- a/tests/integration/pipeline_crtdl_enrichment_test.go
+++ b/tests/integration/pipeline_crtdl_enrichment_test.go
@@ -22,7 +22,7 @@ import (
 //
 // We don't run the full flattening pipeline here (that needs an external
 // fhir-flattener service); instead we mimic exactly what flattening does
-// today: it parses job.InputSource via services.ParseCRTDL and consumes the
+// today: it parses job.CRTDLPath via services.ParseCRTDL and consumes the
 // resulting attribute groups. If enrichment was correctly applied at job
 // creation, the parsed groups must contain the added attribute.
 func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
@@ -80,16 +80,16 @@ func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
-	// CreateJob must repoint InputSource at the enriched CRTDL inside jobDir.
+	// CreateJob must repoint CRTDLPath at the enriched CRTDL inside jobDir.
 	expectedPath := filepath.Join(jobsDir, job.JobID, "enriched-crtdl.json")
-	require.Equal(t, expectedPath, job.InputSource,
-		"InputSource must point at the enriched CRTDL after CreateJob")
+	require.Equal(t, expectedPath, job.CRTDLPath,
+		"CRTDLPath must point at the enriched CRTDL after CreateJob")
 
-	// Mimic what ExecuteFlatteningStep does: ParseCRTDL on job.InputSource.
-	parsed, err := services.ParseCRTDL(job.InputSource)
+	// Mimic what ExecuteFlatteningStep does: ParseCRTDL on job.CRTDLPath.
+	parsed, err := services.ParseCRTDL(job.CRTDLPath)
 	require.NoError(t, err)
 
 	groups := services.GetAttributeGroups(parsed)
@@ -104,10 +104,10 @@ func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
 	assert.Contains(t, refs, "Patient.id",
 		"original Patient.id must be preserved")
 
-	// Reload from disk — the enriched InputSource must be persisted so
+	// Reload from disk — the enriched CRTDLPath must be persisted so
 	// `aether pipeline continue` resumes with the correct CRTDL.
 	reloaded, err := pipeline.LoadJob(jobsDir, job.JobID)
 	require.NoError(t, err)
-	assert.Equal(t, expectedPath, reloaded.InputSource,
+	assert.Equal(t, expectedPath, reloaded.CRTDLPath,
 		"persisted state must reference the enriched CRTDL for resume")
 }

--- a/tests/integration/pipeline_dimp_resume_test.go
+++ b/tests/integration/pipeline_dimp_resume_test.go
@@ -54,7 +54,7 @@ func TestDIMPResumeAfterInterrupt(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	// Create a job
-	job, err := pipeline.CreateJob("test-input", config, logger)
+	job, err := pipeline.CreateJob("test-input", "", config, logger)
 	require.NoError(t, err)
 
 	// Manually set up import directory with test files

--- a/tests/integration/pipeline_flattening_test.go
+++ b/tests/integration/pipeline_flattening_test.go
@@ -161,6 +161,7 @@ func TestExecuteFlatteningStep_FullPipeline(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -217,16 +218,21 @@ func TestExecuteFlatteningStep_NotEnabled(t *testing.T) {
 	assert.NoError(t, err) // Should skip without error
 }
 
-func TestExecuteFlatteningStep_WrongInputType(t *testing.T) {
+// TestExecuteFlatteningStep_NoCRTDLAttached verifies that flattening rejects
+// a job with no CRTDL (CRTDLPath empty) regardless of input type. Previously
+// this test asserted coupling between InputType and CRTDL requirement; after
+// issue #286 the two are decoupled and the check is purely on CRTDLPath.
+func TestExecuteFlatteningStep_NoCRTDLAttached(t *testing.T) {
 	tempDir := t.TempDir()
-	jobID := "test-job-wrong-input"
+	jobID := "test-job-no-crtdl"
 	jobDir := filepath.Join(tempDir, "jobs", jobID)
 	require.NoError(t, os.MkdirAll(jobDir, 0755))
 
 	job := &models.PipelineJob{
 		JobID:     jobID,
 		Status:    models.JobStatusInProgress,
-		InputType: models.InputTypeLocal, // Not CRTDL
+		InputType: models.InputTypeLocal, // intentionally not CRTDL
+		// CRTDLPath intentionally empty
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -245,7 +251,8 @@ func TestExecuteFlatteningStep_WrongInputType(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "requires CRTDL input")
+	assert.Contains(t, err.Error(), "requires a CRTDL file")
+	assert.Contains(t, err.Error(), "--crtdl")
 }
 
 func TestExecuteFlatteningStep_MissingCRTDL(t *testing.T) {
@@ -259,6 +266,7 @@ func TestExecuteFlatteningStep_MissingCRTDL(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: "/nonexistent/path.crtdl",
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   "/nonexistent/path.crtdl",
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -305,6 +313,7 @@ func TestExecuteFlatteningStep_MissingLookupTables(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -357,6 +366,7 @@ func TestExecuteFlatteningStep_NoInputFiles(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -436,6 +446,7 @@ func TestExecuteFlatteningStep_FlattenerServiceError(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{

--- a/tests/integration/pipeline_flattening_test.go
+++ b/tests/integration/pipeline_flattening_test.go
@@ -85,7 +85,7 @@ func TestExecuteFlatteningStep_FullPipeline(t *testing.T) {
 	groupID := "group-patient-1"
 
 	// Create CRTDL file with group ID
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := `{
 		"dataExtraction": {
 			"attributeGroups": [
@@ -264,9 +264,9 @@ func TestExecuteFlatteningStep_MissingCRTDL(t *testing.T) {
 	job := &models.PipelineJob{
 		JobID:       jobID,
 		Status:      models.JobStatusInProgress,
-		InputSource: "/nonexistent/path.crtdl",
+		InputSource: "/nonexistent/path.json",
 		InputType:   models.InputTypeCRTDL,
-		CRTDLPath:   "/nonexistent/path.crtdl",
+		CRTDLPath:   "/nonexistent/path.json",
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -295,7 +295,7 @@ func TestExecuteFlatteningStep_MissingLookupTables(t *testing.T) {
 	require.NoError(t, os.MkdirAll(jobDir, 0755))
 
 	// Create valid CRTDL
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := `{
 		"dataExtraction": {
 			"attributeGroups": [{
@@ -343,7 +343,7 @@ func TestExecuteFlatteningStep_NoInputFiles(t *testing.T) {
 	require.NoError(t, os.MkdirAll(inputDir, 0755)) // Empty input dir
 
 	// Create valid CRTDL
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := `{
 		"dataExtraction": {
 			"attributeGroups": [{
@@ -405,7 +405,7 @@ func TestExecuteFlatteningStep_FlattenerServiceError(t *testing.T) {
 	groupID := "group-patient"
 
 	// Create CRTDL
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := `{
 		"dataExtraction": {
 			"attributeGroups": [{

--- a/tests/integration/pipeline_import_error_test.go
+++ b/tests/integration/pipeline_import_error_test.go
@@ -42,7 +42,7 @@ func TestPipelineImportError_UnreachableURL(t *testing.T) {
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create job with unreachable URL
-	job, err := pipeline.CreateJob(unreachableURL, config, logger)
+	job, err := pipeline.CreateJob(unreachableURL, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	assert.Equal(t, models.InputTypeHTTP, job.InputType, "Input type should be HTTP")
 
@@ -107,7 +107,7 @@ func TestPipelineImportError_HTTP404(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/missing.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/missing.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -157,7 +157,7 @@ func TestPipelineImportError_HTTP500WithRetry(t *testing.T) {
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/error.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/error.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -199,7 +199,7 @@ func TestPipelineImportError_InvalidLocalPath(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create job with invalid path
-	job, err := pipeline.CreateJob(invalidPath, config, logger)
+	job, err := pipeline.CreateJob(invalidPath, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	assert.Equal(t, models.InputTypeLocal, job.InputType, "Input type should be local")
 
@@ -243,7 +243,7 @@ func TestPipelineImportError_EmptyDirectory(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(emptyDir, config, logger)
+	job, _ := pipeline.CreateJob(emptyDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -282,7 +282,7 @@ func TestPipelineImportError_PathIsFile(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(filePath, config, logger)
+	job, _ := pipeline.CreateJob(filePath, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -326,7 +326,7 @@ func TestPipelineImportError_NetworkTimeout(t *testing.T) {
 	httpClient := services.NewHTTPClient(1*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/slow.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/slow.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -369,7 +369,7 @@ func TestPipelineImportError_StatePersistence(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/bad.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/bad.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -427,7 +427,7 @@ func TestPipelineImportError_PartialDownloadCleanup(t *testing.T) {
 
 	// Note: This test would ideally simulate connection drop, but for now
 	// we test the cleanup mechanism with a different error scenario
-	job, _ := pipeline.CreateJob("http://localhost:99999/unreachable.ndjson", config, logger)
+	job, _ := pipeline.CreateJob("http://localhost:99999/unreachable.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 

--- a/tests/integration/pipeline_import_local_test.go
+++ b/tests/integration/pipeline_import_local_test.go
@@ -57,7 +57,7 @@ func TestPipelineImportLocal_EndToEnd(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Step 1: Create new job
-	job, err := pipeline.CreateJob(sourceDir, config, logger)
+	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	require.NotNil(t, job, "Job should be created")
 	assert.NotEmpty(t, job.JobID, "Job should have an ID")
@@ -146,7 +146,7 @@ func TestPipelineImportLocal_InvalidSource(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create job with invalid source
-	job, err := pipeline.CreateJob(nonexistentDir, config, logger)
+	job, err := pipeline.CreateJob(nonexistentDir, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed even with invalid source")
 
 	// Start job
@@ -194,7 +194,7 @@ func TestPipelineImportLocal_EmptyDirectory(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create and start job
-	job, err := pipeline.CreateJob(sourceDir, config, logger)
+	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
 	require.NoError(t, err)
 	startedJob := pipeline.StartJob(job)
 
@@ -241,7 +241,7 @@ func TestPipelineImportLocal_ResourceCounting(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(sourceDir, config, logger)
+	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -287,8 +287,8 @@ func TestPipelineImportLocal_JobListAndStatus(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create multiple jobs
-	job1, _ := pipeline.CreateJob(sourceDir, config, logger)
-	job2, _ := pipeline.CreateJob(sourceDir, config, logger)
+	job1, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job2, _ := pipeline.CreateJob(sourceDir, "", config, logger)
 
 	// Execute import for first job
 	startedJob1 := pipeline.StartJob(job1)

--- a/tests/integration/pipeline_import_url_test.go
+++ b/tests/integration/pipeline_import_url_test.go
@@ -56,7 +56,7 @@ func TestPipelineImportURL_EndToEnd(t *testing.T) {
 
 	// Step 1: Create job with HTTP URL input
 	url := server.URL + "/Patient.ndjson"
-	job, err := pipeline.CreateJob(url, config, logger)
+	job, err := pipeline.CreateJob(url, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	assert.Equal(t, models.InputTypeHTTP, job.InputType, "Input type should be HTTP")
 	assert.Equal(t, url, job.InputSource, "Input source should be the URL")
@@ -138,7 +138,7 @@ func TestPipelineImportURL_WithRetry(t *testing.T) {
 	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create and execute job
-	job, _ := pipeline.CreateJob(server.URL+"/test.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/test.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -186,7 +186,7 @@ func TestPipelineImportURL_LargeFile(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import with progress
-	job, _ := pipeline.CreateJob(server.URL+"/large.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/large.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, true)
 
@@ -240,7 +240,7 @@ func TestPipelineImportURL_ProgressDisplay(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute with progress display enabled
-	job, _ := pipeline.CreateJob(server.URL+"/data.ndjson", config, logger)
+	job, _ := pipeline.CreateJob(server.URL+"/data.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 
 	// This should use progress bar/spinner internally (progress indicator requirementsc, Progress indicators must update at least every 2 seconds)
@@ -289,7 +289,7 @@ func TestPipelineImportURL_MultipleURLs(t *testing.T) {
 	// Download from each URL as separate jobs
 	var jobs []*models.PipelineJob
 	for _, url := range urls {
-		job, _ := pipeline.CreateJob(url, config, logger)
+		job, _ := pipeline.CreateJob(url, "", config, logger)
 		startedJob := pipeline.StartJob(job)
 		importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 		require.NoError(t, err, "Import should succeed for URL %s", url)
@@ -364,7 +364,7 @@ func TestPipelineImportURL_FilenameFromURL(t *testing.T) {
 
 			// Execute import
 			url := server.URL + tt.urlPath
-			job, _ := pipeline.CreateJob(url, config, logger)
+			job, _ := pipeline.CreateJob(url, "", config, logger)
 			startedJob := pipeline.StartJob(job)
 			_, _ = pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -407,8 +407,8 @@ func TestPipelineImportURL_ConcurrentDownloads(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute two downloads "concurrently" (sequentially in test, but verify isolation)
-	job1, _ := pipeline.CreateJob(server.URL+"/data1.ndjson", config, logger)
-	job2, _ := pipeline.CreateJob(server.URL+"/data2.ndjson", config, logger)
+	job1, _ := pipeline.CreateJob(server.URL+"/data1.ndjson", "", config, logger)
+	job2, _ := pipeline.CreateJob(server.URL+"/data2.ndjson", "", config, logger)
 
 	startedJob1 := pipeline.StartJob(job1)
 	startedJob2 := pipeline.StartJob(job2)

--- a/tests/integration/pipeline_multistep_test.go
+++ b/tests/integration/pipeline_multistep_test.go
@@ -73,7 +73,7 @@ func TestPipelineMultiStep_AutomaticExecution(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create job
-	job, err := pipeline.CreateJob(importDir, config, logger)
+	job, err := pipeline.CreateJob(importDir, "", config, logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, job.JobID)
 
@@ -190,7 +190,7 @@ func TestPipelineMultiStep_OnlyImportEnabled(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create and start job
-	job, err := pipeline.CreateJob(importDir, config, logger)
+	job, err := pipeline.CreateJob(importDir, "", config, logger)
 	require.NoError(t, err)
 
 	startedJob := pipeline.StartJob(job)
@@ -311,7 +311,7 @@ func TestPipelineMultiStep_JobStatePersistedBetweenSteps(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create job
-	job, err := pipeline.CreateJob(importDir, config, logger)
+	job, err := pipeline.CreateJob(importDir, "", config, logger)
 	require.NoError(t, err)
 	jobID := job.JobID
 

--- a/tests/integration/pipeline_resume_test.go
+++ b/tests/integration/pipeline_resume_test.go
@@ -55,7 +55,7 @@ func TestPipelineResume_AfterImportComplete(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Phase 1: Create and start job (SESSION 1 simulation)
-	job, err := pipeline.CreateJob(sourceDir, config, logger)
+	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
 	require.NoError(t, err, "CreateJob should succeed")
 	require.NotNil(t, job, "Job should be created")
 
@@ -269,7 +269,7 @@ func createCompletedImportJob(t *testing.T, jobsDir string, fileCount int) *mode
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create job
-	job, err := pipeline.CreateJob(tempSourceDir, config, logger)
+	job, err := pipeline.CreateJob(tempSourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	// Start job and complete import

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -153,14 +153,14 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
 	// Verify job was created with correct input type. CreateJob copies the
-	// CRTDL into the job directory (PrepareCRTDL) so InputSource now points
+	// CRTDL into the job directory (PrepareCRTDL) so CRTDLPath now points
 	// at jobs/<id>/crtdl.json rather than the original input path.
 	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
-	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.InputSource)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath)
 	assert.NotEmpty(t, job.JobID)
 
 	// Execute import step (which should trigger TORCH extraction)
@@ -262,7 +262,7 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -310,7 +310,7 @@ func TestPipeline_TORCHExtraction_ServerUnavailable(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -404,7 +404,7 @@ func TestPipeline_DirectTORCHURL_Download(t *testing.T) {
 
 	// Create job with TORCH result URL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(torchResultURL, config, logger)
+	job, err := pipeline.CreateJob(torchResultURL, "", config, logger)
 	require.NoError(t, err)
 
 	// Verify job was created with correct input type
@@ -497,7 +497,7 @@ func TestPipeline_DirectTORCHURL_EmptyResult(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(torchResultURL, config, logger)
+	job, err := pipeline.CreateJob(torchResultURL, "", config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -759,7 +759,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Step 1: Create job with CRTDL input
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
 
@@ -989,7 +989,7 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
 	// Execute import step (triggers TORCH extraction with preprocessing)
@@ -1047,9 +1047,9 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 	assert.Contains(t, string(savedContent), "Patient.identifier:PseudonymisierterIdentifier",
 		"Saved CRTDL should contain the enrichment attribute")
 
-	// Verify job.InputSource was updated to point to the job-local copy
-	assert.Equal(t, crtdlJobPath, updatedJob.InputSource,
-		"job.InputSource should point to enriched-crtdl.json in the job directory")
+	// Verify job.CRTDLPath was updated to point to the job-local copy
+	assert.Equal(t, crtdlJobPath, updatedJob.CRTDLPath,
+		"job.CRTDLPath should point to enriched-crtdl.json in the job directory")
 
 	t.Logf("SUCCESS: CRTDL preprocessing enriched document before TORCH submission")
 	t.Logf("Original attributes: 2, Enriched attributes: 4")
@@ -1158,7 +1158,7 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// PHASE 1: Start extraction (simulate initial job creation)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 	require.Equal(t, models.InputTypeCRTDL, job.InputType)
 
@@ -1297,7 +1297,7 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidEnrichmentsPath(t *t
 	// CRTDL is used by every downstream step). An invalid enrichments path
 	// must therefore be reported by CreateJob, not by the import step.
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	_, err := pipeline.CreateJob(crtdlPath, config, logger)
+	_, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prepare CRTDL", "Error should mention CRTDL preparation failure")
 	assert.Contains(t, err.Error(), "load enrichments", "Error should surface the underlying enrichments-loading failure")
@@ -1421,7 +1421,7 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
 	// Execute import step - should use original CRTDL without preprocessing
@@ -1456,9 +1456,9 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 	assert.JSONEq(t, string(originalContent), string(savedContent),
 		"Copied CRTDL should match the original when preprocessing is disabled")
 
-	// Verify job.InputSource was updated to point to the job-local copy
-	assert.Equal(t, crtdlJobPath, updatedJob.InputSource,
-		"job.InputSource should point to crtdl.json in the job directory")
+	// Verify job.CRTDLPath was updated to point to the job-local copy
+	assert.Equal(t, crtdlJobPath, updatedJob.CRTDLPath,
+		"job.CRTDLPath should point to crtdl.json in the job directory")
 }
 
 // TestPrepareCRTDL_InvalidCRTDL covers the error path where CRTDL parsing
@@ -1478,6 +1478,7 @@ func TestPrepareCRTDL_InvalidCRTDL(t *testing.T) {
 		JobID:       jobID,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			JobsDir: jobsDir,
 			Services: models.ServiceConfig{
@@ -1621,7 +1622,7 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
 	require.NoError(t, err)
 
 	// Execute import step - should use original CRTDL content when no enrichments configured
@@ -1656,9 +1657,9 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 	assert.JSONEq(t, string(originalFileContent), string(savedContent),
 		"Copied CRTDL should match the original when no enrichments are applied")
 
-	// Verify job.InputSource was updated to point to the job-local copy
-	assert.Equal(t, crtdlJobPath, updatedJob.InputSource,
-		"job.InputSource should point to crtdl.json in the job directory")
+	// Verify job.CRTDLPath was updated to point to the job-local copy
+	assert.Equal(t, crtdlJobPath, updatedJob.CRTDLPath,
+		"job.CRTDLPath should point to crtdl.json in the job directory")
 
 	t.Logf("SUCCESS: With empty enrichments, original CRTDL content was submitted and saved to job dir")
 }

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -153,13 +153,13 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
-	// Verify job was created with correct input type. CreateJob copies the
-	// CRTDL into the job directory (PrepareCRTDL) so CRTDLPath now points
-	// at jobs/<id>/crtdl.json rather than the original input path.
-	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
+	// CRTDL is attached via the CRTDL-positional CLI contract, no external
+	// input source. PrepareCRTDL repoints CRTDLPath at jobs/<id>/crtdl.json.
+	assert.Equal(t, models.InputTypeLocal, job.InputType)
+	assert.Empty(t, job.InputSource)
 	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath)
 	assert.NotEmpty(t, job.JobID)
 
@@ -262,7 +262,7 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -310,7 +310,7 @@ func TestPipeline_TORCHExtraction_ServerUnavailable(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -759,9 +759,9 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Step 1: Create job with CRTDL input
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
-	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath)
 
 	// Step 2: Execute TORCH import step
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -989,7 +989,7 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// Execute import step (triggers TORCH extraction with preprocessing)
@@ -1047,7 +1047,8 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 	assert.Contains(t, string(savedContent), "Patient.identifier:PseudonymisierterIdentifier",
 		"Saved CRTDL should contain the enrichment attribute")
 
-	// Verify job.CRTDLPath was updated to point to the job-local copy
+	// Verify job.CRTDLPath was repointed to the enriched copy so downstream
+	// steps (flattening) read the same CRTDL that was submitted to TORCH.
 	assert.Equal(t, crtdlJobPath, updatedJob.CRTDLPath,
 		"job.CRTDLPath should point to enriched-crtdl.json in the job directory")
 
@@ -1158,9 +1159,9 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// PHASE 1: Start extraction (simulate initial job creation)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
-	require.Equal(t, models.InputTypeCRTDL, job.InputType)
+	require.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath)
 
 	// Simulate starting the extraction and getting the extraction URL
 	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -1191,7 +1192,7 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	// Verify job state was preserved
 	assert.Equal(t, job.JobID, reloadedJob.JobID)
 	assert.Equal(t, extractionURL, reloadedJob.TORCHExtractionURL)
-	assert.Equal(t, models.InputTypeCRTDL, reloadedJob.InputType)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), reloadedJob.CRTDLPath)
 
 	t.Logf("Phase 2: Job reloaded from disk with extraction URL: %s", reloadedJob.TORCHExtractionURL)
 
@@ -1297,7 +1298,7 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidEnrichmentsPath(t *t
 	// CRTDL is used by every downstream step). An invalid enrichments path
 	// must therefore be reported by CreateJob, not by the import step.
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	_, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	_, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prepare CRTDL", "Error should mention CRTDL preparation failure")
 	assert.Contains(t, err.Error(), "load enrichments", "Error should surface the underlying enrichments-loading failure")
@@ -1421,7 +1422,7 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// Execute import step - should use original CRTDL without preprocessing
@@ -1447,7 +1448,9 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 	// Original CRTDL only has 1 attribute
 	assert.Len(t, attributes, 1, "Original CRTDL should have only 1 attribute (no enrichment)")
 
-	// Verify original CRTDL was copied to job directory as crtdl.json
+	// Even with preprocessing disabled, PrepareCRTDL copies the original CRTDL
+	// to the job directory so every downstream step sees the same effective
+	// CRTDL.
 	crtdlJobPath := filepath.Join(jobsDir, job.JobID, "crtdl.json")
 	savedContent, readErr := os.ReadFile(crtdlJobPath)
 	require.NoError(t, readErr, "CRTDL should be copied to job directory as crtdl.json")
@@ -1456,7 +1459,6 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 	assert.JSONEq(t, string(originalContent), string(savedContent),
 		"Copied CRTDL should match the original when preprocessing is disabled")
 
-	// Verify job.CRTDLPath was updated to point to the job-local copy
 	assert.Equal(t, crtdlJobPath, updatedJob.CRTDLPath,
 		"job.CRTDLPath should point to crtdl.json in the job directory")
 }
@@ -1622,7 +1624,7 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, "", config, logger)
+	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// Execute import step - should use original CRTDL content when no enrichments configured
@@ -1648,16 +1650,15 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, originalContent, decodedBytes, "When no enrichments configured, original file content should be submitted")
 
-	// Verify original CRTDL was copied to job directory as crtdl.json (even with empty enrichments)
+	// With preprocessing enabled but no enrichments configured, PrepareCRTDL
+	// falls back to a verbatim copy at jobDir/crtdl.json — same shape as the
+	// preprocessing-disabled path.
 	crtdlJobPath := filepath.Join(jobsDir, job.JobID, "crtdl.json")
 	savedContent, readErr := os.ReadFile(crtdlJobPath)
 	require.NoError(t, readErr, "CRTDL should be copied to job directory as crtdl.json")
-
-	originalFileContent, _ := os.ReadFile(crtdlPath)
-	assert.JSONEq(t, string(originalFileContent), string(savedContent),
+	assert.JSONEq(t, string(originalContent), string(savedContent),
 		"Copied CRTDL should match the original when no enrichments are applied")
 
-	// Verify job.CRTDLPath was updated to point to the job-local copy
 	assert.Equal(t, crtdlJobPath, updatedJob.CRTDLPath,
 		"job.CRTDLPath should point to crtdl.json in the job directory")
 

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -28,7 +28,7 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version": "1.0.0",
@@ -210,7 +210,7 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "empty-cohort.crtdl")
+	crtdlPath := filepath.Join(tempDir, "empty-cohort.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{"version":"1.0.0","inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
@@ -286,7 +286,7 @@ func TestPipeline_TORCHExtraction_ServerUnavailable(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{"version":"1.0.0","inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
@@ -525,7 +525,7 @@ func TestPipeline_TORCHExtraction_PollingTimeout(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "timeout-test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "timeout-test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -631,7 +631,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -857,7 +857,7 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file with a Patient group (missing the enrichment attributes)
-	crtdlPath := filepath.Join(tempDir, "test-preprocessing.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test-preprocessing.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -1065,7 +1065,7 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "resumption-test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "resumption-test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -1239,7 +1239,7 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidEnrichmentsPath(t *t
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create valid CRTDL file
-	crtdlPath := filepath.Join(tempDir, "valid.crtdl")
+	crtdlPath := filepath.Join(tempDir, "valid.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -1311,7 +1311,7 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create CRTDL file
-	crtdlPath := filepath.Join(tempDir, "original.crtdl")
+	crtdlPath := filepath.Join(tempDir, "original.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -1473,7 +1473,7 @@ func TestPrepareCRTDL_InvalidCRTDL(t *testing.T) {
 	jobID := "550e8400-e29b-41d4-a716-446655440000"
 	require.NoError(t, os.MkdirAll(filepath.Join(jobsDir, jobID), 0755))
 
-	crtdlPath := filepath.Join(tempDir, "invalid.crtdl")
+	crtdlPath := filepath.Join(tempDir, "invalid.json")
 	require.NoError(t, os.WriteFile(crtdlPath, []byte("{this is not valid json"), 0644))
 
 	job := &models.PipelineJob{
@@ -1513,7 +1513,7 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 	_ = os.MkdirAll(jobsDir, 0755)
 
 	// Create valid CRTDL file
-	crtdlPath := filepath.Join(tempDir, "valid.crtdl")
+	crtdlPath := filepath.Join(tempDir, "valid.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",

--- a/tests/integration/pipeline_wait_test.go
+++ b/tests/integration/pipeline_wait_test.go
@@ -49,7 +49,7 @@ func TestPipelineWithWaitStep_PausesExecution(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Create and start job
-	job, err := pipeline.CreateJob(sourceDir, config, logger)
+	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	startedJob := pipeline.StartJob(job)
@@ -114,7 +114,7 @@ func TestPipelineWithWaitStep_DirectoryCreated(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Create, start, and execute import
-	job, err := pipeline.CreateJob(sourceDir, config, logger)
+	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	startedJob := pipeline.StartJob(job)
@@ -172,7 +172,7 @@ func TestPipelineWithWaitStep_EmptyDirectory(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Run through pipeline to wait step
-	job, _ := pipeline.CreateJob(sourceDir, config, logger)
+	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
@@ -226,7 +226,7 @@ func TestPipelineWithWaitStep_ContinuesAfterCommand(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Run through import and wait steps
-	job, _ := pipeline.CreateJob(sourceDir, config, logger)
+	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
@@ -306,7 +306,7 @@ func TestWaitStep_ContinueWithFilesPresent(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Create, start, and execute import step
-	job, _ := pipeline.CreateJob(sourceDir, config, logger)
+	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
@@ -393,7 +393,7 @@ func TestWaitStep_ContinueWithEmptyDirectory(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Run through import to wait step
-	job, _ := pipeline.CreateJob(sourceDir, config, logger)
+	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 

--- a/tests/unit/crtdl_parser_test.go
+++ b/tests/unit/crtdl_parser_test.go
@@ -15,7 +15,7 @@ import (
 func TestParseCRTDL(t *testing.T) {
 	t.Run("valid CRTDL", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [
@@ -46,7 +46,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("multiple attribute groups", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [
@@ -74,14 +74,14 @@ func TestParseCRTDL(t *testing.T) {
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		_, err := services.ParseCRTDL("/nonexistent/path/test.crtdl")
+		_, err := services.ParseCRTDL("/nonexistent/path/test.json")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read CRTDL file")
 	})
 
 	t.Run("invalid JSON", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		err := os.WriteFile(crtdlPath, []byte("not valid json"), 0644)
 		require.NoError(t, err)
 
@@ -92,7 +92,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("missing attribute groups", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{"dataExtraction": {"attributeGroups": []}}`
 		err := os.WriteFile(crtdlPath, []byte(crtdlJSON), 0644)
 		require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("missing id", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [{
@@ -124,7 +124,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("missing name", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [{
@@ -144,7 +144,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("missing groupReference", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [{
@@ -164,7 +164,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("missing attributes", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [{
@@ -185,7 +185,7 @@ func TestParseCRTDL(t *testing.T) {
 
 	t.Run("missing attributeRef", func(t *testing.T) {
 		tempDir := t.TempDir()
-		crtdlPath := filepath.Join(tempDir, "test.crtdl")
+		crtdlPath := filepath.Join(tempDir, "test.json")
 		crtdlJSON := `{
 			"dataExtraction": {
 				"attributeGroups": [{
@@ -300,13 +300,12 @@ func TestIsCRTDLFile(t *testing.T) {
 		path     string
 		expected bool
 	}{
-		{"/path/to/file.crtdl", true},
-		{"query.crtdl", true},
-		{"/path/to/file.json", false},
-		{"/path/to/file.crtd", false},
-		{".crtdl", false},
+		{"/path/to/file.json", true},
+		{"crtdl.json", true},
+		{"/path/to/file.jso", false},
+		{".json", false},
 		{"", false},
-		{"crtdl", false},
+		{"json", false},
 	}
 
 	for _, tt := range tests {

--- a/tests/unit/crtdl_prep_test.go
+++ b/tests/unit/crtdl_prep_test.go
@@ -56,6 +56,7 @@ func newJobForPrep(t *testing.T, jobsDir, jobID, crtdlPath string, preprocessing
 		JobID:       jobID,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			JobsDir: jobsDir,
 			Services: models.ServiceConfig{
@@ -65,12 +66,12 @@ func newJobForPrep(t *testing.T, jobsDir, jobID, crtdlPath string, preprocessing
 	}
 }
 
-func TestPrepareCRTDL_NotCRTDLInputType_NoOp(t *testing.T) {
+func TestPrepareCRTDL_NoCRTDLAttached_NoOp(t *testing.T) {
 	tempDir := t.TempDir()
 	jobsDir := filepath.Join(tempDir, "jobs")
 
 	job := &models.PipelineJob{
-		JobID:       "job-not-crtdl",
+		JobID:       "job-no-crtdl",
 		InputSource: "/some/local/dir",
 		InputType:   models.InputTypeLocal,
 		Config:      models.ProjectConfig{JobsDir: jobsDir},
@@ -78,8 +79,8 @@ func TestPrepareCRTDL_NotCRTDLInputType_NoOp(t *testing.T) {
 
 	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
 
-	assert.Equal(t, "/some/local/dir", job.InputSource,
-		"InputSource must be untouched when InputType is not CRTDL")
+	assert.Equal(t, "", job.CRTDLPath,
+		"CRTDLPath must remain empty when no CRTDL is attached to the job")
 }
 
 func TestPrepareCRTDL_PreprocessingDisabled_CopiesOriginalToJobDir(t *testing.T) {
@@ -93,8 +94,8 @@ func TestPrepareCRTDL_PreprocessingDisabled_CopiesOriginalToJobDir(t *testing.T)
 	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
 
 	expectedPath := filepath.Join(jobsDir, jobID, "crtdl.json")
-	assert.Equal(t, expectedPath, job.InputSource,
-		"InputSource must point at jobDir/crtdl.json after copy")
+	assert.Equal(t, expectedPath, job.CRTDLPath,
+		"CRTDLPath must point at jobDir/crtdl.json after copy")
 
 	originalBytes, err := os.ReadFile(crtdlPath)
 	require.NoError(t, err)
@@ -128,8 +129,8 @@ func TestPrepareCRTDL_PreprocessingEnabled_AppliesEnrichmentAndSavesEnrichedFile
 	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
 
 	expectedPath := filepath.Join(jobsDir, jobID, "enriched-crtdl.json")
-	assert.Equal(t, expectedPath, job.InputSource,
-		"InputSource must point at jobDir/enriched-crtdl.json after enrichment")
+	assert.Equal(t, expectedPath, job.CRTDLPath,
+		"CRTDLPath must point at jobDir/enriched-crtdl.json after enrichment")
 
 	enriched, err := services.ParseCRTDL(expectedPath)
 	require.NoError(t, err)
@@ -160,7 +161,7 @@ func TestPrepareCRTDL_PreprocessingEnabledButNoEnrichments_FallsBackToCopy(t *te
 	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
 
 	expectedPath := filepath.Join(jobsDir, jobID, "crtdl.json")
-	assert.Equal(t, expectedPath, job.InputSource,
+	assert.Equal(t, expectedPath, job.CRTDLPath,
 		"With enabled+empty enrichments, fall back to copying as crtdl.json")
 
 	originalBytes, err := os.ReadFile(crtdlPath)
@@ -170,7 +171,7 @@ func TestPrepareCRTDL_PreprocessingEnabledButNoEnrichments_FallsBackToCopy(t *te
 	assert.Equal(t, originalBytes, copiedBytes)
 }
 
-func TestPrepareCRTDL_Idempotent_SkipsWhenInputSourceAlreadyInJobDir(t *testing.T) {
+func TestPrepareCRTDL_Idempotent_SkipsWhenCRTDLPathAlreadyInJobDir(t *testing.T) {
 	tempDir := t.TempDir()
 	jobsDir := filepath.Join(tempDir, "jobs")
 	jobID := "job-idempotent"
@@ -190,7 +191,7 @@ func TestPrepareCRTDL_Idempotent_SkipsWhenInputSourceAlreadyInJobDir(t *testing.
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	require.NoError(t, pipeline.PrepareCRTDL(job, logger))
-	firstPath := job.InputSource
+	firstPath := job.CRTDLPath
 
 	// Capture file content after first run, then call again — content must be
 	// identical (no double-enrichment) because the second call is a no-op.
@@ -198,7 +199,7 @@ func TestPrepareCRTDL_Idempotent_SkipsWhenInputSourceAlreadyInJobDir(t *testing.
 	require.NoError(t, err)
 
 	require.NoError(t, pipeline.PrepareCRTDL(job, logger))
-	assert.Equal(t, firstPath, job.InputSource, "InputSource unchanged on repeat call")
+	assert.Equal(t, firstPath, job.CRTDLPath, "CRTDLPath unchanged on repeat call")
 
 	secondBytes, err := os.ReadFile(firstPath)
 	require.NoError(t, err)
@@ -265,6 +266,7 @@ func TestPrepareCRTDL_InputInJobDirWithDifferentName_NotConsideredPrepared(t *te
 		JobID:       jobID,
 		InputSource: otherNamePath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   otherNamePath,
 		Config: models.ProjectConfig{
 			JobsDir:  jobsDir,
 			Services: models.ServiceConfig{CRTDLPreprocessing: models.CRTDLPreprocessingConfig{Enabled: false}},
@@ -274,7 +276,7 @@ func TestPrepareCRTDL_InputInJobDirWithDifferentName_NotConsideredPrepared(t *te
 	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
 
 	expectedPath := filepath.Join(jobDir, "crtdl.json")
-	assert.Equal(t, expectedPath, job.InputSource,
+	assert.Equal(t, expectedPath, job.CRTDLPath,
 		"isPreparedCRTDLPath must return false for non-canonical filenames so prep proceeds")
 
 	_, err := os.Stat(expectedPath)
@@ -298,6 +300,7 @@ func TestPrepareCRTDL_PreprocessingDisabled_FailsWhenJobDirUnwritable(t *testing
 		JobID:       "job-bad-jobdir",
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			JobsDir:  jobsDir,
 			Services: models.ServiceConfig{CRTDLPreprocessing: models.CRTDLPreprocessingConfig{Enabled: false}},

--- a/tests/unit/crtdl_prep_test.go
+++ b/tests/unit/crtdl_prep_test.go
@@ -88,7 +88,7 @@ func TestPrepareCRTDL_PreprocessingDisabled_CopiesOriginalToJobDir(t *testing.T)
 	jobsDir := filepath.Join(tempDir, "jobs")
 	jobID := "job-disabled"
 
-	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.json", crtdlWithoutPatientIdentifier())
 	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, models.CRTDLPreprocessingConfig{Enabled: false})
 
 	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
@@ -109,7 +109,7 @@ func TestPrepareCRTDL_PreprocessingEnabled_AppliesEnrichmentAndSavesEnrichedFile
 	jobsDir := filepath.Join(tempDir, "jobs")
 	jobID := "job-enriched"
 
-	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.json", crtdlWithoutPatientIdentifier())
 	preprocessing := models.CRTDLPreprocessingConfig{
 		Enabled: true,
 		Enrichments: []models.GroupEnrichment{
@@ -152,7 +152,7 @@ func TestPrepareCRTDL_PreprocessingEnabledButNoEnrichments_FallsBackToCopy(t *te
 	jobsDir := filepath.Join(tempDir, "jobs")
 	jobID := "job-empty-enrich"
 
-	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.json", crtdlWithoutPatientIdentifier())
 	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, models.CRTDLPreprocessingConfig{
 		Enabled:     true,
 		Enrichments: []models.GroupEnrichment{},
@@ -176,7 +176,7 @@ func TestPrepareCRTDL_Idempotent_SkipsWhenCRTDLPathAlreadyInJobDir(t *testing.T)
 	jobsDir := filepath.Join(tempDir, "jobs")
 	jobID := "job-idempotent"
 
-	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.json", crtdlWithoutPatientIdentifier())
 	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, models.CRTDLPreprocessingConfig{
 		Enabled: true,
 		Enrichments: []models.GroupEnrichment{
@@ -210,7 +210,7 @@ func TestPrepareCRTDL_EnrichmentEnabled_FailsWhenInputCRTDLInvalid(t *testing.T)
 	tempDir := t.TempDir()
 	jobsDir := filepath.Join(tempDir, "jobs")
 
-	crtdlPath := filepath.Join(tempDir, "bad.crtdl")
+	crtdlPath := filepath.Join(tempDir, "bad.json")
 	require.NoError(t, os.WriteFile(crtdlPath, []byte("{not json"), 0644))
 
 	job := newJobForPrep(t, jobsDir, "job-bad-crtdl", crtdlPath, models.CRTDLPreprocessingConfig{
@@ -237,7 +237,7 @@ func TestPrepareCRTDL_PreprocessingDisabled_FailsWhenInputMissing(t *testing.T) 
 	jobsDir := filepath.Join(tempDir, "jobs")
 	jobID := "job-missing-input"
 
-	missingPath := filepath.Join(tempDir, "does-not-exist.crtdl")
+	missingPath := filepath.Join(tempDir, "does-not-exist.json")
 	job := newJobForPrep(t, jobsDir, jobID, missingPath, models.CRTDLPreprocessingConfig{Enabled: false})
 
 	err := pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug))
@@ -294,7 +294,7 @@ func TestPrepareCRTDL_PreprocessingDisabled_FailsWhenJobDirUnwritable(t *testing
 	jobsDir := filepath.Join(tempDir, "jobs-as-file")
 	require.NoError(t, os.WriteFile(jobsDir, []byte("not a directory"), 0644))
 
-	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.json", crtdlWithoutPatientIdentifier())
 
 	job := &models.PipelineJob{
 		JobID:       "job-bad-jobdir",

--- a/tests/unit/import_local_test.go
+++ b/tests/unit/import_local_test.go
@@ -292,7 +292,7 @@ func TestValidateImportSource_CRTDLValidation(t *testing.T) {
 		{
 			name: "Valid CRTDL file",
 			setupFunc: func() string {
-				file := filepath.Join(tempDir, "valid.crtdl")
+				file := filepath.Join(tempDir, "valid.json")
 				_ = os.WriteFile(file, []byte("{}"), 0644)
 				return file
 			},
@@ -309,7 +309,7 @@ func TestValidateImportSource_CRTDLValidation(t *testing.T) {
 		{
 			name: "Non-existent CRTDL file",
 			setupFunc: func() string {
-				return filepath.Join(tempDir, "nonexistent.crtdl")
+				return filepath.Join(tempDir, "nonexistent.json")
 			},
 			expectError: true,
 			errorMsg:    "does not exist",
@@ -415,16 +415,16 @@ func TestImportFromLocalDirectory_JSONFile(t *testing.T) {
 
 	// Verify error (line 29-30 path)
 	assert.Error(t, err, "Should fail when source is a .json file")
-	assert.Contains(t, err.Error(), "JSON/CRTDL file", "Error should mention JSON/CRTDL file")
+	assert.Contains(t, err.Error(), "JSON file", "Error should mention JSON file")
 	assert.Contains(t, err.Error(), "not a directory", "Error should mention not a directory")
 	assert.Contains(t, err.Error(), "InputTypeCRTDL", "Error should mention InputTypeCRTDL")
 	assert.Nil(t, importedFiles, "Should not return files on error")
 }
 
-// TestImportFromLocalDirectory_CRTDLFile tests error handling when .crtdl file is passed instead of directory (line 29-30)
+// TestImportFromLocalDirectory_CRTDLFile tests error handling when .json file is passed instead of directory (line 29-30)
 func TestImportFromLocalDirectory_CRTDLFile(t *testing.T) {
 	tempDir := t.TempDir()
-	sourceFile := filepath.Join(tempDir, "cohort.crtdl")
+	sourceFile := filepath.Join(tempDir, "cohort.json")
 	destDir := filepath.Join(tempDir, "dest")
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
@@ -435,8 +435,8 @@ func TestImportFromLocalDirectory_CRTDLFile(t *testing.T) {
 	importedFiles, err := services.ImportFromLocalDirectory(sourceFile, destDir, logger, false, "")
 
 	// Verify error (line 29-30 path)
-	assert.Error(t, err, "Should fail when source is a .crtdl file")
-	assert.Contains(t, err.Error(), "JSON/CRTDL file", "Error should mention JSON/CRTDL file")
+	assert.Error(t, err, "Should fail when source is a .json file")
+	assert.Contains(t, err.Error(), "JSON file", "Error should mention JSON file")
 	assert.Contains(t, err.Error(), "not a directory", "Error should mention not a directory")
 	assert.Contains(t, err.Error(), "InputTypeCRTDL", "Error should mention InputTypeCRTDL")
 	assert.Nil(t, importedFiles, "Should not return files on error")
@@ -456,16 +456,16 @@ func TestValidateImportSource_JSONFileForLocalInput(t *testing.T) {
 	assert.Error(t, err, "Should return error for JSON file with InputTypeLocal")
 	assert.Contains(t, err.Error(), "expected directory but got file", "Error should mention file vs directory")
 	// Verify the hint message (lines 174-178)
-	assert.Contains(t, err.Error(), "JSON/CRTDL file", "Error should contain JSON/CRTDL hint")
+	assert.Contains(t, err.Error(), "JSON file", "Error should contain JSON hint")
 	assert.Contains(t, err.Error(), "cohortDefinition", "Error should mention cohortDefinition")
 	assert.Contains(t, err.Error(), "dataExtraction", "Error should mention dataExtraction")
 	assert.Contains(t, err.Error(), "verbose logging", "Error should mention verbose logging")
 }
 
-// TestValidateImportSource_CRTDLFileForLocalInput tests validation hint for .crtdl file with InputTypeLocal (line 174-178)
+// TestValidateImportSource_CRTDLFileForLocalInput tests validation hint for .json file with InputTypeLocal (line 174-178)
 func TestValidateImportSource_CRTDLFileForLocalInput(t *testing.T) {
 	tempDir := t.TempDir()
-	crtdlFile := filepath.Join(tempDir, "cohort.crtdl")
+	crtdlFile := filepath.Join(tempDir, "cohort.json")
 
 	// Create CRTDL file
 	require.NoError(t, os.WriteFile(crtdlFile, []byte(`{"cohortDefinition": {}}`), 0644))
@@ -476,7 +476,7 @@ func TestValidateImportSource_CRTDLFileForLocalInput(t *testing.T) {
 	assert.Error(t, err, "Should return error for CRTDL file with InputTypeLocal")
 	assert.Contains(t, err.Error(), "expected directory but got file", "Error should mention file vs directory")
 	// Verify the hint message (lines 174-178)
-	assert.Contains(t, err.Error(), "JSON/CRTDL file", "Error should contain JSON/CRTDL hint")
+	assert.Contains(t, err.Error(), "JSON file", "Error should contain JSON hint")
 	assert.Contains(t, err.Error(), "cohortDefinition", "Error should mention cohortDefinition")
 	assert.Contains(t, err.Error(), "dataExtraction", "Error should mention dataExtraction")
 	assert.Contains(t, err.Error(), "verbose logging", "Error should mention verbose logging")
@@ -1055,7 +1055,7 @@ func TestValidateImportSource_CRTDLStatAccessError(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	crtdlFile := filepath.Join(tempDir, "cohort.crtdl")
+	crtdlFile := filepath.Join(tempDir, "cohort.json")
 
 	// Create CRTDL file
 	require.NoError(t, os.WriteFile(crtdlFile, []byte(`{"cohortDefinition":{}}`), 0644))

--- a/tests/unit/import_step_test.go
+++ b/tests/unit/import_step_test.go
@@ -206,9 +206,9 @@ func TestExecuteImportStep_TorchImportCRTDLValidationFailure(t *testing.T) {
 	// Create a job with torch import step but non-existent CRTDL file
 	job := &models.PipelineJob{
 		JobID:       "test-job-123",
-		InputSource: "/nonexistent/file.crtdl", // Non-existent CRTDL file
+		InputSource: "/nonexistent/file.json", // Non-existent CRTDL file
 		InputType:   models.InputTypeCRTDL,
-		CRTDLPath:   "/nonexistent/file.crtdl",
+		CRTDLPath:   "/nonexistent/file.json",
 		CurrentStep: string(models.StepTorchImport),
 		Status:      models.JobStatusPending,
 		Steps:       models.InitializeSteps([]models.StepName{models.StepTorchImport}),

--- a/tests/unit/import_step_test.go
+++ b/tests/unit/import_step_test.go
@@ -208,6 +208,7 @@ func TestExecuteImportStep_TorchImportCRTDLValidationFailure(t *testing.T) {
 		JobID:       "test-job-123",
 		InputSource: "/nonexistent/file.crtdl", // Non-existent CRTDL file
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   "/nonexistent/file.crtdl",
 		CurrentStep: string(models.StepTorchImport),
 		Status:      models.JobStatusPending,
 		Steps:       models.InitializeSteps([]models.StepName{models.StepTorchImport}),

--- a/tests/unit/import_step_test.go
+++ b/tests/unit/import_step_test.go
@@ -280,11 +280,14 @@ func TestExecuteImportStep_TorchImportInvalidInputType(t *testing.T) {
 	}
 	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
-	// Create a job with torch import step but local input type (not CRTDL or TORCH URL)
+	// Create a job with torch import step but no CRTDL attached (and not a
+	// TORCH result URL). Under the decoupled model, torch import submits
+	// job.CRTDLPath; validation must reject an empty CRTDL.
 	job := &models.PipelineJob{
 		JobID:       "test-job-123",
-		InputSource: "/some/local/path",
-		InputType:   models.InputTypeLocal, // Invalid for torch import
+		InputSource: "",
+		InputType:   models.InputTypeLocal,
+		CRTDLPath:   "",
 		CurrentStep: string(models.StepTorchImport),
 		Status:      models.JobStatusPending,
 		Steps:       models.InitializeSteps([]models.StepName{models.StepTorchImport}),
@@ -297,10 +300,10 @@ func TestExecuteImportStep_TorchImportInvalidInputType(t *testing.T) {
 		},
 	}
 
-	// Execute import step - should fail with invalid input type
+	// Execute import step - should fail because no CRTDL is attached
 	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
 
-	require.Error(t, err, "Should fail when torch import has invalid input type")
+	require.Error(t, err, "Should fail when torch import has no CRTDL")
 	assert.NotNil(t, updatedJob, "Should return updated job even on error")
-	assert.Contains(t, err.Error(), "torch import requires CRTDL file or TORCH URL", "Error should mention requirement")
+	assert.Contains(t, err.Error(), "CRTDL file path cannot be empty", "Error should mention missing CRTDL")
 }

--- a/tests/unit/input_detection_test.go
+++ b/tests/unit/input_detection_test.go
@@ -56,7 +56,7 @@ func TestDetectInputType_TORCHUrlHTTPS(t *testing.T) {
 
 func TestDetectInputType_CRTDLFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlFile := filepath.Join(tmpDir, "query.crtdl")
+	crtdlFile := filepath.Join(tmpDir, "crtdl.json")
 
 	// Create valid CRTDL file
 	validCRTDL := `{
@@ -79,7 +79,7 @@ func TestDetectInputType_CRTDLFile(t *testing.T) {
 
 func TestDetectInputType_JSONFileIsCRTDL(t *testing.T) {
 	tmpDir := t.TempDir()
-	jsonFile := filepath.Join(tmpDir, "query.json")
+	jsonFile := filepath.Join(tmpDir, "crtdl.json")
 
 	// Create valid CRTDL file with .json extension
 	validCRTDL := `{
@@ -134,7 +134,7 @@ func TestDetectInputType_EmptyString(t *testing.T) {
 
 func TestDetectInputType_InvalidCRTDLExtension(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlFile := filepath.Join(tmpDir, "query.crtdl")
+	crtdlFile := filepath.Join(tmpDir, "crtdl.json")
 
 	// Create invalid CRTDL file (missing required fields)
 	invalidCRTDL := `{
@@ -143,7 +143,7 @@ func TestDetectInputType_InvalidCRTDLExtension(t *testing.T) {
 	err := os.WriteFile(crtdlFile, []byte(invalidCRTDL), 0644)
 	require.NoError(t, err)
 
-	// Invalid CRTDL files with .crtdl extension default to local type
+	// Invalid CRTDL files with .json extension default to local type
 	// (CRTDL validation errors occur during job creation, not input type detection)
 	inputType, err := lib.DetectInputType(crtdlFile)
 	assert.NoError(t, err, "Detection should succeed, CRTDL validation happens later")
@@ -152,7 +152,7 @@ func TestDetectInputType_InvalidCRTDLExtension(t *testing.T) {
 
 func TestDetectInputType_MalformedJSON(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlFile := filepath.Join(tmpDir, "query.crtdl")
+	crtdlFile := filepath.Join(tmpDir, "crtdl.json")
 
 	// Create malformed JSON
 	malformedJSON := `{

--- a/tests/unit/lib/validation_edge_cases_test.go
+++ b/tests/unit/lib/validation_edge_cases_test.go
@@ -135,7 +135,7 @@ func TestDetectInputType(t *testing.T) {
 			name:        "Valid CRTDL file",
 			inputSource: "",
 			setup: func() string {
-				crtdlPath := filepath.Join(tmpDir, "test.crtdl")
+				crtdlPath := filepath.Join(tmpDir, "test.json")
 				crtdlContent := `{
 					"cohortDefinition": {
 						"inclusionCriteria": [[]]
@@ -154,7 +154,7 @@ func TestDetectInputType(t *testing.T) {
 			name:        "Invalid CRTDL file (wrong structure)",
 			inputSource: "",
 			setup: func() string {
-				crtdlPath := filepath.Join(tmpDir, "invalid.crtdl")
+				crtdlPath := filepath.Join(tmpDir, "invalid.json")
 				crtdlContent := `{"invalid": "structure"}`
 				_ = os.WriteFile(crtdlPath, []byte(crtdlContent), 0644)
 				return crtdlPath
@@ -166,7 +166,7 @@ func TestDetectInputType(t *testing.T) {
 			name:        "JSON file with CRTDL structure",
 			inputSource: "",
 			setup: func() string {
-				jsonPath := filepath.Join(tmpDir, "query.json")
+				jsonPath := filepath.Join(tmpDir, "crtdl.json")
 				jsonContent := `{
 					"cohortDefinition": {
 						"inclusionCriteria": [[]]
@@ -268,7 +268,7 @@ func TestIsCRTDLFile(t *testing.T) {
 		},
 		{
 			name:      "Non-existent file",
-			setupFile: func() string { return "/non/existent/file.crtdl" },
+			setupFile: func() string { return "/non/existent/file.json" },
 			isCRTDL:   false,
 		},
 	}
@@ -279,7 +279,7 @@ func TestIsCRTDLFile(t *testing.T) {
 			if tc.setupFile != nil {
 				filePath = tc.setupFile()
 			} else {
-				filePath = filepath.Join(tmpDir, "test.crtdl")
+				filePath = filepath.Join(tmpDir, "test.json")
 				err := os.WriteFile(filePath, []byte(tc.content), 0644)
 				require.NoError(t, err)
 			}
@@ -349,7 +349,7 @@ func TestIsCRTDLFileWithHint(t *testing.T) {
 		},
 		{
 			name:         "Non-existent file",
-			setupFile:    func() string { return "/non/existent/file.crtdl" },
+			setupFile:    func() string { return "/non/existent/file.json" },
 			expectValid:  false,
 			hintContains: "cannot read file",
 		},
@@ -361,7 +361,7 @@ func TestIsCRTDLFileWithHint(t *testing.T) {
 			if tc.setupFile != nil {
 				filePath = tc.setupFile()
 			} else {
-				filePath = filepath.Join(tmpDir, "test.crtdl")
+				filePath = filepath.Join(tmpDir, "test.json")
 				err := os.WriteFile(filePath, []byte(tc.content), 0644)
 				require.NoError(t, err)
 			}
@@ -407,7 +407,7 @@ func TestValidateCRTDLSyntax(t *testing.T) {
 		},
 		{
 			name:          "File not found",
-			setupFile:     func() string { return "/non/existent/file.crtdl" },
+			setupFile:     func() string { return "/non/existent/file.json" },
 			expectError:   true,
 			errorContains: "failed to read CRTDL file",
 		},
@@ -502,7 +502,7 @@ func TestValidateCRTDLSyntax(t *testing.T) {
 			if tc.setupFile != nil {
 				filePath = tc.setupFile()
 			} else {
-				filePath = filepath.Join(tmpDir, "test.crtdl")
+				filePath = filepath.Join(tmpDir, "test.json")
 				err := os.WriteFile(filePath, []byte(tc.content), 0644)
 				require.NoError(t, err)
 			}
@@ -524,7 +524,7 @@ func TestValidateCRTDLSyntax_ErrorMessages(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	t.Run("Error shows available keys when cohortDefinition missing", func(t *testing.T) {
-		filePath := filepath.Join(tmpDir, "missing-cohort.crtdl")
+		filePath := filepath.Join(tmpDir, "missing-cohort.json")
 		content := `{
 			"wrongKey": "value",
 			"dataExtraction": {"attributeGroups": []}
@@ -538,7 +538,7 @@ func TestValidateCRTDLSyntax_ErrorMessages(t *testing.T) {
 	})
 
 	t.Run("Error shows available keys when dataExtraction missing", func(t *testing.T) {
-		filePath := filepath.Join(tmpDir, "missing-extraction.crtdl")
+		filePath := filepath.Join(tmpDir, "missing-extraction.json")
 		content := `{
 			"cohortDefinition": {"inclusionCriteria": [[]]},
 			"wrongKey": "value"
@@ -552,7 +552,7 @@ func TestValidateCRTDLSyntax_ErrorMessages(t *testing.T) {
 	})
 
 	t.Run("Error shows expected structure", func(t *testing.T) {
-		filePath := filepath.Join(tmpDir, "bad-structure.crtdl")
+		filePath := filepath.Join(tmpDir, "bad-structure.json")
 		content := `{"invalid": "data"}`
 		_ = os.WriteFile(filePath, []byte(content), 0644)
 
@@ -580,8 +580,8 @@ func TestDetectInputType_Integration(t *testing.T) {
 		assert.Equal(t, models.InputTypeLocal, inputType)
 	})
 
-	t.Run("CRTDL file with .crtdl extension", func(t *testing.T) {
-		crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	t.Run("CRTDL file with .json extension", func(t *testing.T) {
+		crtdlPath := filepath.Join(tmpDir, "crtdl.json")
 		crtdlContent := `{
 			"cohortDefinition": {"inclusionCriteria": [[]]},
 			"dataExtraction": {"attributeGroups": []}
@@ -594,7 +594,7 @@ func TestDetectInputType_Integration(t *testing.T) {
 	})
 
 	t.Run("CRTDL file with .json extension", func(t *testing.T) {
-		jsonPath := filepath.Join(tmpDir, "query.json")
+		jsonPath := filepath.Join(tmpDir, "crtdl.json")
 		jsonContent := `{
 			"cohortDefinition": {"inclusionCriteria": [[]]},
 			"dataExtraction": {"attributeGroups": []}

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -727,6 +727,62 @@ func TestClassifyFlatteningError(t *testing.T) {
 	})
 }
 
+// TestExecuteFlatteningStep_MissingCRTDLPath verifies the decoupling from
+// issue #286: flattening rejects jobs with no CRTDL attached regardless of
+// InputType, and the error message points to both attachment mechanisms.
+func TestExecuteFlatteningStep_MissingCRTDLPath(t *testing.T) {
+	tempDir := t.TempDir()
+	jobID := "test-no-crtdl"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	require.NoError(t, os.MkdirAll(jobDir, 0755))
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
+
+	job := createFlatteningTestJob("http://localhost:8080", lookupPath, "")
+	job.InputSource = "https://example.com/data.ndjson"
+	job.InputType = models.InputTypeHTTP
+	job.CRTDLPath = ""
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CRTDL")
+	assert.Contains(t, err.Error(), "--crtdl")
+}
+
+// TestExecuteFlatteningStep_AcceptsHTTPInputWithCRTDLPath verifies that an
+// http_import job carrying a CRTDL via CRTDLPath proceeds past the gate that
+// previously blocked it. The job completes with no matching resources (empty
+// input dir) — the point is that the CRTDL precondition no longer depends on
+// InputType.
+func TestExecuteFlatteningStep_AcceptsHTTPInputWithCRTDLPath(t *testing.T) {
+	tempDir := t.TempDir()
+	jobID := "test-http-crtdl"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
+
+	// Minimal resource with no matching provenance -> no CSV emitted, but
+	// the flattening step must not reject the job on the CRTDL check.
+	patient := map[string]any{"resourceType": "Patient", "id": "1"}
+	prov := makeProvenance("prov-1", "Patient/1", "different-group-id")
+	bundle := makeBundle("b1", patient, prov)
+	writeTestNDJSON(t, filepath.Join(inputDir, "test.ndjson"), []map[string]any{bundle})
+
+	job := createFlatteningTestJob("http://localhost:8080", lookupPath, crtdlPath)
+	job.InputSource = "https://example.com/data.ndjson"
+	job.InputType = models.InputTypeHTTP
+	// CRTDLPath is set by createFlatteningTestJob via crtdlPath arg
+
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger())
+	require.NoError(t, err, "http_import + CRTDLPath must be accepted (issue #286)")
+}
+
 // Helper function to create a test flattening job
 func createFlatteningTestJob(serviceURL, lookupPath, crtdlPath string) *models.PipelineJob {
 	return &models.PipelineJob{
@@ -734,6 +790,7 @@ func createFlatteningTestJob(serviceURL, lookupPath, crtdlPath string) *models.P
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -810,6 +867,7 @@ func TestExecuteFlatteningStep_ConfigValidationError(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{
@@ -1694,6 +1752,7 @@ func TestExecuteFlatteningStep_ProvenanceInPseudonymizedDir(t *testing.T) {
 		Status:      models.JobStatusInProgress,
 		InputSource: crtdlPath,
 		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
 		Config: models.ProjectConfig{
 			Services: models.ServiceConfig{
 				Flattening: models.FlatteningConfig{

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -762,7 +762,7 @@ func TestExecuteFlatteningStep_AcceptsHTTPInputWithCRTDLPath(t *testing.T) {
 	inputDir := filepath.Join(jobDir, "import")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 	lookupPath := filepath.Join(tempDir, "lookup.json")
 	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
@@ -858,7 +858,7 @@ func TestExecuteFlatteningStep_ConfigValidationError(t *testing.T) {
 	jobDir := filepath.Join(tempDir, "jobs", "test-job")
 	require.NoError(t, os.MkdirAll(jobDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 
 	// Create job with invalid config (empty ServiceURL)
@@ -897,7 +897,7 @@ func TestExecuteFlatteningStep_LookupValidationError(t *testing.T) {
 	jobDir := filepath.Join(tempDir, "jobs", "test-job")
 	require.NoError(t, os.MkdirAll(jobDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 
 	// Create lookup table with duplicate URLs (validation error)
@@ -936,7 +936,7 @@ func TestExecuteFlatteningStep_ViewDefinitionBuildError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Create CRTDL referencing a profile that doesn't exist in lookup
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "UnknownType", "https://example.com/UnknownProfile")
 
 	// Create lookup table for a different profile
@@ -968,7 +968,7 @@ func TestExecuteFlatteningStep_NoMatchingResources(t *testing.T) {
 	inputDir := filepath.Join(jobDir, "import")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1001,7 +1001,7 @@ func TestExecuteFlatteningStep_LoadAllResourcesError(t *testing.T) {
 	inputDir := filepath.Join(jobDir, "import")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1031,7 +1031,7 @@ func TestExecuteFlatteningStep_OutputDirCreationError(t *testing.T) {
 	inputDir := filepath.Join(jobDir, "import")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1099,7 +1099,7 @@ func TestExecuteFlatteningStep_ViewDefinitionWriteError(t *testing.T) {
 	require.NoError(t, os.WriteFile(viewDefDir, []byte("not a directory"), 0644))
 
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", "https://example.com/Patient")
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1158,7 +1158,7 @@ func TestExecuteFlatteningStep_CSVWriteError(t *testing.T) {
 	})
 
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", "https://example.com/Patient")
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1208,7 +1208,7 @@ func TestExecuteFlatteningStep_MultipleBatches(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1273,7 +1273,7 @@ func TestExecuteFlatteningStep_FlattenerError(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1318,7 +1318,7 @@ func TestExecuteFlatteningStep_BundleExtraction(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1374,7 +1374,7 @@ func TestExecuteFlatteningStep_StreamingEdgeCases(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1441,7 +1441,7 @@ func TestExecuteFlatteningStep_BatchFlushOnThreshold(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1525,7 +1525,7 @@ func TestExecuteFlatteningStep_NilViewDefSkipped(t *testing.T) {
 
 	// CRTDL references a profile, but the lookup table has NO matching entry for it.
 	// This means the ViewDefinition build will fail, leaving viewDefs[0] == nil.
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1565,7 +1565,7 @@ func TestExecuteFlatteningStep_BundleEntryUnmatchedProfile(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1601,7 +1601,7 @@ func TestExecuteFlatteningStep_FlattenerErrorDuringFlush(t *testing.T) {
 
 	profileURL := "https://example.com/Patient"
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1689,7 +1689,7 @@ func TestExecuteFlatteningStep_OpenFileError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	profileURL := "https://example.com/Patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-patient", "Patient", profileURL)
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -1731,7 +1731,7 @@ func TestExecuteFlatteningStep_ProvenanceInPseudonymizedDir(t *testing.T) {
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
 	groupID := "group-patient"
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, groupID, "Patient", "https://example.com/Patient")
 	lookupPath := filepath.Join(tempDir, "lookup.json")
 	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
@@ -1794,7 +1794,7 @@ func TestExecuteFlatteningStep_UnknownProfile(t *testing.T) {
 	inputDir := filepath.Join(jobDir, "import")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	writeTestCRTDL(t, crtdlPath, "group-patient", "Patient", "https://example.com/Patient")
 
 	lookupPath := filepath.Join(tempDir, "lookup.json")

--- a/tests/unit/pipeline_job_test.go
+++ b/tests/unit/pipeline_job_test.go
@@ -412,10 +412,11 @@ func TestCreateJob_CRTDLFlagWithHTTPInput(t *testing.T) {
 	assert.Equal(t, string(models.StepHttpImport), job.CurrentStep)
 }
 
-// TestCreateJob_TorchBackwardCompat verifies CRTDL-positional callers keep
-// working without passing --crtdl: CRTDLPath is backfilled from InputSource
-// and then repointed by PrepareCRTDL at the canonical jobDir copy.
-func TestCreateJob_TorchBackwardCompat(t *testing.T) {
+// TestCreateJob_TorchCRTDLOnly verifies a torch job where the CRTDL is
+// attached via crtdlPath and no separate input source is provided (the
+// typical torch-extraction shape under the CRTDL-as-positional CLI contract).
+// PrepareCRTDL repoints CRTDLPath at the canonical copy inside jobDir.
+func TestCreateJob_TorchCRTDLOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
 	writeValidCRTDL(t, crtdlPath)
@@ -428,41 +429,39 @@ func TestCreateJob_TorchBackwardCompat(t *testing.T) {
 		},
 	}
 
-	job, err := pipeline.CreateJob(crtdlPath, "", config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob("", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.NoError(t, err)
 	require.NotNil(t, job)
-	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
-	assert.Equal(t, crtdlPath, job.InputSource)
+	assert.Equal(t, models.InputTypeLocal, job.InputType, "no external input source → default InputTypeLocal")
+	assert.Empty(t, job.InputSource)
 	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath,
-		"CRTDLPath must be backfilled from InputSource then repointed at the prepared copy")
+		"CRTDLPath must point at the prepared CRTDL inside jobDir")
 }
 
-// TestCreateJob_ConflictingCRTDLSources rejects ambiguous input: positional
-// CRTDL + --crtdl flag pointing elsewhere.
-func TestCreateJob_ConflictingCRTDLSources(t *testing.T) {
+// TestCreateJob_InvalidCRTDL covers the CRTDL validation failure branch (job.go line 50-51):
+// when crtdlPath points to a missing/invalid file, CreateJob must surface the
+// validation error rather than silently proceed.
+func TestCreateJob_InvalidCRTDL(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlA := filepath.Join(tmpDir, "a.crtdl")
-	crtdlB := filepath.Join(tmpDir, "b.crtdl")
-	writeValidCRTDL(t, crtdlA)
-	writeValidCRTDL(t, crtdlB)
+	missingCRTDL := filepath.Join(tmpDir, "does-not-exist.crtdl")
 
 	config := models.ProjectConfig{
 		JobsDir: filepath.Join(tmpDir, "jobs"),
 		Pipeline: models.PipelineConfig{
-			EnabledSteps: []models.StepName{models.StepTorchImport},
+			EnabledSteps: []models.StepName{models.StepHttpImport, models.StepFlattening},
 		},
 	}
 
-	job, err := pipeline.CreateJob(crtdlA, crtdlB, config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob("https://example.com/data.ndjson", missingCRTDL, config, lib.NewLogger(lib.LogLevelDebug))
 
-	require.Error(t, err)
+	require.Error(t, err, "CreateJob must fail when CRTDL file is unreadable")
 	assert.Nil(t, job)
-	assert.Contains(t, err.Error(), "conflicting CRTDL sources")
+	assert.Contains(t, err.Error(), "CRTDL validation failed", "error must mention CRTDL validation")
 }
 
 // TestCreateJob_CRTDLFlagOnlyNoPositional covers the local_import scenario
-// where the data dir comes from config and --crtdl attaches the query.
+// where the data dir comes from config and the CRTDL is attached separately.
 func TestCreateJob_CRTDLFlagOnlyNoPositional(t *testing.T) {
 	tmpDir := t.TempDir()
 	crtdlPath := filepath.Join(tmpDir, "query.crtdl")

--- a/tests/unit/pipeline_job_test.go
+++ b/tests/unit/pipeline_job_test.go
@@ -302,7 +302,7 @@ func TestCreateJob_FailsWhenSaveStateAfterCRTDLPreparationFails(t *testing.T) {
 
 	// Write a valid CRTDL file so DetectInputType returns CRTDL and
 	// ValidateCRTDLSyntax/ParseCRTDL both succeed.
-	crtdlPath := filepath.Join(tmpDir, "input.crtdl")
+	crtdlPath := filepath.Join(tmpDir, "input.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -390,7 +390,7 @@ func writeValidCRTDL(t *testing.T, path string) {
 // the canonical copy inside the job directory.
 func TestCreateJob_CRTDLFlagWithHTTPInput(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	crtdlPath := filepath.Join(tmpDir, "crtdl.json")
 	writeValidCRTDL(t, crtdlPath)
 
 	jobsDir := filepath.Join(tmpDir, "jobs")
@@ -418,7 +418,7 @@ func TestCreateJob_CRTDLFlagWithHTTPInput(t *testing.T) {
 // PrepareCRTDL repoints CRTDLPath at the canonical copy inside jobDir.
 func TestCreateJob_TorchCRTDLOnly(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	crtdlPath := filepath.Join(tmpDir, "crtdl.json")
 	writeValidCRTDL(t, crtdlPath)
 
 	jobsDir := filepath.Join(tmpDir, "jobs")
@@ -444,7 +444,7 @@ func TestCreateJob_TorchCRTDLOnly(t *testing.T) {
 // validation error rather than silently proceed.
 func TestCreateJob_InvalidCRTDL(t *testing.T) {
 	tmpDir := t.TempDir()
-	missingCRTDL := filepath.Join(tmpDir, "does-not-exist.crtdl")
+	missingCRTDL := filepath.Join(tmpDir, "does-not-exist.json")
 
 	config := models.ProjectConfig{
 		JobsDir: filepath.Join(tmpDir, "jobs"),
@@ -464,7 +464,7 @@ func TestCreateJob_InvalidCRTDL(t *testing.T) {
 // where the data dir comes from config and the CRTDL is attached separately.
 func TestCreateJob_CRTDLFlagOnlyNoPositional(t *testing.T) {
 	tmpDir := t.TempDir()
-	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	crtdlPath := filepath.Join(tmpDir, "crtdl.json")
 	writeValidCRTDL(t, crtdlPath)
 
 	jobsDir := filepath.Join(tmpDir, "jobs")

--- a/tests/unit/pipeline_job_test.go
+++ b/tests/unit/pipeline_job_test.go
@@ -282,7 +282,7 @@ func TestCreateJob_EmptyInputSource(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Create job with empty input source
-	job, err := pipeline.CreateJob("", config, logger)
+	job, err := pipeline.CreateJob("", "", config, logger)
 
 	require.NoError(t, err, "CreateJob should succeed with empty input source")
 	assert.NotNil(t, job)
@@ -344,7 +344,7 @@ func TestCreateJob_FailsWhenSaveStateAfterCRTDLPreparationFails(t *testing.T) {
 	}
 	services.StateFileOpsProvider = ops
 
-	job, err := pipeline.CreateJob(crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob(crtdlPath, "", config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.Error(t, err, "CreateJob must surface the second SaveJobState failure")
 	assert.Nil(t, job)
@@ -369,9 +369,122 @@ func TestCreateJob_NoImportStepEnabled(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Create job - should fail because no import step is enabled
-	job, err := pipeline.CreateJob("/some/path", config, logger)
+	job, err := pipeline.CreateJob("/some/path", "", config, logger)
 
 	require.Error(t, err, "CreateJob should fail when no import step is enabled")
 	assert.Nil(t, job)
 	assert.Contains(t, err.Error(), "no import step enabled", "Error should mention no import step")
+}
+
+// writeValidCRTDL writes a minimal structurally-valid CRTDL file for testing.
+func writeValidCRTDL(t *testing.T, path string) {
+	t.Helper()
+	content := `{"cohortDefinition":{"inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+}
+
+// TestCreateJob_CRTDLFlagWithHTTPInput verifies issue #286: an HTTP URL can
+// be combined with a CRTDL attached via the explicit crtdlPath arg. The job
+// retains InputType=HTTP (so http_import runs) and carries CRTDLPath for
+// flattening. CreateJob runs PrepareCRTDL so CRTDLPath ends up pointing at
+// the canonical copy inside the job directory.
+func TestCreateJob_CRTDLFlagWithHTTPInput(t *testing.T) {
+	tmpDir := t.TempDir()
+	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	writeValidCRTDL(t, crtdlPath)
+
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	config := models.ProjectConfig{
+		JobsDir: jobsDir,
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepHttpImport, models.StepFlattening},
+		},
+	}
+
+	job, err := pipeline.CreateJob("https://example.com/data.ndjson", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, models.InputTypeHTTP, job.InputType, "http URL should still be http_url")
+	assert.Equal(t, "https://example.com/data.ndjson", job.InputSource)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath,
+		"CRTDLPath must point at the prepared CRTDL inside jobDir")
+	assert.Equal(t, string(models.StepHttpImport), job.CurrentStep)
+}
+
+// TestCreateJob_TorchBackwardCompat verifies CRTDL-positional callers keep
+// working without passing --crtdl: CRTDLPath is backfilled from InputSource
+// and then repointed by PrepareCRTDL at the canonical jobDir copy.
+func TestCreateJob_TorchBackwardCompat(t *testing.T) {
+	tmpDir := t.TempDir()
+	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	writeValidCRTDL(t, crtdlPath)
+
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	config := models.ProjectConfig{
+		JobsDir: jobsDir,
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepTorchImport},
+		},
+	}
+
+	job, err := pipeline.CreateJob(crtdlPath, "", config, lib.NewLogger(lib.LogLevelDebug))
+
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
+	assert.Equal(t, crtdlPath, job.InputSource)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath,
+		"CRTDLPath must be backfilled from InputSource then repointed at the prepared copy")
+}
+
+// TestCreateJob_ConflictingCRTDLSources rejects ambiguous input: positional
+// CRTDL + --crtdl flag pointing elsewhere.
+func TestCreateJob_ConflictingCRTDLSources(t *testing.T) {
+	tmpDir := t.TempDir()
+	crtdlA := filepath.Join(tmpDir, "a.crtdl")
+	crtdlB := filepath.Join(tmpDir, "b.crtdl")
+	writeValidCRTDL(t, crtdlA)
+	writeValidCRTDL(t, crtdlB)
+
+	config := models.ProjectConfig{
+		JobsDir: filepath.Join(tmpDir, "jobs"),
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepTorchImport},
+		},
+	}
+
+	job, err := pipeline.CreateJob(crtdlA, crtdlB, config, lib.NewLogger(lib.LogLevelDebug))
+
+	require.Error(t, err)
+	assert.Nil(t, job)
+	assert.Contains(t, err.Error(), "conflicting CRTDL sources")
+}
+
+// TestCreateJob_CRTDLFlagOnlyNoPositional covers the local_import scenario
+// where the data dir comes from config and --crtdl attaches the query.
+func TestCreateJob_CRTDLFlagOnlyNoPositional(t *testing.T) {
+	tmpDir := t.TempDir()
+	crtdlPath := filepath.Join(tmpDir, "query.crtdl")
+	writeValidCRTDL(t, crtdlPath)
+
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	config := models.ProjectConfig{
+		JobsDir: jobsDir,
+		Services: models.ServiceConfig{
+			LocalImport: models.LocalImportConfig{Dir: tmpDir},
+		},
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepLocalImport, models.StepFlattening},
+		},
+	}
+
+	job, err := pipeline.CreateJob("", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, models.InputTypeLocal, job.InputType)
+	assert.Equal(t, "", job.InputSource)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath,
+		"CRTDLPath must point at the prepared CRTDL inside jobDir")
 }

--- a/tests/unit/state_persistence_test.go
+++ b/tests/unit/state_persistence_test.go
@@ -282,7 +282,7 @@ func TestLoadJobState_BackfillCRTDLPath(t *testing.T) {
 	jobDir := services.GetJobDir(tempDir, jobID)
 	require.NoError(t, os.MkdirAll(jobDir, 0755))
 
-	crtdlInSource := filepath.Join(tempDir, "legacy.crtdl")
+	crtdlInSource := filepath.Join(tempDir, "legacy.json")
 	now := time.Now()
 
 	legacy := map[string]any{

--- a/tests/unit/state_persistence_test.go
+++ b/tests/unit/state_persistence_test.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -268,6 +269,89 @@ func TestStatePersistence_ConcurrentAccess(t *testing.T) {
 	loadedJob, err := services.LoadJobState(tempDir, jobID)
 	require.NoError(t, err)
 	assert.Equal(t, 90, loadedJob.TotalFiles, "Final state should have last written value")
+}
+
+// TestLoadJobState_BackfillCRTDLPath verifies the legacy-state backfill branch
+// in state.go (lines 75-77): jobs saved before issue #286 carried the CRTDL
+// path in InputSource (with InputType=crtdl_file) and no CRTDLPath field.
+// On load, CRTDLPath must be populated from InputSource so flattening still
+// resolves the CRTDL for pre-existing jobs.
+func TestLoadJobState_BackfillCRTDLPath(t *testing.T) {
+	tempDir := t.TempDir()
+	jobID := uuid.New().String()
+	jobDir := services.GetJobDir(tempDir, jobID)
+	require.NoError(t, os.MkdirAll(jobDir, 0755))
+
+	crtdlInSource := filepath.Join(tempDir, "legacy.crtdl")
+	now := time.Now()
+
+	legacy := map[string]any{
+		"job_id":       jobID,
+		"created_at":   now.Format(time.RFC3339Nano),
+		"updated_at":   now.Format(time.RFC3339Nano),
+		"input_source": crtdlInSource,
+		"input_type":   string(models.InputTypeCRTDL),
+		// CRTDLPath intentionally omitted to simulate pre-#286 state.
+		"current_step": string(models.StepTorchImport),
+		"status":       string(models.JobStatusPending),
+		"steps": []map[string]any{
+			{
+				"name":            string(models.StepTorchImport),
+				"status":          string(models.StepStatusPending),
+				"files_processed": 0,
+				"bytes_processed": 0,
+			},
+		},
+		"config": map[string]any{
+			"pipeline": map[string]any{
+				"enabled_steps": []string{string(models.StepTorchImport)},
+			},
+			"services": map[string]any{
+				"torch": map[string]any{
+					"base_url": "http://torch.example",
+				},
+			},
+			"retry": map[string]any{
+				"max_attempts":       5,
+				"initial_backoff_ms": 1000,
+				"max_backoff_ms":     30000,
+			},
+			"jobs_dir": tempDir,
+		},
+		"total_files": 0,
+		"total_bytes": 0,
+	}
+
+	data, err := json.MarshalIndent(legacy, "", "  ")
+	require.NoError(t, err)
+	statePath := services.GetStateFilePath(tempDir, jobID)
+	require.NoError(t, os.WriteFile(statePath, data, 0644))
+
+	loaded, err := services.LoadJobState(tempDir, jobID)
+	require.NoError(t, err, "legacy state without CRTDLPath must load via backfill")
+	require.NotNil(t, loaded)
+	assert.Equal(t, crtdlInSource, loaded.CRTDLPath, "CRTDLPath must be backfilled from InputSource")
+	assert.Equal(t, crtdlInSource, loaded.InputSource, "InputSource must remain unchanged")
+	assert.Equal(t, models.InputTypeCRTDL, loaded.InputType)
+}
+
+// TestLoadJobState_BackfillSkippedForNonCRTDL verifies the backfill does NOT
+// run when InputType is something other than crtdl_file: CRTDLPath must stay
+// empty and InputSource must not be copied into it.
+func TestLoadJobState_BackfillSkippedForNonCRTDL(t *testing.T) {
+	tempDir := t.TempDir()
+	jobID := uuid.New().String()
+
+	job := createTestJob(jobID, tempDir)
+	job.InputType = models.InputTypeLocal
+	job.InputSource = filepath.Join(tempDir, "data")
+	job.CRTDLPath = ""
+
+	require.NoError(t, services.SaveJobState(tempDir, job))
+
+	loaded, err := services.LoadJobState(tempDir, jobID)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.CRTDLPath, "non-CRTDL jobs must NOT backfill CRTDLPath")
 }
 
 // Helper function to create a test job

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -24,7 +24,7 @@ import (
 func TestTORCHClient_SubmitExtraction_Success(t *testing.T) {
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -93,7 +93,7 @@ func TestTORCHClient_SubmitExtraction_FileNotFound(t *testing.T) {
 	}
 
 	client := services.NewTORCHClient(torchConfig, httpClient, logger)
-	_, err := client.SubmitExtraction("/nonexistent/file.crtdl")
+	_, err := client.SubmitExtraction("/nonexistent/file.json")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read CRTDL file")
@@ -102,7 +102,7 @@ func TestTORCHClient_SubmitExtraction_FileNotFound(t *testing.T) {
 func TestTORCHClient_SubmitExtraction_Unauthorized(t *testing.T) {
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{"inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
@@ -571,7 +571,7 @@ func TestTORCHClient_DownloadExtractionFiles_PartialFailure(t *testing.T) {
 func TestTORCHClient_EncodeCRTDLToBase64_ValidJSON(t *testing.T) {
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlContent := map[string]any{
 		"cohortDefinition": map[string]any{
 			"version":           "1.0.0",
@@ -782,7 +782,7 @@ func TestTORCHClient_MakeAbsoluteURL_RelativeURL(t *testing.T) {
 
 func TestTORCHClient_EncodeCRTDLToBase64_EmptyFile(t *testing.T) {
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "empty.crtdl")
+	crtdlPath := filepath.Join(tempDir, "empty.json")
 	// Create empty file
 	err := os.WriteFile(crtdlPath, []byte(""), 0644)
 	require.NoError(t, err)
@@ -804,7 +804,7 @@ func TestTORCHClient_EncodeCRTDLToBase64_EmptyFile(t *testing.T) {
 
 func TestTORCHClient_EncodeCRTDLToBase64_InvalidJSON(t *testing.T) {
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "invalid.crtdl")
+	crtdlPath := filepath.Join(tempDir, "invalid.json")
 	// Write invalid JSON
 	err := os.WriteFile(crtdlPath, []byte("{invalid json"), 0644)
 	require.NoError(t, err)
@@ -935,7 +935,7 @@ func TestTORCHClient_ParseExtractionResult_InvalidJSON(t *testing.T) {
 
 func TestTORCHClient_SubmitExtraction_MissingContentLocation(t *testing.T) {
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{"inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 
@@ -1353,7 +1353,7 @@ func TestTORCHClient_DownloadExtractionFiles_CompressedFileSizeSmaller(t *testin
 func TestTORCHClient_SubmitExtraction_HttpDoError(t *testing.T) {
 	// Create temp CRTDL file
 	tempDir := t.TempDir()
-	crtdlPath := filepath.Join(tempDir, "test.crtdl")
+	crtdlPath := filepath.Join(tempDir, "test.json")
 	crtdlJSON := []byte(`{"cohortDefinition":{"inclusionCriteria":[]},"dataExtraction":{"attributeGroups":[]}}`)
 	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
 


### PR DESCRIPTION
## Summary
- Completes the CRTDL / InputType decoupling started for #286: CRTDL is now attached to every job via a dedicated `job.CRTDLPath`, independent of `InputSource`. `http_import` and `local_import` can feed `flattening` without re-interpreting the positional arg.
- **Breaking CLI change**: `aether pipeline start` now requires the CRTDL as the first positional argument; the optional input source (directory / URL) is the second positional. The `--crtdl` flag is removed.
- Torch import dispatches on whether the input is a TORCH result URL; otherwise it submits `job.CRTDLPath`, so torch jobs no longer need `InputType=CRTDL`. `saveCRTDLToJobDir` now repoints `CRTDLPath` (not `InputSource`) so flattening reads the same effective CRTDL that was sent to TORCH.
- Validation loosened: empty `InputSource` is allowed whenever a CRTDL is attached. Error classification in `ExecuteImportStep` keys off the current step, not `InputType`.

## New CLI shape
```
aether pipeline start <crtdl> [input]
  omitted    → torch submits CRTDL / local_import uses --dir or config
  directory  → local_import
  HTTP URL   → http_import (requires --allow-http-crtdl)
  TORCH URL  → torch_import (auto-detected, skips extraction submit)
```

## Examples
```bash
# TORCH extraction
aether pipeline start query.crtdl

# Local import + flattening (dir as positional)
aether pipeline start query.crtdl /path/to/fhir/data

# Local import + flattening (dir via flag)
aether pipeline start query.crtdl --dir /path/to/fhir/data

# HTTP import + flattening
aether pipeline start query.crtdl https://example.com/Patient.ndjson --allow-http-crtdl

# Direct TORCH result URL
aether pipeline start query.crtdl "https://torch.example.com/fhir/extraction/result-123"
```

## Migration
- Callers that passed the CRTDL as the sole positional continue to work (first arg is still the CRTDL path).
- Callers using `--crtdl <file>` with a separate input must move the CRTDL to the first positional and drop the flag.
- Pre-#286 persisted jobs keep loading: `LoadJobState` still backfills `CRTDLPath` from `InputSource` when the old shape is detected.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit + integration + contract)
- [ ] Smoke from a dev shell:
  - [ ] `aether pipeline start query.crtdl` (torch extraction)
  - [ ] `aether pipeline start query.crtdl /data/fhir` (local + flattening)
  - [ ] `aether pipeline start query.crtdl https://.../Patient.ndjson --allow-http-crtdl` (http + flattening)
  - [ ] `aether pipeline start` → expected error: "requires at least 1 arg(s)"
  - [ ] `aether pipeline start not-a-crtdl.txt` → expected error: "first argument must be a CRTDL file"

Closes #286.