### PR TITLE
fix(validation): surface CRTDL errors instead of demoting to local

### DIFF
--- a/internal/lib/validation.go
+++ b/internal/lib/validation.go
@@ -99,13 +99,14 @@ func DetectInputType(inputSource string) (models.InputType, error) {
 	}
 
 	if strings.HasSuffix(inputSource, ".json") {
-		isCRTDL, _ := IsCRTDLFileWithHint(inputSource)
+		isCRTDL, hint := IsCRTDLFileWithHint(inputSource)
 		if isCRTDL {
 			return models.InputTypeCRTDL, nil
 		}
-		// JSON file that isn't a valid CRTDL — fall through to local type.
-		// CRTDL validation errors are surfaced later during job creation.
-		return models.InputTypeLocal, nil
+		// A .json extension is a strong signal of user intent; surface the
+		// structural diagnostic instead of silently demoting to local_directory
+		// and failing downstream with an unrelated-looking torch import error.
+		return "", fmt.Errorf("file %q has a .json extension but is not a valid CRTDL: %s", inputSource, hint)
 	}
 
 	// Default to local path (backward compatibility)

--- a/tests/unit/input_detection_test.go
+++ b/tests/unit/input_detection_test.go
@@ -112,10 +112,11 @@ func TestDetectInputType_JSONFileNotCRTDL(t *testing.T) {
 	err := os.WriteFile(jsonFile, []byte(notCRTDL), 0644)
 	require.NoError(t, err)
 
-	// Non-CRTDL JSON files default to local type (error occurs during import validation)
-	inputType, err := lib.DetectInputType(jsonFile)
-	assert.NoError(t, err, "Detection should succeed, validation happens later")
-	assert.Equal(t, models.InputTypeLocal, inputType, "Non-CRTDL JSON file should default to local type")
+	// .json file failing CRTDL validation surfaces the structural hint
+	_, err = lib.DetectInputType(jsonFile)
+	require.Error(t, err, "non-CRTDL .json should return error")
+	assert.Contains(t, err.Error(), jsonFile, "error should name the offending file")
+	assert.Contains(t, err.Error(), "missing both 'cohortDefinition' and 'dataExtraction'")
 }
 
 func TestDetectInputType_NonExistentPath(t *testing.T) {
@@ -143,30 +144,45 @@ func TestDetectInputType_InvalidCRTDLExtension(t *testing.T) {
 	err := os.WriteFile(crtdlFile, []byte(invalidCRTDL), 0644)
 	require.NoError(t, err)
 
-	// Invalid CRTDL files with .json extension default to local type
-	// (CRTDL validation errors occur during job creation, not input type detection)
-	inputType, err := lib.DetectInputType(crtdlFile)
-	assert.NoError(t, err, "Detection should succeed, CRTDL validation happens later")
-	assert.Equal(t, models.InputTypeLocal, inputType, "Invalid CRTDL should default to local type")
+	// .json extension signals intent: structural failure must surface immediately
+	_, err = lib.DetectInputType(crtdlFile)
+	require.Error(t, err, "invalid CRTDL .json should return error")
+	assert.Contains(t, err.Error(), "cohortDefinition", "error should include structural hint")
 }
 
 func TestDetectInputType_MalformedJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	crtdlFile := filepath.Join(tmpDir, "crtdl.json")
 
-	// Create malformed JSON
+	// Truncated JSON (missing closing braces) - simulates an incomplete export
 	malformedJSON := `{
 		"cohortDefinition": {
 			"version": "1.0"
-		// missing closing braces
 	`
 	err := os.WriteFile(crtdlFile, []byte(malformedJSON), 0644)
 	require.NoError(t, err)
 
-	// Malformed JSON files default to local type (error occurs during CRTDL validation)
-	inputType, err := lib.DetectInputType(crtdlFile)
-	assert.NoError(t, err, "Detection should succeed, JSON parsing errors occur during validation")
-	assert.Equal(t, models.InputTypeLocal, inputType, "Malformed JSON should default to local type")
+	// Malformed JSON surfaces the parse error via the hint
+	_, err = lib.DetectInputType(crtdlFile)
+	require.Error(t, err, "malformed CRTDL .json should return error")
+	assert.Contains(t, err.Error(), "not valid JSON", "error should include JSON parse hint")
+}
+
+func TestDetectInputType_FHIRParametersFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	crtdlFile := filepath.Join(tmpDir, "query.json")
+
+	// Unsupported FHIR Parameters format
+	parametersCRTDL := `{
+		"resourceType": "Parameters",
+		"parameter": []
+	}`
+	err := os.WriteFile(crtdlFile, []byte(parametersCRTDL), 0644)
+	require.NoError(t, err)
+
+	_, err = lib.DetectInputType(crtdlFile)
+	require.Error(t, err, "FHIR Parameters format should return error")
+	assert.Contains(t, err.Error(), "FHIR Parameters format", "error should name the unsupported format")
 }
 
 func TestDetectInputType_TORCHUrlWithoutFHIRPath(t *testing.T) {

--- a/tests/unit/lib/validation_edge_cases_test.go
+++ b/tests/unit/lib/validation_edge_cases_test.go
@@ -86,11 +86,12 @@ func TestDetectInputType(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	testCases := []struct {
-		name         string
-		inputSource  string
-		expectedType models.InputType
-		expectError  bool
-		setup        func() string // Returns actual input path
+		name          string
+		inputSource   string
+		expectedType  models.InputType
+		expectError   bool
+		errorContains string
+		setup         func() string // Returns actual input path
 	}{
 		{
 			name:         "Empty input",
@@ -159,8 +160,8 @@ func TestDetectInputType(t *testing.T) {
 				_ = os.WriteFile(crtdlPath, []byte(crtdlContent), 0644)
 				return crtdlPath
 			},
-			expectedType: models.InputTypeLocal, // Falls back to local
-			expectError:  false,
+			expectError:   true,
+			errorContains: "cohortDefinition",
 		},
 		{
 			name:        "JSON file with CRTDL structure",
@@ -200,6 +201,9 @@ func TestDetectInputType(t *testing.T) {
 
 			if tc.expectError {
 				require.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedType, result)
@@ -611,8 +615,9 @@ func TestDetectInputType_Integration(t *testing.T) {
 		jsonContent := `{"setting": "value"}`
 		_ = os.WriteFile(jsonPath, []byte(jsonContent), 0644)
 
-		inputType, err := lib.DetectInputType(jsonPath)
-		require.NoError(t, err)
-		assert.Equal(t, models.InputTypeLocal, inputType) // Falls back to local
+		// .json with non-CRTDL content surfaces structural hint rather than silently demoting to local
+		_, err := lib.DetectInputType(jsonPath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cohortDefinition")
 	})
 }


### PR DESCRIPTION
## Summary
- `DetectInputType` no longer silently demotes invalid `.crtdl`/`.json` files to `InputTypeLocal`. It now returns an error that includes the file path and the existing structural hint (JSON parse error, missing `cohortDefinition`/`dataExtraction`, or unsupported FHIR Parameters format).
- Users see the actual cause (e.g. a trailing comma in a Data Portal / FDPG export) instead of the misleading `torch import requires CRTDL file or TORCH URL, got input type: local_directory` downstream.
- Tests in `tests/unit/input_detection_test.go` and `tests/unit/lib/validation_edge_cases_test.go` updated to assert on the new error path; added a dedicated case for the FHIR Parameters format.

Closes #282