### PR TITLE
fix(flattening): stop duplicating sibling blocks in ViewDefinition

### DIFF
--- a/internal/services/viewdefinition_builder.go
+++ b/internal/services/viewdefinition_builder.go
@@ -205,61 +205,50 @@ func (b *ViewDefinitionBuilder) resolveGrandchildren(lookup *models.LookupTable,
 	return result
 }
 
-// resolveWithParent wraps an element's select in parent forEach contexts
-// This handles the case when a child element is referenced directly in CRTDL
-func (b *ViewDefinitionBuilder) resolveWithParent(lookup *models.LookupTable, element *models.LookupElement, elementID string) []models.SelectClause {
-	// Get the element's own resolved selects (with children)
+// resolveWithParent wraps an element's resolved selects in its ancestor chain's
+// forEach contexts. Unlike a naive downward re-resolution from an ancestor,
+// this does not walk the parent's children, so sibling attributes sharing an
+// ancestor do not pollute each other's output (regression fix for #300).
+func (b *ViewDefinitionBuilder) resolveWithParent(lookup *models.LookupTable, element *models.LookupElement, _ string) []models.SelectClause {
 	elementSelects := b.resolveWithChildren(lookup, element)
+	return b.wrapInAncestors(lookup, element.Parent, elementSelects)
+}
 
-	// If no parent, return as-is
-	if element.Parent == "" {
-		return elementSelects
+// wrapInAncestors walks up the parent chain starting at parentID and wraps
+// selects in each ancestor's forEach context. Placeholder ancestors (no root
+// forEach and no select-level forEach) are passed through unchanged so the
+// selects bubble up to the next ancestor that provides context.
+func (b *ViewDefinitionBuilder) wrapInAncestors(lookup *models.LookupTable, parentID string, selects []models.SelectClause) []models.SelectClause {
+	if parentID == "" {
+		return selects
+	}
+	parent := GetElement(lookup, parentID)
+	if parent == nil {
+		return selects
 	}
 
-	// Find parent element
-	parentElement := GetElement(lookup, element.Parent)
-	if parentElement == nil {
-		return elementSelects
-	}
+	wrapped := selects
+	parentHasRootForEach := parent.ViewDefinition.ForEach != "" || parent.ViewDefinition.ForEachOrNull != ""
 
-	// Check if parent has root-level forEach/forEachOrNull
-	parentHasRootForEach := parentElement.ViewDefinition.ForEach != "" || parentElement.ViewDefinition.ForEachOrNull != ""
-
-	// If parent is placeholder (no root forEach and empty Select), continue up the hierarchy
-	if !parentHasRootForEach && len(parentElement.ViewDefinition.Select) == 0 {
-		return b.resolveWithParent(lookup, parentElement, element.Parent)
-	}
-
-	var result []models.SelectClause
-
-	// If parent has root-level forEach, wrap element's selects in parent's context
 	if parentHasRootForEach {
-		wrapper := viewDefSnippetToSelectClause(parentElement.ViewDefinition)
-		wrapper.Select = elementSelects
-		result = []models.SelectClause{wrapper}
+		wrapper := models.SelectClause{
+			ForEach:       parent.ViewDefinition.ForEach,
+			ForEachOrNull: parent.ViewDefinition.ForEachOrNull,
+			Select:        selects,
+		}
+		wrapped = []models.SelectClause{wrapper}
 	} else {
-		// Check if parent's select clauses have forEach
-		for _, parentSel := range parentElement.ViewDefinition.Select {
-			if parentSel.ForEach != "" || parentSel.ForEachOrNull != "" {
-				newSel := cloneSelectClause(parentSel)
-				// Clear existing nested selects and add element's selects
-				newSel.Select = elementSelects
-				result = append(result, newSel)
+		for _, ps := range parent.ViewDefinition.Select {
+			if ps.ForEach != "" || ps.ForEachOrNull != "" {
+				newSel := cloneSelectClause(ps)
+				newSel.Select = selects
+				wrapped = []models.SelectClause{newSel}
+				break
 			}
 		}
 	}
 
-	// If we wrapped in parent's forEach, recursively wrap in grandparent context
-	if len(result) > 0 && parentElement.Parent != "" {
-		return b.resolveWithParent(lookup, parentElement, element.Parent)
-	}
-
-	// If no forEach found in parent, return element's selects directly
-	if len(result) == 0 {
-		return elementSelects
-	}
-
-	return result
+	return b.wrapInAncestors(lookup, parent.Parent, wrapped)
 }
 
 // cloneSelectClause creates a deep copy of a SelectClause

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -1670,3 +1670,95 @@ func TestIssue142EmbedChildrenIntoParents(t *testing.T) {
 		assert.Contains(t, columnNames, "birth_date")
 	})
 }
+
+// TestSiblingsUnderPlaceholderParent is a regression test for issue #300.
+// Two sibling attributes sharing a placeholder parent must produce exactly one
+// block each, not duplicates. The placeholder parent has no root forEach and an
+// empty select, mirroring the structure of auto-generated MII lookup tables
+// where extension leaves share a common abstract ancestor.
+func TestSiblingsUnderPlaceholderParent(t *testing.T) {
+	t.Run("two siblings under placeholder parent produce one block each", func(t *testing.T) {
+		lookupTables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Condition",
+				ResourceType: "Condition",
+				Elements: map[string]models.LookupElement{
+					"Condition.extension": {
+						Children: []string{
+							"Condition.extension:Feststellungsdatum",
+							"Condition.extension:ReferenzPrimaerdiagnose",
+						},
+						ViewDefinition: models.ViewDefSnippet{
+							Select: []models.SelectClause{}, // placeholder
+						},
+					},
+					"Condition.extension:Feststellungsdatum": {
+						Parent: "Condition.extension",
+						ViewDefinition: models.ViewDefSnippet{
+							ForEachOrNull: "extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate')",
+							Column: []models.ColumnDefinition{
+								{Name: "Feststellungsdatum", Path: "value.ofType(dateTime)", Type: "dateTime"},
+							},
+						},
+					},
+					"Condition.extension:ReferenzPrimaerdiagnose": {
+						Parent: "Condition.extension",
+						ViewDefinition: models.ViewDefSnippet{
+							ForEachOrNull: "extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-related')",
+							Column: []models.ColumnDefinition{
+								{Name: "ReferenzPrimaerdiagnose", Path: "value.ofType(Reference).reference", Type: "string"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		group := models.AttributeGroup{
+			Name:           "MII PR Diagnose Condition",
+			GroupReference: "https://example.com/Condition",
+			Attributes: []models.Attribute{
+				{AttributeRef: "Condition.extension:Feststellungsdatum"},
+				{AttributeRef: "Condition.extension:ReferenzPrimaerdiagnose"},
+			},
+		}
+
+		builder := services.NewViewDefinitionBuilder(lookupTables)
+		viewDef, err := builder.BuildViewDefinition(group)
+
+		require.NoError(t, err)
+		require.NotNil(t, viewDef)
+
+		assertedDateCount := 0
+		relatedCount := 0
+		for _, sel := range viewDef.Select {
+			fe := sel.ForEach
+			if fe == "" {
+				fe = sel.ForEachOrNull
+			}
+			switch fe {
+			case "extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate')":
+				assertedDateCount++
+			case "extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-related')":
+				relatedCount++
+			}
+		}
+
+		assert.Equal(t, 1, assertedDateCount, "assertedDate extension block must appear exactly once")
+		assert.Equal(t, 1, relatedCount, "condition-related extension block must appear exactly once")
+
+		columnNames := services.ExtractColumnNames(*viewDef)
+		assert.Equal(t, 1, countOccurrences(columnNames, "Feststellungsdatum"), "Feststellungsdatum column must appear exactly once")
+		assert.Equal(t, 1, countOccurrences(columnNames, "ReferenzPrimaerdiagnose"), "ReferenzPrimaerdiagnose column must appear exactly once")
+	})
+}
+
+func countOccurrences(names []string, target string) int {
+	n := 0
+	for _, s := range names {
+		if s == target {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

- `resolveWithParent` was re-entering itself with the parent element whenever the parent was a placeholder or had a grandparent. That re-entry ran `resolveWithChildren` on the parent and pulled in all of the parent's children — every sibling of the current element. Processing two sibling attributes therefore emitted each sibling's block twice.
- Replaced the two re-entrant calls with `wrapInAncestors`, which walks up the parent chain wrapping the already-resolved `elementSelects` in each ancestor's `forEach` context without re-resolving children. Placeholder ancestors are passed through unchanged.
- Added regression test `TestSiblingsUnderPlaceholderParent` covering two extension siblings sharing a placeholder ancestor (mirrors the real MII lookup layout from the bug report).

Closes #300