### PR TITLE
fix(ci): configure git identity early in docs-deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Determine version and ref
         id: vars
         env:
@@ -190,8 +195,6 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add "${VERSION}" versions.json index.html .nojekyll
           git commit -m "Deploy docs: ${VERSION}" || echo "No changes to commit"
           git push origin gh-pages


### PR DESCRIPTION
## Summary
- Add a dedicated `Configure git identity` step early in the `docs-deploy` job so the orphan-branch init path can commit when `gh-pages` does not yet exist.
- Remove the now-duplicate `git config` lines from the `Commit and push` step (single source of truth).

## Why
On first run (or a fresh fork), the `Checkout gh-pages branch` step creates an orphan branch and runs `git commit -m "Initialize gh-pages branch"` before any identity has been set, causing:

```
fatal: empty ident name (for <runner@...>) not allowed
Error: Process completed with exit code 128.
```

Closes #302