### PR TITLE
feat(send): wire TLS config into S3 uploader

### DIFF
--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -22,21 +22,23 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
-// s3UploaderFactory creates an S3Uploader. Overridable in tests.
-var s3UploaderFactory = func(s3Config models.S3Config, auth models.AuthConfig, logger *lib.Logger) (services.S3Uploader, error) {
-	return services.NewAWSS3Uploader(s3Config, auth, logger)
+// defaultS3UploaderFactory is the production S3 uploader constructor, shared
+// by package-init and ResetS3UploaderFactory so both stay in sync.
+var defaultS3UploaderFactory = func(s3Config models.S3Config, auth models.AuthConfig, tlsConfig models.TLSConfig, logger *lib.Logger) (services.S3Uploader, error) {
+	return services.NewAWSS3Uploader(s3Config, auth, tlsConfig, logger)
 }
 
+// s3UploaderFactory creates an S3Uploader. Overridable in tests.
+var s3UploaderFactory = defaultS3UploaderFactory
+
 // SetS3UploaderFactoryForTesting replaces the S3 uploader factory for tests.
-func SetS3UploaderFactoryForTesting(factory func(models.S3Config, models.AuthConfig, *lib.Logger) (services.S3Uploader, error)) {
+func SetS3UploaderFactoryForTesting(factory func(models.S3Config, models.AuthConfig, models.TLSConfig, *lib.Logger) (services.S3Uploader, error)) {
 	s3UploaderFactory = factory
 }
 
 // ResetS3UploaderFactory restores the default S3 uploader factory.
 func ResetS3UploaderFactory() {
-	s3UploaderFactory = func(s3Config models.S3Config, auth models.AuthConfig, logger *lib.Logger) (services.S3Uploader, error) {
-		return services.NewAWSS3Uploader(s3Config, auth, logger)
-	}
+	s3UploaderFactory = defaultS3UploaderFactory
 }
 
 // ClearOAuth2TokenCacheForTesting clears the OAuth2 token cache - exported for testing
@@ -600,7 +602,7 @@ func executeS3UploadSend(job *models.PipelineJob, jobDir string, step *models.Pi
 	s3Config := job.Config.Services.Send.S3
 
 	// Create uploader via factory (allows test injection)
-	uploader, err := s3UploaderFactory(s3Config, job.Config.Services.Send.Auth, logger)
+	uploader, err := s3UploaderFactory(s3Config, job.Config.Services.Send.Auth, job.Config.TLS, logger)
 	if err != nil {
 		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
 		recordStepError(step, err, models.ErrorTypeNonTransient)

--- a/internal/services/s3_uploader.go
+++ b/internal/services/s3_uploader.go
@@ -45,15 +45,23 @@ func (t *proxyAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 // NewAWSS3Uploader creates a new S3 uploader from config.
-func NewAWSS3Uploader(s3Config models.S3Config, auth models.AuthConfig, logger *lib.Logger) (*AWSS3Uploader, error) {
-	httpClient := &http.Client{}
+func NewAWSS3Uploader(s3Config models.S3Config, auth models.AuthConfig, tlsConfig models.TLSConfig, logger *lib.Logger) (*AWSS3Uploader, error) {
+	tlsTransport, err := BuildTLSTransport(tlsConfig, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS transport for S3 client: %w", err)
+	}
+	base := http.DefaultTransport
+	if tlsTransport != nil {
+		base = tlsTransport
+	}
 
-	// Wrap HTTP client with proxy auth if configured
+	httpClient := &http.Client{Transport: base}
+
 	if auth.Username != "" && auth.Password != "" {
 		creds := auth.Username + ":" + auth.Password
 		encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 		httpClient.Transport = &proxyAuthTransport{
-			base:      http.DefaultTransport,
+			base:      base,
 			authValue: "Basic " + encoded,
 		}
 	}

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -1628,7 +1628,7 @@ func TestExecuteSendStep_FHIR_CoreAndCompressed(t *testing.T) {
 
 func TestExecuteSendStep_S3_Success(t *testing.T) {
 	mock := &services.MockS3Uploader{Bucket: "test-bucket"}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -1678,7 +1678,7 @@ func TestExecuteSendStep_S3_Success(t *testing.T) {
 
 func TestExecuteSendStep_S3_NoFiles(t *testing.T) {
 	mock := &services.MockS3Uploader{Bucket: "test-bucket"}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -1702,7 +1702,7 @@ func TestExecuteSendStep_S3_UploadError(t *testing.T) {
 		Bucket:    "test-bucket",
 		UploadErr: &services.S3Error{Message: "AccessDenied: access denied", ErrorType: models.ErrorTypeNonTransient},
 	}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -1735,7 +1735,7 @@ func TestExecuteSendStep_S3_UploadError(t *testing.T) {
 func TestExecuteSendStep_S3_ManifestRetry(t *testing.T) {
 	uploadCount := 0
 	mock := &services.MockS3Uploader{Bucket: "test-bucket"}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		// Reset tracked keys on each factory call (new "session")
 		mock.UploadedKeys = nil
 		return mock, nil
@@ -1783,7 +1783,7 @@ func TestExecuteSendStep_S3_ManifestRetry(t *testing.T) {
 
 func TestExecuteSendStep_S3_SubdirectoryFiles(t *testing.T) {
 	mock := &services.MockS3Uploader{Bucket: "test-bucket"}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -1855,7 +1855,7 @@ func TestExecuteSendStep_S3_TransientError(t *testing.T) {
 		Bucket:    "test-bucket",
 		UploadErr: &services.S3Error{Message: "SlowDown: rate exceeded", ErrorType: models.ErrorTypeTransient},
 	}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -2141,7 +2141,7 @@ func TestFormatSize_AllBranches(t *testing.T) {
 }
 
 func TestExecuteSendStep_S3_UploaderFactoryError(t *testing.T) {
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return nil, fmt.Errorf("failed to initialize S3 client")
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -2163,7 +2163,7 @@ func TestExecuteSendStep_S3_UploaderFactoryError(t *testing.T) {
 func TestExecuteSendStep_S3_CorruptedManifest(t *testing.T) {
 	// A corrupted manifest should trigger a warning and start fresh
 	mock := &services.MockS3Uploader{Bucket: "test-bucket"}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()
@@ -2189,7 +2189,7 @@ func TestExecuteSendStep_S3_CorruptedManifest(t *testing.T) {
 
 func TestExecuteSendStep_S3_NonExistentInputDir(t *testing.T) {
 	mock := &services.MockS3Uploader{Bucket: "test-bucket"}
-	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ *lib.Logger) (services.S3Uploader, error) {
+	pipeline.SetS3UploaderFactoryForTesting(func(_ models.S3Config, _ models.AuthConfig, _ models.TLSConfig, _ *lib.Logger) (services.S3Uploader, error) {
 		return mock, nil
 	})
 	defer pipeline.ResetS3UploaderFactory()

--- a/tests/unit/s3_uploader_test.go
+++ b/tests/unit/s3_uploader_test.go
@@ -2,6 +2,7 @@ package unit
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,18 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
+
+// writeTLSServerCertPEM writes the TLS server's self-signed cert to a PEM file
+// so it can be passed to NewAWSS3Uploader as a trusted CA.
+func writeTLSServerCertPEM(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	cert := server.Certificate()
+	require.NotNil(t, cert, "httptest server must expose a certificate")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, pemBytes, 0600))
+	return path
+}
 
 func TestS3Error_Classification_Transient(t *testing.T) {
 	transientMessages := []string{
@@ -123,7 +136,7 @@ func TestNewAWSS3Uploader_BasicConstruction(t *testing.T) {
 		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 	require.NotNil(t, uploader)
 	assert.Equal(t, "test-bucket", uploader.GetBucket())
@@ -140,7 +153,7 @@ func TestNewAWSS3Uploader_WithEndpointAndPathStyle(t *testing.T) {
 		UsePathStyle:    true,
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 	require.NotNil(t, uploader)
 	assert.Equal(t, "my-bucket", uploader.GetBucket())
@@ -161,7 +174,7 @@ func TestNewAWSS3Uploader_WithProxyAuth(t *testing.T) {
 		Password: "proxy-pass",
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, auth, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, auth, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 	require.NotNil(t, uploader)
 	assert.Equal(t, "proxy-bucket", uploader.GetBucket())
@@ -187,7 +200,7 @@ func TestAWSS3Uploader_UploadFile_Success(t *testing.T) {
 		UsePathStyle:    true,
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 
 	// Create a temp file to upload
@@ -225,7 +238,7 @@ func TestAWSS3Uploader_UploadFile_WithProxyAuth(t *testing.T) {
 		Password: "proxy-pass",
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, auth, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, auth, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
@@ -255,7 +268,7 @@ func TestAWSS3Uploader_UploadFile_FileNotFound(t *testing.T) {
 		UsePathStyle:    true,
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 
 	_, err = uploader.UploadFile(context.Background(), "/nonexistent/file.ndjson", "key")
@@ -283,7 +296,7 @@ func TestAWSS3Uploader_UploadFile_S3Error(t *testing.T) {
 		UsePathStyle:    true,
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
@@ -314,7 +327,7 @@ func TestAWSS3Uploader_UploadFile_NilETag(t *testing.T) {
 		UsePathStyle:    true,
 	}
 
-	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, logger)
+	uploader, err := services.NewAWSS3Uploader(s3Config, models.AuthConfig{}, models.TLSConfig{}, logger)
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
@@ -325,4 +338,112 @@ func TestAWSS3Uploader_UploadFile_NilETag(t *testing.T) {
 	require.NoError(t, err)
 	// ETag should be empty when server doesn't return one
 	assert.Empty(t, etag)
+}
+
+// Self-signed TLS tests — Issue #238.
+//
+// httptest.NewTLSServer generates a one-off self-signed cert. An S3 client with
+// default TLS config cannot verify it, mirroring the production failure mode
+// users hit with private CAs. Three paths must work: rejection, CA trust, and
+// opt-out via InsecureSkipVerify.
+
+func tlsS3Config(endpoint string) models.S3Config {
+	return models.S3Config{
+		Endpoint:        endpoint,
+		Region:          "us-east-1",
+		Bucket:          "test-bucket",
+		AccessKeyID:     "test-key",
+		SecretAccessKey: "test-secret",
+		UsePathStyle:    true,
+	}
+}
+
+func writeS3TestPayload(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.ndjson")
+	require.NoError(t, os.WriteFile(path, []byte("data\n"), 0600))
+	return path
+}
+
+func TestAWSS3Uploader_SelfSignedCert_UnknownAuthorityRejected(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"should-not-reach"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	uploader, err := services.NewAWSS3Uploader(tlsS3Config(server.URL), models.AuthConfig{}, models.TLSConfig{}, logger)
+	require.NoError(t, err)
+
+	_, err = uploader.UploadFile(context.Background(), writeS3TestPayload(t), "job/test.ndjson")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate signed by unknown authority")
+}
+
+func TestAWSS3Uploader_SelfSignedCert_TrustedViaCACertPath(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"tls-ok"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	tlsConfig := models.TLSConfig{CACertPath: writeTLSServerCertPEM(t, server)}
+
+	uploader, err := services.NewAWSS3Uploader(tlsS3Config(server.URL), models.AuthConfig{}, tlsConfig, logger)
+	require.NoError(t, err)
+
+	etag, err := uploader.UploadFile(context.Background(), writeS3TestPayload(t), "job/test.ndjson")
+	require.NoError(t, err)
+	assert.Contains(t, etag, "tls-ok")
+}
+
+func TestAWSS3Uploader_SelfSignedCert_InsecureSkipVerify(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"skipped"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	tlsConfig := models.TLSConfig{InsecureSkipVerify: true}
+
+	uploader, err := services.NewAWSS3Uploader(tlsS3Config(server.URL), models.AuthConfig{}, tlsConfig, logger)
+	require.NoError(t, err)
+
+	etag, err := uploader.UploadFile(context.Background(), writeS3TestPayload(t), "job/test.ndjson")
+	require.NoError(t, err)
+	assert.Contains(t, etag, "skipped")
+}
+
+func TestAWSS3Uploader_SelfSignedCert_ProxyAuthLayeredOnTLS(t *testing.T) {
+	// Proxy auth must wrap (not replace) the TLS transport.
+	var gotProxyAuth string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProxyAuth = r.Header.Get("Proxy-Authorization")
+		w.Header().Set("ETag", `"proxy-tls"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	tlsConfig := models.TLSConfig{CACertPath: writeTLSServerCertPEM(t, server)}
+	auth := models.AuthConfig{Username: "u", Password: "p"}
+
+	uploader, err := services.NewAWSS3Uploader(tlsS3Config(server.URL), auth, tlsConfig, logger)
+	require.NoError(t, err)
+
+	_, err = uploader.UploadFile(context.Background(), writeS3TestPayload(t), "job/test.ndjson")
+	require.NoError(t, err)
+	assert.Contains(t, gotProxyAuth, "Basic ")
+}
+
+func TestAWSS3Uploader_CACertPath_NotFound(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	tlsConfig := models.TLSConfig{CACertPath: "/nonexistent/path/to/ca.pem"}
+
+	_, err := services.NewAWSS3Uploader(tlsS3Config("http://localhost:1"), models.AuthConfig{}, tlsConfig, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build TLS transport")
 }


### PR DESCRIPTION
## Summary
- S3 uploader now honors `tls.ca_cert_path` and `tls.insecure_skip_verify`, matching every other HTTP client in the pipeline (DIMP/Torch/Flattener).
- `NewAWSS3Uploader` accepts `models.TLSConfig`, delegates to the existing `BuildTLSTransport` helper, and keeps proxy auth wrapping on top of the TLS transport so both work together.
- Adds 5 unit tests via `httptest.NewTLSServer`: rejection without CA, trust via `CACertPath`, `InsecureSkipVerify`, proxy+TLS layering, invalid CA path error propagation.

Closes #238