### PR TITLE
refactor(config): standardize service URLs to server root

### DIFF
--- a/.github/test/aether-direct-load.yaml
+++ b/.github/test/aether-direct-load.yaml
@@ -21,7 +21,7 @@ services:
 
   # Send step configuration - direct resource load to Blaze FHIR server
   send:
-    url: "http://blaze-fhir:8080/fhir"
+    url: "http://blaze-fhir:8080"
     send_as: "direct_resource_load"
     batch_size: 100
 

--- a/.github/test/aether-flattening.yaml
+++ b/.github/test/aether-flattening.yaml
@@ -4,7 +4,7 @@
 services:
   # DIMP Service (dummy URL - step is already completed in pre-staged state)
   dimp:
-    url: "http://fhir-pseudonymizer:8080/fhir"
+    url: "http://fhir-pseudonymizer:8080"
 
   # Flattening Service (FHIR to CSV transformation)
   flattening:

--- a/.github/test/aether.yaml
+++ b/.github/test/aether.yaml
@@ -21,7 +21,7 @@ services:
 
   # DIMP Pseudonymization Service
   dimp:
-    url: "http://fhir-pseudonymizer:8080/fhir"
+    url: "http://fhir-pseudonymizer:8080"
     bundle_split_threshold_mb: 10
 
   # Flattening Service (FHIR to CSV transformation)
@@ -43,7 +43,7 @@ services:
 
   # Send step configuration (Blaze FHIR server for e2e testing)
   send:
-    url: "http://blaze-fhir:8080/fhir"
+    url: "http://blaze-fhir:8080"
     send_as: "transfer_load"
     transfer:
       project_identifier: "MII-E2E-TEST"

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -36,8 +36,9 @@ services:
 
   # DIMP Pseudonymization Service (optional)
   # Leave empty to skip pseudonymization step
+  # URL must be the server root; aether appends /fhir internally.
   dimp:
-    url: "http://localhost:32861/fhir"
+    url: "http://localhost:32861"
 
     # Bundle splitting threshold in megabytes (MB)
     # Large FHIR Bundles exceeding this size will be automatically split into smaller chunks
@@ -112,8 +113,9 @@ services:
     # - "s3_upload": Upload files to S3 bucket
     send_as: "transfer_load"
 
-    # FHIR server base URL (required for direct_resource_load and transfer_load modes)
-    url: "https://fhir-server.example.com/fhir"
+    # FHIR server root URL (required for direct_resource_load and transfer_load modes)
+    # Configure the server root; aether appends /fhir internally.
+    url: "https://fhir-server.example.com"
 
     # Number of resources per transaction bundle (only for direct_resource_load mode)
     # Default: 100, Max: 1000

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -111,13 +111,13 @@ DIMP pseudonymization service.
 ```yaml
 services:
   dimp:
-    url: "http://dimp:32861/fhir"
+    url: "http://dimp:32861"
     bundle_split_threshold_mb: 10
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `url` | string | - | DIMP service URL (required if dimp step enabled) |
+| `url` | string | - | DIMP server root URL (required if dimp step enabled). Do not include `/fhir` — the client appends it. |
 | `bundle_split_threshold_mb` | int | 10 | Split Bundles larger than this (1-100 MB) |
 
 ### Flattening
@@ -153,7 +153,7 @@ Upload FHIR resources directly to a FHIR server.
 services:
   send:
     send_as: "direct_resource_load"
-    url: "https://fhir-server.example.com/fhir"
+    url: "https://fhir-server.example.com"
     batch_size: 100
     auth:
       username: "${FHIR_USER}"
@@ -168,7 +168,7 @@ Package files for DSF-based transfer.
 services:
   send:
     send_as: "transfer_load"
-    url: "https://transfer.example.com/fhir"
+    url: "https://transfer.example.com"
     auth:
       oauth_issuer_uri: "${OAUTH_ISSUER}"
       oauth_client_id: "${OAUTH_CLIENT}"
@@ -181,7 +181,7 @@ services:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `send_as` | string | - | `direct_resource_load` or `transfer_load` |
-| `url` | string | - | FHIR server base URL |
+| `url` | string | - | FHIR server root URL. Do not include `/fhir` — the client appends it. |
 | `batch_size` | int | 100 | Resources per transaction (direct mode, 1-1000) |
 
 **Authentication (choose one):**
@@ -411,7 +411,7 @@ services:
     username: "${TORCH_USER}"
     password: "${TORCH_PASS}"
   dimp:
-    url: "http://dimp:32861/fhir"
+    url: "http://dimp:32861"
 
 pipeline:
   enabled_steps:
@@ -428,7 +428,7 @@ services:
   local_import:
     dir: "/data/fhir"
   dimp:
-    url: "http://dimp:32861/fhir"
+    url: "http://dimp:32861"
   flattening:
     service_url: "http://fhir-flattener:8000"
     lookup_path: "/config/lookup.json"
@@ -455,10 +455,10 @@ services:
     username: "${TORCH_USER}"
     password: "${TORCH_PASS}"
   dimp:
-    url: "http://dimp:32861/fhir"
+    url: "http://dimp:32861"
   send:
     send_as: "transfer_load"
-    url: "https://transfer.mii.de/fhir"
+    url: "https://transfer.mii.de"
     auth:
       oauth_issuer_uri: "${OAUTH_ISSUER}"
       oauth_client_id: "${OAUTH_CLIENT}"

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -12,7 +12,7 @@ services:
     password: "your-password"
 
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"
 
 pipeline:
   enabled_steps:
@@ -41,7 +41,7 @@ services:
 ```yaml
 services:
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"  # server root; /fhir appended by client
     bundle_split_threshold_mb: 10  # Auto-split large bundles
 ```
 
@@ -64,7 +64,7 @@ services:
 services:
   send:
     send_as: "direct_resource_load"
-    url: "https://fhir-server.example.com/fhir"
+    url: "https://fhir-server.example.com"  # server root; /fhir appended by client
     batch_size: 100
     auth:
       username: "${FHIR_USER}"
@@ -76,7 +76,7 @@ services:
 services:
   send:
     send_as: "transfer_load"
-    url: "https://transfer-server.example.com/fhir"
+    url: "https://transfer-server.example.com"  # server root; /fhir appended by client
     auth:
       oauth_issuer_uri: "${OAUTH_ISSUER}"
       oauth_client_id: "${OAUTH_CLIENT_ID}"

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -14,7 +14,7 @@ services:
     password: "your-password"
 
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"
 
 pipeline:
   enabled_steps:
@@ -78,7 +78,7 @@ services:
   local_import:
     dir: "/path/to/fhir/data"
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"
 
 pipeline:
   enabled_steps:

--- a/docs/guides/dimp.md
+++ b/docs/guides/dimp.md
@@ -15,7 +15,7 @@ Add DIMP to your `aether.yaml`:
 ```yaml
 services:
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"
 
 pipeline:
   enabled_steps:
@@ -80,7 +80,7 @@ For large datasets, Aether automatically splits bundles before sending to DIMP:
 ```yaml
 services:
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"
     bundle_split_threshold_mb: 10   # Split bundles larger than 10MB
 ```
 

--- a/docs/guides/steps/dimp.md
+++ b/docs/guides/steps/dimp.md
@@ -13,7 +13,7 @@ De-identifies FHIR data using a DIMP service.
 ```yaml
 services:
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"  # server root; /fhir appended by client
     bundle_split_threshold_mb: 10  # 1-100 MB, default: 10
 
 pipeline:
@@ -26,7 +26,7 @@ pipeline:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `url` | string | - | DIMP service URL (required) |
+| `url` | string | - | DIMP server root URL (required). Do not include `/fhir` — the client appends it. |
 | `bundle_split_threshold_mb` | int | 10 | Split Bundles larger than this (1-100 MB) |
 
 ## Bundle Splitting

--- a/docs/guides/steps/send.md
+++ b/docs/guides/steps/send.md
@@ -10,7 +10,7 @@ Sends NDJSON directly to a FHIR server using transaction bundles.
 services:
   send:
     send_as: "direct_resource_load"
-    url: "https://fhir-server.example.com/fhir"
+    url: "https://fhir-server.example.com"  # server root; /fhir appended by client
     batch_size: 100  # resources per transaction (1-1000)
     auth:
       username: "${FHIR_USER}"
@@ -38,7 +38,7 @@ Packages files for DSF-based transfer using Binary/DocumentReference resources.
 services:
   send:
     send_as: "transfer_load"
-    url: "https://transfer-server.example.com/fhir"
+    url: "https://transfer-server.example.com"  # server root; /fhir appended by client
     auth:
       oauth_issuer_uri: "${OAUTH_ISSUER}"
       oauth_client_id: "${OAUTH_CLIENT_ID}"
@@ -66,7 +66,7 @@ pipeline:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `send_as` | string | - | `direct_resource_load` or `transfer_load` |
-| `url` | string | - | FHIR server base URL |
+| `url` | string | - | FHIR server root URL. Do not include `/fhir` — the client appends it. |
 | `batch_size` | int | 100 | Resources per transaction (direct mode, 1-1000) |
 
 ## Authentication

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -494,7 +494,7 @@ func buildDocumentReference(binaries []binaryEntry, config models.TransferConfig
 
 // uploadBinary PUTs a single Binary resource to the FHIR server.
 func uploadBinary(binary binaryEntry, config models.SendConfig, httpClient *services.HTTPClient, logger *lib.Logger) error {
-	targetURL := fmt.Sprintf("%s/Binary/%s", strings.TrimSuffix(config.URL, "/"), binary.id)
+	targetURL := fmt.Sprintf("%s/fhir/Binary/%s", strings.TrimSuffix(config.URL, "/"), binary.id)
 	jsonData, err := json.Marshal(binary.resource)
 	if err != nil {
 		return fmt.Errorf("failed to marshal Binary: %w", err)
@@ -527,7 +527,7 @@ func uploadBinary(binary binaryEntry, config models.SendConfig, httpClient *serv
 // uploadDocumentReference PUTs the DocumentReference to the FHIR server.
 func uploadDocumentReference(docRef map[string]any, config models.SendConfig, httpClient *services.HTTPClient, logger *lib.Logger) error {
 	id, _ := docRef["id"].(string)
-	targetURL := fmt.Sprintf("%s/DocumentReference/%s", strings.TrimSuffix(config.URL, "/"), id)
+	targetURL := fmt.Sprintf("%s/fhir/DocumentReference/%s", strings.TrimSuffix(config.URL, "/"), id)
 	jsonData, err := json.Marshal(docRef)
 	if err != nil {
 		return fmt.Errorf("failed to marshal DocumentReference: %w", err)

--- a/internal/services/dimp_client.go
+++ b/internal/services/dimp_client.go
@@ -28,16 +28,20 @@ func NewDIMPClient(baseURL string, httpClient *HTTPClient, logger *lib.Logger) *
 
 // Pseudonymize sends a FHIR resource to the DIMP service for pseudonymization
 // Returns the pseudonymized resource or an error
-// Per contract: POST /$de-identify with single FHIR resource
+// Per contract: POST /fhir/$de-identify with single FHIR resource
 func (c *DIMPClient) Pseudonymize(resource map[string]any) (map[string]any, error) {
 	// Extract resource info for logging
 	resourceType, _ := resource["resourceType"].(string)
 	resourceID, _ := resource["id"].(string)
 
+	// Endpoint per dimp-service contract; baseURL is the server root and
+	// the /fhir prefix is appended here (see issue #283).
+	url := c.baseURL + "/fhir/$de-identify"
+
 	c.logger.Debug("Sending resource to DIMP",
 		"resourceType", resourceType,
 		"id", resourceID,
-		"url", c.baseURL+"/$de-identify")
+		"url", url)
 
 	// Marshal resource to JSON
 	jsonBody, err := json.Marshal(resource)
@@ -46,9 +50,6 @@ func (c *DIMPClient) Pseudonymize(resource map[string]any) (map[string]any, erro
 	}
 
 	c.logger.Debug("Request body size", "bytes", len(jsonBody))
-
-	// Construct endpoint URL
-	url := c.baseURL + "/$de-identify"
 
 	// Send POST request
 	resp, err := c.httpClient.PostJSON(url, jsonBody)

--- a/internal/services/fhir_client.go
+++ b/internal/services/fhir_client.go
@@ -136,7 +136,7 @@ func (c *FHIRClient) sendBatch(resources []json.RawMessage) error {
 		return fmt.Errorf("failed to marshal bundle: %w", err)
 	}
 
-	url := strings.TrimSuffix(c.url, "/")
+	url := strings.TrimSuffix(c.url, "/") + "/fhir"
 
 	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonData))
 	if err != nil {

--- a/tests/contract/dimp_service_test.go
+++ b/tests/contract/dimp_service_test.go
@@ -21,7 +21,7 @@ func TestDIMPService_Pseudonymize_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/$de-identify", r.URL.Path)
+		assert.Equal(t, "/fhir/$de-identify", r.URL.Path)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
 		// Read original resource

--- a/tests/integration/pipeline_dimp_consistency_test.go
+++ b/tests/integration/pipeline_dimp_consistency_test.go
@@ -161,7 +161,7 @@ func TestDIMPConsistency_SplitVsUnsplit(t *testing.T) {
 // to simulate real DIMP behavior
 func createRealisticMockDIMPServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/$de-identify" {
+		if r.URL.Path != "/fhir/$de-identify" {
 			http.Error(w, "Invalid path", http.StatusNotFound)
 			return
 		}

--- a/tests/integration/pipeline_dimp_split_test.go
+++ b/tests/integration/pipeline_dimp_split_test.go
@@ -293,7 +293,7 @@ func TestDIMPStepWithSmallBundleNoSplit(t *testing.T) {
 func createMockDIMPServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Only accept de-identify requests
-		if r.URL.Path != "/$de-identify" {
+		if r.URL.Path != "/fhir/$de-identify" {
 			http.Error(w, "Invalid path", http.StatusNotFound)
 			return
 		}

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -738,7 +738,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 				MaxPollingInterval: 5 * time.Second,
 			},
 			DIMP: models.DIMPConfig{
-				URL: dimpServer.URL + "/fhir",
+				URL: dimpServer.URL,
 			},
 		},
 		Pipeline: models.PipelineConfig{

--- a/tests/unit/fhir_client_test.go
+++ b/tests/unit/fhir_client_test.go
@@ -506,8 +506,8 @@ func TestFHIRClient_UploadNDJSON_URLTrailingSlash(t *testing.T) {
 
 	_, err := client.UploadNDJSON("test.ndjson", reader)
 	require.NoError(t, err)
-	// Trailing slash should be removed
-	assert.Equal(t, "/", receivedPath)
+	// Trailing slash should be removed; client appends /fhir
+	assert.Equal(t, "/fhir", receivedPath)
 }
 
 func TestFHIRClient_UploadNDJSON_MixedResources(t *testing.T) {

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -128,7 +128,7 @@ func TestExecuteSendStep_Success(t *testing.T) {
 
 	// Verify PUT paths match resource IDs
 	for _, req := range receivedRequests {
-		// Path should be /Binary/{id} or /DocumentReference/{id}
+		// Path should be /fhir/Binary/{id} or /fhir/DocumentReference/{id}
 		assert.True(t, len(req.Path) > 1, "Path should not be empty")
 	}
 


### PR DESCRIPTION
## Summary

- All configured service URLs now point at the server root; each client appends its own `/fhir` path internally.
- Fixes the footgun where `dimp.url` and `send.url` required `/fhir` in config while `torch` and `flattening` did not — users applying the convention uniformly got silent doubled `/fhir/fhir/...` 404s.

## Changes

- `internal/services/dimp_client.go`: POST `/fhir/\$de-identify`
- `internal/services/fhir_client.go`: transaction bundle POST now targets `/fhir`
- `internal/pipeline/send.go`: Binary and DocumentReference PUTs under `/fhir`
- Example configs (`.github/test/*.yaml`, `config/aether.example.yaml`) updated
- Docs (`docs/**`) updated with note that `/fhir` is appended by the client
- Tests updated to assert new paths and to configure dimp URL as server root

## Breaking change

Users must drop the trailing `/fhir` from `services.dimp.url` and `services.send.url`. No compatibility shim — clean break as suggested in the issue (aether is pre-1.0).

Closes #283