### PR TITLE
docs(nav): separate Community dropdown from version selector

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     // Top navigation bar
     nav: [
       {
-        text: 'GitHub',
+        text: 'Community',
         items: [
           {
             text: 'Issues',

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -77,7 +77,9 @@ onMounted(async () => {
 <style scoped>
 .version-switcher {
   position: relative;
-  margin-right: 8px;
+  margin-right: 16px;
+  padding-right: 16px;
+  border-right: 1px solid var(--vp-c-divider);
 }
 
 .version-button {
@@ -157,7 +159,9 @@ onMounted(async () => {
 }
 
 .version-text {
-  margin-right: 8px;
+  margin-right: 16px;
+  padding-right: 16px;
+  border-right: 1px solid var(--vp-c-divider);
   font-size: 13px;
   color: var(--vp-c-text-2);
 }


### PR DESCRIPTION
## Summary
- Rename the `GitHub` nav dropdown to `Community` so Issues / Discussions / Releases have a clearer label separate from the version selector.
- Add a right-side divider + extra spacing on `VersionSwitcher` (both the dropdown and the text fallback) so the version control reads as its own thing, not the first item of the nav.

## Context
`docs/.vitepress/config.ts` already carried the three links in a `GitHub` dropdown, and `VersionSwitcher.vue` is injected via `nav-bar-content-before` so it sits flush against the nav. That adjacency, plus the shared "pill + caret" shape, made the two controls look merged on the landing page (see #308).

## Verification
- `npm run docs:build` passes (vitepress 1.6.4, build complete in 4.46s).
- Two distinct controls in the header: version selector on the left, `Community` dropdown on the right, separated by a divider line.
- Clicking each only opens its own menu (version selector is self-contained Vue state; `Community` is the vitepress nav item).

Closes #308