### PR TITLE
ci(docs): trigger docs-deploy on release tag push

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
     paths:
       - 'docs/**'
       - '.github/workflows/docs-deploy.yml'
@@ -27,7 +29,14 @@ jobs:
   deploy:
     name: Build and Deploy Documentation
     runs-on: ubuntu-24.04
-    if: ${{ !(github.event_name == 'release' && github.event.release.prerelease) }}
+    if: >-
+      ${{
+        !(github.event_name == 'release' && github.event.release.prerelease)
+        && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+          && (contains(github.ref_name, '-alpha')
+            || contains(github.ref_name, '-beta')
+            || contains(github.ref_name, '-rc')))
+      }}
 
     steps:
       - name: Harden Runner
@@ -47,11 +56,21 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          PUSH_REF: ${{ github.ref }}
+          PUSH_REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            echo "version=dev" >> "$GITHUB_OUTPUT"
-            echo "ref=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            if [[ "${PUSH_REF}" == refs/tags/* ]]; then
+              # Tag push: workflow triggered by release tag (release event is suppressed
+              # when the release is created with the default GITHUB_TOKEN).
+              echo "version=${PUSH_REF_NAME}" >> "$GITHUB_OUTPUT"
+              echo "ref=${PUSH_REF_NAME}" >> "$GITHUB_OUTPUT"
+              echo "is_release=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "version=dev" >> "$GITHUB_OUTPUT"
+              echo "ref=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+              echo "is_release=false" >> "$GITHUB_OUTPUT"
+            fi
           elif [[ "${EVENT_NAME}" == "release" ]]; then
             echo "version=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
             echo "ref=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add `push.tags: ['v*.*.*']` trigger to `docs-deploy.yml` so docs deploy on release.
- Extend `Determine version and ref` step to handle tag-push events (sets `version`/`ref`/`is_release` from `github.ref_name`).
- Replace job-level `if` with prerelease check that also covers tag-push events via regex on `-alpha`/`-beta`/`-rc`.

## Why
Release tags are created in `_release.yaml` via `softprops/action-gh-release` using the default `GITHUB_TOKEN`. Per GitHub policy, events fired by `GITHUB_TOKEN` do not trigger downstream workflows, so `release: published` never fired and docs-deploy never ran on tag.

Per [GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore): "Path filters are not evaluated for pushes of tags." — so the existing `paths:` filter does not block the new tag trigger.

The existing `release: [published]` trigger is kept as a no-op fallback for manually-created releases.

Closes #319