### PR TITLE
fix(pipeline): apply CRTDL enrichment for all import paths

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -544,6 +544,15 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
+	// Idempotent — reconciles state if the original `pipeline start` crashed
+	// between writing the prepared CRTDL and persisting the new InputSource.
+	if err := pipeline.PrepareCRTDL(job, logger); err != nil {
+		return fmt.Errorf("failed to prepare CRTDL: %w", err)
+	}
+	if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
+		return fmt.Errorf("failed to save job state: %w", err)
+	}
+
 	currentStepName := models.StepName(job.CurrentStep)
 	currentStep, found := models.GetStepByName(*job, currentStepName)
 

--- a/internal/pipeline/crtdl_prep.go
+++ b/internal/pipeline/crtdl_prep.go
@@ -1,0 +1,107 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// PrepareCRTDL ensures every pipeline step uses the same effective CRTDL.
+// For CRTDL inputs it copies (or enriches) the file into the job directory
+// and repoints job.InputSource at the saved file. The call is a no-op for
+// non-CRTDL inputs and idempotent when InputSource already lives in jobDir.
+//
+// With CRTDLPreprocessing enabled and at least one enrichment configured,
+// the result is written as enriched-crtdl.json. Otherwise the original is
+// copied verbatim as crtdl.json.
+func PrepareCRTDL(job *models.PipelineJob, logger *lib.Logger) error {
+	if job.InputType != models.InputTypeCRTDL {
+		return nil
+	}
+
+	jobDir := services.GetJobDir(job.Config.JobsDir, job.JobID)
+	if isPreparedCRTDLPath(job.InputSource, jobDir) {
+		logger.Debug("CRTDL already prepared, skipping", "path", job.InputSource)
+		return nil
+	}
+
+	preprocessing := job.Config.Services.CRTDLPreprocessing
+	if !preprocessing.Enabled {
+		return copyOriginalCRTDL(job, jobDir, logger)
+	}
+
+	logger.Info("CRTDL preprocessing enabled, enriching CRTDL", "source", job.InputSource)
+
+	originalDoc, err := services.ParseCRTDL(job.InputSource)
+	if err != nil {
+		return fmt.Errorf("failed to parse CRTDL: %w", err)
+	}
+
+	enrichments, err := services.LoadEnrichments(preprocessing)
+	if err != nil {
+		return fmt.Errorf("failed to load enrichments: %w", err)
+	}
+
+	if len(enrichments) == 0 {
+		logger.Warn("CRTDL preprocessing enabled but no enrichments configured")
+		return copyOriginalCRTDL(job, jobDir, logger)
+	}
+
+	logger.Info("Applying CRTDL enrichments",
+		"enrichment_count", len(enrichments),
+		"original_groups", len(originalDoc.DataExtraction.AttributeGroups))
+
+	enrichedDoc, err := services.EnrichCRTDL(*originalDoc, enrichments)
+	if err != nil {
+		return fmt.Errorf("failed to enrich CRTDL: %w", err)
+	}
+
+	logger.Info("CRTDL enriched successfully",
+		"enriched_groups", len(enrichedDoc.DataExtraction.AttributeGroups))
+
+	enrichedContent, err := json.MarshalIndent(enrichedDoc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize enriched CRTDL: %w", err)
+	}
+
+	return saveCRTDL(job, jobDir, "enriched-crtdl.json", enrichedContent, logger)
+}
+
+// copyOriginalCRTDL copies job.InputSource verbatim into jobDir/crtdl.json.
+func copyOriginalCRTDL(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	content, err := os.ReadFile(job.InputSource)
+	if err != nil {
+		return fmt.Errorf("failed to read CRTDL file: %w", err)
+	}
+	return saveCRTDL(job, jobDir, "crtdl.json", content, logger)
+}
+
+// isPreparedCRTDLPath reports whether path is the canonical prepared CRTDL
+// inside jobDir (crtdl.json or enriched-crtdl.json). A path that merely lives
+// inside jobDir under some other name still needs preparation.
+func isPreparedCRTDLPath(path, jobDir string) bool {
+	if filepath.Clean(filepath.Dir(path)) != filepath.Clean(jobDir) {
+		return false
+	}
+	switch filepath.Base(path) {
+	case "crtdl.json", "enriched-crtdl.json":
+		return true
+	}
+	return false
+}
+
+// saveCRTDL writes content to jobDir/filename and repoints job.InputSource.
+func saveCRTDL(job *models.PipelineJob, jobDir, filename string, content []byte, logger *lib.Logger) error {
+	crtdlPath := filepath.Join(jobDir, filename)
+	if err := os.WriteFile(crtdlPath, content, 0644); err != nil {
+		return fmt.Errorf("failed to save CRTDL to job directory: %w", err)
+	}
+	job.InputSource = crtdlPath
+	logger.Info("CRTDL saved to job directory", "path", crtdlPath)
+	return nil
+}

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -1,10 +1,7 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
@@ -146,49 +143,21 @@ func failImportStep(job *models.PipelineJob, err error, errorType models.ErrorTy
 	return updatedJob
 }
 
-// executeTORCHExtraction performs CRTDL-based data extraction from TORCH server
-// Submits CRTDL, polls for completion, and downloads resulting NDJSON files
+// executeTORCHExtraction submits the (already prepared) CRTDL to TORCH,
+// polls until extraction completes, and downloads the resulting NDJSON
+// files. PrepareCRTDL ensures job.InputSource points at the effective CRTDL
+// shared by every downstream pipeline step.
 func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClient *services.HTTPClient, logger *lib.Logger, showProgress bool, compress bool, compressionLevel string) ([]models.FHIRDataFile, error) {
-	// Create TORCH client
 	torchClient := services.NewTORCHClient(job.Config.Services.TORCH, httpClient, logger)
 
-	var extractionURL string
-	var err error
-
-	// Check if CRTDL preprocessing is enabled
-	if job.Config.Services.CRTDLPreprocessing.Enabled {
-		logger.Info("CRTDL preprocessing enabled, enriching CRTDL before submission")
-
-		enrichedContent, preprocessErr := preprocessCRTDL(job, logger)
-		if preprocessErr != nil {
-			return nil, fmt.Errorf("failed to preprocess CRTDL: %w", preprocessErr)
-		}
-
-		// Submit enriched CRTDL content
-		extractionURL, err = torchClient.SubmitExtractionWithContent(enrichedContent)
-	} else {
-		// Copy original CRTDL to job directory so all steps use the same source
-		originalContent, readErr := os.ReadFile(job.InputSource)
-		if readErr != nil {
-			return nil, fmt.Errorf("failed to read CRTDL file: %w", readErr)
-		}
-		if saveErr := saveCRTDLToJobDir(job, originalContent, "crtdl.json", logger); saveErr != nil {
-			return nil, saveErr
-		}
-
-		// Submit original CRTDL content directly (already in memory from the copy)
-		extractionURL, err = torchClient.SubmitExtractionWithContent(originalContent)
-	}
-
+	extractionURL, err := torchClient.SubmitExtraction(job.InputSource)
 	if err != nil {
 		return nil, fmt.Errorf("failed to submit TORCH extraction: %w", err)
 	}
 
-	// Store extraction URL in job for resumption capability
 	job.TORCHExtractionURL = extractionURL
 	logger.Info("TORCH extraction URL stored for resumption", "url", extractionURL)
 
-	// Poll extraction status until complete
 	fileURLs, err := torchClient.PollExtractionStatus(extractionURL, showProgress)
 	if err != nil {
 		return nil, fmt.Errorf("TORCH extraction failed: %w", err)
@@ -199,12 +168,10 @@ func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClien
 		return []models.FHIRDataFile{}, nil
 	}
 
-	// Download extraction files
 	files, err := torchClient.DownloadExtractionFiles(fileURLs, importDir, showProgress, compress, compressionLevel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download TORCH files: %w", err)
 	}
-
 	return files, nil
 }
 
@@ -255,85 +222,4 @@ func classifyImportError(err error, inputType models.InputType) models.ErrorType
 	// For local imports, most errors are non-transient (file not found, permissions, etc.)
 	// Default to non-transient
 	return models.ErrorTypeNonTransient
-}
-
-// saveCRTDLToJobDir writes the CRTDL content to the job directory under the given
-// filename and updates job.InputSource so all downstream steps use this copy.
-func saveCRTDLToJobDir(job *models.PipelineJob, content []byte, filename string, logger *lib.Logger) error {
-	jobDir := services.GetJobDir(job.Config.JobsDir, job.JobID)
-	crtdlPath := filepath.Join(jobDir, filename)
-
-	if err := os.WriteFile(crtdlPath, content, 0644); err != nil {
-		return fmt.Errorf("failed to save CRTDL to job directory: %w", err)
-	}
-
-	job.InputSource = crtdlPath
-	logger.Info("CRTDL saved to job directory", "path", crtdlPath)
-	return nil
-}
-
-// preprocessCRTDL loads, enriches, and saves the CRTDL document for DIMP requirements.
-// Returns the serialized enriched CRTDL content ready for TORCH submission.
-// The effective CRTDL is saved to the job directory so that all downstream steps
-// (e.g. flattening) use the same CRTDL as TORCH:
-//   - enriched-crtdl.json when enrichments are applied
-//   - crtdl.json when no enrichments are configured
-//
-// Process:
-//  1. Parse original CRTDL from job input source
-//  2. Load enrichments from configuration (file or inline)
-//  3. Apply enrichments using EnrichCRTDL
-//  4. Save effective CRTDL to job directory
-//  5. Return serialized JSON content
-func preprocessCRTDL(job *models.PipelineJob, logger *lib.Logger) ([]byte, error) {
-	// 1. Parse original CRTDL
-	logger.Info("Parsing original CRTDL", "path", job.InputSource)
-	originalDoc, err := services.ParseCRTDL(job.InputSource)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CRTDL: %w", err)
-	}
-
-	// 2. Load enrichments from configuration
-	enrichments, err := services.LoadEnrichments(job.Config.Services.CRTDLPreprocessing)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load enrichments: %w", err)
-	}
-
-	if len(enrichments) == 0 {
-		logger.Warn("CRTDL preprocessing enabled but no enrichments configured")
-		content, err := os.ReadFile(job.InputSource)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CRTDL file: %w", err)
-		}
-		if err := saveCRTDLToJobDir(job, content, "crtdl.json", logger); err != nil {
-			return nil, err
-		}
-		return content, nil
-	}
-
-	logger.Info("Applying CRTDL enrichments",
-		"enrichment_count", len(enrichments),
-		"original_groups", len(originalDoc.DataExtraction.AttributeGroups))
-
-	// 3. Apply enrichments
-	enrichedDoc, err := services.EnrichCRTDL(*originalDoc, enrichments)
-	if err != nil {
-		return nil, fmt.Errorf("failed to enrich CRTDL: %w", err)
-	}
-
-	logger.Info("CRTDL enriched successfully",
-		"enriched_groups", len(enrichedDoc.DataExtraction.AttributeGroups))
-
-	// 4. Serialize enriched document
-	enrichedContent, err := json.MarshalIndent(enrichedDoc, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize enriched CRTDL: %w", err)
-	}
-
-	// 5. Save effective CRTDL to job directory
-	if err := saveCRTDLToJobDir(job, enrichedContent, "enriched-crtdl.json", logger); err != nil {
-		return nil, err
-	}
-
-	return enrichedContent, nil
 }

--- a/internal/pipeline/job.go
+++ b/internal/pipeline/job.go
@@ -99,6 +99,15 @@ func CreateJob(inputSource string, config models.ProjectConfig, logger *lib.Logg
 		return nil, fmt.Errorf("failed to save initial job state: %w", err)
 	}
 
+	// Prepare the effective CRTDL once so every downstream step reads the
+	// same enriched/copied file. Persist again so InputSource is up to date.
+	if err := PrepareCRTDL(job, logger); err != nil {
+		return nil, fmt.Errorf("failed to prepare CRTDL: %w", err)
+	}
+	if err := services.SaveJobState(config.JobsDir, job); err != nil {
+		return nil, fmt.Errorf("failed to save job state after CRTDL preparation: %w", err)
+	}
+
 	return job, nil
 }
 

--- a/tests/integration/pipeline_crtdl_enrichment_test.go
+++ b/tests/integration/pipeline_crtdl_enrichment_test.go
@@ -1,0 +1,113 @@
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// TestCRTDLEnrichmentAppliedForLocalImportPath is the regression test for
+// bug #323: when the import step is local_import (not torch) but
+// CRTDLPreprocessing is enabled, every downstream step (e.g. flattening)
+// must read the enriched CRTDL — not the original input.
+//
+// We don't run the full flattening pipeline here (that needs an external
+// fhir-flattener service); instead we mimic exactly what flattening does
+// today: it parses job.InputSource via services.ParseCRTDL and consumes the
+// resulting attribute groups. If enrichment was correctly applied at job
+// creation, the parsed groups must contain the added attribute.
+func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	require.NoError(t, os.MkdirAll(jobsDir, 0755))
+
+	// Original CRTDL — Patient group has no identifier attribute. This is
+	// the exact misconfiguration described in issue #323.
+	crtdlPath := filepath.Join(tempDir, "query.crtdl")
+	crtdl := map[string]any{
+		"cohortDefinition": map[string]any{
+			"version":           "1.0.0",
+			"inclusionCriteria": []any{},
+		},
+		"dataExtraction": map[string]any{
+			"attributeGroups": []map[string]any{
+				{
+					"id":             "patient-group",
+					"name":           "PatientPseudonymisiert",
+					"groupReference": "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert",
+					"attributes": []map[string]any{
+						{"attributeRef": "Patient.id", "mustHave": true},
+					},
+				},
+			},
+		},
+	}
+	bytes, err := json.Marshal(crtdl)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(crtdlPath, bytes, 0644))
+
+	// Pipeline uses local_import (not torch). Without the bug 323 fix,
+	// enrichment would be skipped here.
+	config := models.ProjectConfig{
+		JobsDir: jobsDir,
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepLocalImport, models.StepFlattening},
+		},
+		Services: models.ServiceConfig{
+			LocalImport: models.LocalImportConfig{Dir: tempDir},
+			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
+				Enabled: true,
+				Enrichments: []models.GroupEnrichment{
+					{
+						GroupReference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert",
+						AttributesToAdd: []models.EnrichmentAttribute{
+							{AttributeRef: "Patient.identifier", MustHave: false},
+						},
+					},
+				},
+			},
+		},
+		Retry: models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 1, MaxBackoffMs: 10},
+	}
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	job, err := pipeline.CreateJob(crtdlPath, config, logger)
+	require.NoError(t, err)
+
+	// CreateJob must repoint InputSource at the enriched CRTDL inside jobDir.
+	expectedPath := filepath.Join(jobsDir, job.JobID, "enriched-crtdl.json")
+	require.Equal(t, expectedPath, job.InputSource,
+		"InputSource must point at the enriched CRTDL after CreateJob")
+
+	// Mimic what ExecuteFlatteningStep does: ParseCRTDL on job.InputSource.
+	parsed, err := services.ParseCRTDL(job.InputSource)
+	require.NoError(t, err)
+
+	groups := services.GetAttributeGroups(parsed)
+	require.Len(t, groups, 1)
+
+	refs := make([]string, 0, len(groups[0].Attributes))
+	for _, a := range groups[0].Attributes {
+		refs = append(refs, a.AttributeRef)
+	}
+	assert.Contains(t, refs, "Patient.identifier",
+		"flattening (and every other downstream step) must see Patient.identifier added by enrichment")
+	assert.Contains(t, refs, "Patient.id",
+		"original Patient.id must be preserved")
+
+	// Reload from disk — the enriched InputSource must be persisted so
+	// `aether pipeline continue` resumes with the correct CRTDL.
+	reloaded, err := pipeline.LoadJob(jobsDir, job.JobID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, reloaded.InputSource,
+		"persisted state must reference the enriched CRTDL for resume")
+}

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -156,9 +156,11 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 	job, err := pipeline.CreateJob(crtdlPath, config, logger)
 	require.NoError(t, err)
 
-	// Verify job was created with correct input type
+	// Verify job was created with correct input type. CreateJob copies the
+	// CRTDL into the job directory (PrepareCRTDL) so InputSource now points
+	// at jobs/<id>/crtdl.json rather than the original input path.
 	assert.Equal(t, models.InputTypeCRTDL, job.InputType)
-	assert.Equal(t, crtdlPath, job.InputSource)
+	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.InputSource)
 	assert.NotEmpty(t, job.JobID)
 
 	// Execute import step (which should trigger TORCH extraction)
@@ -1291,18 +1293,14 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidEnrichmentsPath(t *t
 		JobsDir: jobsDir,
 	}
 
-	// Create job with CRTDL input
+	// CRTDL preparation now runs inside CreateJob (so the same effective
+	// CRTDL is used by every downstream step). An invalid enrichments path
+	// must therefore be reported by CreateJob, not by the import step.
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(crtdlPath, config, logger)
-	require.NoError(t, err)
-
-	// Execute import step - should fail during enrichments loading
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	_, err = pipeline.ExecuteImportStep(job, logger, httpClient, false)
-
-	// Verify error is returned due to invalid enrichments path
+	_, err := pipeline.CreateJob(crtdlPath, config, logger)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "preprocess CRTDL", "Error should mention preprocessing failure")
+	assert.Contains(t, err.Error(), "prepare CRTDL", "Error should mention CRTDL preparation failure")
+	assert.Contains(t, err.Error(), "load enrichments", "Error should surface the underlying enrichments-loading failure")
 }
 
 func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *testing.T) {
@@ -1463,82 +1461,44 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 		"job.InputSource should point to crtdl.json in the job directory")
 }
 
-// TestPipeline_TORCHExtraction_PreprocessingError_InvalidCRTDL tests error handling when CRTDL parsing fails
-// (covers import.go lines 262-264)
-func TestPipeline_TORCHExtraction_PreprocessingError_InvalidCRTDL(t *testing.T) {
-	// Setup: Create test environment
+// TestPrepareCRTDL_InvalidCRTDL covers the error path where CRTDL parsing
+// fails during preparation. The check now happens in PrepareCRTDL (called
+// from CreateJob) so all import paths benefit from the same enriched/copied
+// CRTDL.
+func TestPrepareCRTDL_InvalidCRTDL(t *testing.T) {
 	tempDir := t.TempDir()
 	jobsDir := filepath.Join(tempDir, "jobs")
-	_ = os.MkdirAll(jobsDir, 0755)
+	jobID := "550e8400-e29b-41d4-a716-446655440000"
+	require.NoError(t, os.MkdirAll(filepath.Join(jobsDir, jobID), 0755))
 
-	// Create INVALID CRTDL file (not valid JSON)
 	crtdlPath := filepath.Join(tempDir, "invalid.crtdl")
-	_ = os.WriteFile(crtdlPath, []byte("{this is not valid json"), 0644)
+	require.NoError(t, os.WriteFile(crtdlPath, []byte("{this is not valid json"), 0644))
 
-	// Mock TORCH server (won't be called since CRTDL parsing fails)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	// Create configuration WITH preprocessing enabled
-	config := models.ProjectConfig{
-		Services: models.ServiceConfig{
-			TORCH: models.TORCHConfig{
-				BaseURL:            server.URL,
-				Username:           "testuser",
-				Password:           "testpass",
-				ExtractionTimeout:  1 * time.Minute,
-				PollingInterval:    1 * time.Second,
-				MaxPollingInterval: 5 * time.Second,
-			},
-			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
-				Enabled: true,
-				Enrichments: []models.GroupEnrichment{
-					{
-						GroupReference: "https://example.org/Patient",
-						AttributesToAdd: []models.EnrichmentAttribute{
-							{AttributeRef: "Patient.test", MustHave: true},
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: crtdlPath,
+		InputType:   models.InputTypeCRTDL,
+		Config: models.ProjectConfig{
+			JobsDir: jobsDir,
+			Services: models.ServiceConfig{
+				CRTDLPreprocessing: models.CRTDLPreprocessingConfig{
+					Enabled: true,
+					Enrichments: []models.GroupEnrichment{
+						{
+							GroupReference: "https://example.org/Patient",
+							AttributesToAdd: []models.EnrichmentAttribute{
+								{AttributeRef: "Patient.test", MustHave: true},
+							},
 						},
 					},
 				},
 			},
 		},
-		Pipeline: models.PipelineConfig{
-			EnabledSteps: []models.StepName{models.StepTorchImport},
-		},
-		Retry: models.RetryConfig{
-			MaxAttempts:      3,
-			InitialBackoffMs: 100,
-			MaxBackoffMs:     1000,
-		},
-		JobsDir: jobsDir,
 	}
 
-	// Create job manually (bypassing CreateJob which might validate CRTDL)
-	job := &models.PipelineJob{
-		JobID:       "550e8400-e29b-41d4-a716-446655440000", // Valid UUID
-		InputSource: crtdlPath,
-		InputType:   models.InputTypeCRTDL,
-		CurrentStep: string(models.StepTorchImport),
-		Status:      models.JobStatusPending,
-		Steps:       models.InitializeSteps([]models.StepName{models.StepTorchImport}),
-		Config:      config,
-	}
-
-	// Save job
-	err := pipeline.UpdateJob(jobsDir, job)
-	require.NoError(t, err)
-
-	// Execute import step - should fail during CRTDL parsing
-	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	_, err = pipeline.ExecuteImportStep(job, logger, httpClient, false)
-
-	// Verify error is returned due to invalid CRTDL
+	err := pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "preprocess CRTDL", "Error should mention preprocessing failure")
-	t.Logf("Got expected error: %v", err)
+	assert.Contains(t, err.Error(), "parse CRTDL", "Error should mention CRTDL parsing failure")
 }
 
 // TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments tests path when preprocessing is enabled but no enrichments configured

--- a/tests/unit/crtdl_prep_test.go
+++ b/tests/unit/crtdl_prep_test.go
@@ -1,0 +1,311 @@
+package unit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// crtdlWithoutPatientIdentifier matches the bug 323 scenario: a Patient
+// attribute group missing the identifier attribute. The enrichment should add
+// Patient.identifier so downstream steps (flattening) see the enriched group.
+func crtdlWithoutPatientIdentifier() map[string]any {
+	return map[string]any{
+		"cohortDefinition": map[string]any{
+			"version":           "1.0.0",
+			"inclusionCriteria": []any{},
+		},
+		"dataExtraction": map[string]any{
+			"attributeGroups": []map[string]any{
+				{
+					"id":             "patient-group",
+					"name":           "PatientPseudonymisiert",
+					"groupReference": "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert",
+					"attributes": []map[string]any{
+						{"attributeRef": "Patient.id", "mustHave": true},
+						{"attributeRef": "Patient.gender", "mustHave": false},
+					},
+				},
+			},
+		},
+	}
+}
+
+func writeCRTDLFile(t *testing.T, dir, filename string, content map[string]any) string {
+	t.Helper()
+	path := filepath.Join(dir, filename)
+	bytes, err := json.Marshal(content)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, bytes, 0644))
+	return path
+}
+
+func newJobForPrep(t *testing.T, jobsDir, jobID, crtdlPath string, preprocessing models.CRTDLPreprocessingConfig) *models.PipelineJob {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(jobsDir, jobID), 0755))
+	return &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: crtdlPath,
+		InputType:   models.InputTypeCRTDL,
+		Config: models.ProjectConfig{
+			JobsDir: jobsDir,
+			Services: models.ServiceConfig{
+				CRTDLPreprocessing: preprocessing,
+			},
+		},
+	}
+}
+
+func TestPrepareCRTDL_NotCRTDLInputType_NoOp(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+
+	job := &models.PipelineJob{
+		JobID:       "job-not-crtdl",
+		InputSource: "/some/local/dir",
+		InputType:   models.InputTypeLocal,
+		Config:      models.ProjectConfig{JobsDir: jobsDir},
+	}
+
+	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
+
+	assert.Equal(t, "/some/local/dir", job.InputSource,
+		"InputSource must be untouched when InputType is not CRTDL")
+}
+
+func TestPrepareCRTDL_PreprocessingDisabled_CopiesOriginalToJobDir(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	jobID := "job-disabled"
+
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, models.CRTDLPreprocessingConfig{Enabled: false})
+
+	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
+
+	expectedPath := filepath.Join(jobsDir, jobID, "crtdl.json")
+	assert.Equal(t, expectedPath, job.InputSource,
+		"InputSource must point at jobDir/crtdl.json after copy")
+
+	originalBytes, err := os.ReadFile(crtdlPath)
+	require.NoError(t, err)
+	copiedBytes, err := os.ReadFile(expectedPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalBytes, copiedBytes, "Copied CRTDL must match original byte-for-byte")
+}
+
+func TestPrepareCRTDL_PreprocessingEnabled_AppliesEnrichmentAndSavesEnrichedFile(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	jobID := "job-enriched"
+
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	preprocessing := models.CRTDLPreprocessingConfig{
+		Enabled: true,
+		Enrichments: []models.GroupEnrichment{
+			{
+				GroupReference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert",
+				CreateIfNotExists: &models.CreateGroupConfig{
+					GroupName: "PatientPseudonymisiert",
+				},
+				AttributesToAdd: []models.EnrichmentAttribute{
+					{AttributeRef: "Patient.identifier", MustHave: false},
+				},
+			},
+		},
+	}
+	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, preprocessing)
+
+	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
+
+	expectedPath := filepath.Join(jobsDir, jobID, "enriched-crtdl.json")
+	assert.Equal(t, expectedPath, job.InputSource,
+		"InputSource must point at jobDir/enriched-crtdl.json after enrichment")
+
+	enriched, err := services.ParseCRTDL(expectedPath)
+	require.NoError(t, err)
+	require.Len(t, enriched.DataExtraction.AttributeGroups, 1)
+
+	patientGroup := enriched.DataExtraction.AttributeGroups[0]
+	refs := make([]string, 0, len(patientGroup.Attributes))
+	for _, a := range patientGroup.Attributes {
+		refs = append(refs, a.AttributeRef)
+	}
+	assert.Contains(t, refs, "Patient.identifier",
+		"Enriched CRTDL must contain Patient.identifier added by enrichment rule")
+	assert.Contains(t, refs, "Patient.id",
+		"Enriched CRTDL must preserve original Patient.id")
+}
+
+func TestPrepareCRTDL_PreprocessingEnabledButNoEnrichments_FallsBackToCopy(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	jobID := "job-empty-enrich"
+
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, models.CRTDLPreprocessingConfig{
+		Enabled:     true,
+		Enrichments: []models.GroupEnrichment{},
+	})
+
+	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
+
+	expectedPath := filepath.Join(jobsDir, jobID, "crtdl.json")
+	assert.Equal(t, expectedPath, job.InputSource,
+		"With enabled+empty enrichments, fall back to copying as crtdl.json")
+
+	originalBytes, err := os.ReadFile(crtdlPath)
+	require.NoError(t, err)
+	copiedBytes, err := os.ReadFile(expectedPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalBytes, copiedBytes)
+}
+
+func TestPrepareCRTDL_Idempotent_SkipsWhenInputSourceAlreadyInJobDir(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	jobID := "job-idempotent"
+
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+	job := newJobForPrep(t, jobsDir, jobID, crtdlPath, models.CRTDLPreprocessingConfig{
+		Enabled: true,
+		Enrichments: []models.GroupEnrichment{
+			{
+				GroupReference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert",
+				AttributesToAdd: []models.EnrichmentAttribute{
+					{AttributeRef: "Patient.identifier", MustHave: false},
+				},
+			},
+		},
+	})
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	require.NoError(t, pipeline.PrepareCRTDL(job, logger))
+	firstPath := job.InputSource
+
+	// Capture file content after first run, then call again — content must be
+	// identical (no double-enrichment) because the second call is a no-op.
+	firstBytes, err := os.ReadFile(firstPath)
+	require.NoError(t, err)
+
+	require.NoError(t, pipeline.PrepareCRTDL(job, logger))
+	assert.Equal(t, firstPath, job.InputSource, "InputSource unchanged on repeat call")
+
+	secondBytes, err := os.ReadFile(firstPath)
+	require.NoError(t, err)
+	assert.Equal(t, firstBytes, secondBytes, "File content unchanged on repeat call")
+}
+
+func TestPrepareCRTDL_EnrichmentEnabled_FailsWhenInputCRTDLInvalid(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+
+	crtdlPath := filepath.Join(tempDir, "bad.crtdl")
+	require.NoError(t, os.WriteFile(crtdlPath, []byte("{not json"), 0644))
+
+	job := newJobForPrep(t, jobsDir, "job-bad-crtdl", crtdlPath, models.CRTDLPreprocessingConfig{
+		Enabled: true,
+		Enrichments: []models.GroupEnrichment{
+			{
+				GroupReference: "https://example.org/Patient",
+				AttributesToAdd: []models.EnrichmentAttribute{
+					{AttributeRef: "Patient.id"},
+				},
+			},
+		},
+	})
+
+	err := pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse CRTDL")
+}
+
+// TestPrepareCRTDL_PreprocessingDisabled_FailsWhenInputMissing covers the
+// ReadFile error branch in copyOriginalCRTDL (crtdl_prep.go lines 78-80).
+func TestPrepareCRTDL_PreprocessingDisabled_FailsWhenInputMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	jobID := "job-missing-input"
+
+	missingPath := filepath.Join(tempDir, "does-not-exist.crtdl")
+	job := newJobForPrep(t, jobsDir, jobID, missingPath, models.CRTDLPreprocessingConfig{Enabled: false})
+
+	err := pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read CRTDL file",
+		"Error must come from copyOriginalCRTDL ReadFile branch")
+}
+
+// TestPrepareCRTDL_InputInJobDirWithDifferentName_NotConsideredPrepared covers
+// isPreparedCRTDLPath returning false from the switch default (crtdl_prep.go
+// line 95): the path lives in jobDir but the filename is neither crtdl.json
+// nor enriched-crtdl.json, so preparation must proceed and produce the
+// canonical crtdl.json.
+func TestPrepareCRTDL_InputInJobDirWithDifferentName_NotConsideredPrepared(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	jobID := "job-other-name"
+
+	jobDir := filepath.Join(jobsDir, jobID)
+	require.NoError(t, os.MkdirAll(jobDir, 0755))
+
+	// CRTDL lives inside jobDir but under a non-canonical filename.
+	otherNamePath := writeCRTDLFile(t, jobDir, "user-supplied.json", crtdlWithoutPatientIdentifier())
+
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: otherNamePath,
+		InputType:   models.InputTypeCRTDL,
+		Config: models.ProjectConfig{
+			JobsDir:  jobsDir,
+			Services: models.ServiceConfig{CRTDLPreprocessing: models.CRTDLPreprocessingConfig{Enabled: false}},
+		},
+	}
+
+	require.NoError(t, pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug)))
+
+	expectedPath := filepath.Join(jobDir, "crtdl.json")
+	assert.Equal(t, expectedPath, job.InputSource,
+		"isPreparedCRTDLPath must return false for non-canonical filenames so prep proceeds")
+
+	_, err := os.Stat(expectedPath)
+	require.NoError(t, err, "Canonical crtdl.json must be written even though source was inside jobDir")
+}
+
+// TestPrepareCRTDL_PreprocessingDisabled_FailsWhenJobDirUnwritable covers the
+// WriteFile error branch in saveCRTDL (crtdl_prep.go lines 101-103). Pass a
+// jobsDir whose path is occupied by a regular file so jobDir cannot exist as a
+// directory and os.WriteFile fails when saveCRTDL tries to write into it.
+func TestPrepareCRTDL_PreprocessingDisabled_FailsWhenJobDirUnwritable(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// jobsDir is a regular file, not a directory — any path inside it is invalid.
+	jobsDir := filepath.Join(tempDir, "jobs-as-file")
+	require.NoError(t, os.WriteFile(jobsDir, []byte("not a directory"), 0644))
+
+	crtdlPath := writeCRTDLFile(t, tempDir, "input.crtdl", crtdlWithoutPatientIdentifier())
+
+	job := &models.PipelineJob{
+		JobID:       "job-bad-jobdir",
+		InputSource: crtdlPath,
+		InputType:   models.InputTypeCRTDL,
+		Config: models.ProjectConfig{
+			JobsDir:  jobsDir,
+			Services: models.ServiceConfig{CRTDLPreprocessing: models.CRTDLPreprocessingConfig{Enabled: false}},
+		},
+	}
+
+	err := pipeline.PrepareCRTDL(job, lib.NewLogger(lib.LogLevelDebug))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save CRTDL to job directory",
+		"Error must come from saveCRTDL WriteFile branch")
+}

--- a/tests/unit/pipeline_job_test.go
+++ b/tests/unit/pipeline_job_test.go
@@ -1,6 +1,9 @@
 package unit
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -11,7 +14,27 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
 )
+
+// countingStateFileOps wraps the default file ops and fails the Nth WriteFile call.
+type countingStateFileOps struct {
+	writeCount int
+	failOnNth  int
+	failErr    error
+}
+
+func (c *countingStateFileOps) WriteFile(name string, data []byte, perm os.FileMode) error {
+	c.writeCount++
+	if c.writeCount == c.failOnNth {
+		return c.failErr
+	}
+	return os.WriteFile(name, data, perm)
+}
+func (c *countingStateFileOps) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+func (c *countingStateFileOps) Remove(name string) error { return os.Remove(name) }
 
 // Helper to create a test job with given steps
 func createJobForPipelineTests(steps []models.StepName) models.PipelineJob {
@@ -266,6 +289,68 @@ func TestCreateJob_EmptyInputSource(t *testing.T) {
 	assert.Equal(t, models.InputTypeLocal, job.InputType, "Input type should be local")
 	assert.Equal(t, "", job.InputSource, "Input source should be empty")
 	assert.Equal(t, string(models.StepLocalImport), job.CurrentStep, "Current step should be local_import")
+}
+
+// TestCreateJob_FailsWhenSaveStateAfterCRTDLPreparationFails covers job.go
+// lines 107-109: the second SaveJobState call (after PrepareCRTDL has rewritten
+// job.InputSource) errors. We force the failure by injecting a
+// StateFileOpsProvider that succeeds for the first SaveJobState write and
+// fails for the second.
+func TestCreateJob_FailsWhenSaveStateAfterCRTDLPreparationFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	jobsDir := filepath.Join(tmpDir, "jobs")
+
+	// Write a valid CRTDL file so DetectInputType returns CRTDL and
+	// ValidateCRTDLSyntax/ParseCRTDL both succeed.
+	crtdlPath := filepath.Join(tmpDir, "input.crtdl")
+	crtdlContent := map[string]any{
+		"cohortDefinition": map[string]any{
+			"version":           "1.0.0",
+			"inclusionCriteria": []any{},
+		},
+		"dataExtraction": map[string]any{
+			"attributeGroups": []map[string]any{
+				{
+					"id":             "g1",
+					"name":           "PatientPseudonymisiert",
+					"groupReference": "https://example.org/Patient",
+					"attributes": []map[string]any{
+						{"attributeRef": "Patient.id", "mustHave": true},
+					},
+				},
+			},
+		},
+	}
+	bytes, err := json.Marshal(crtdlContent)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(crtdlPath, bytes, 0644))
+
+	config := models.ProjectConfig{
+		JobsDir: jobsDir,
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepTorchImport, models.StepFlattening},
+		},
+		Services: models.ServiceConfig{
+			CRTDLPreprocessing: models.CRTDLPreprocessingConfig{Enabled: false},
+		},
+	}
+
+	original := services.StateFileOpsProvider
+	t.Cleanup(func() { services.StateFileOpsProvider = original })
+
+	ops := &countingStateFileOps{
+		failOnNth: 2,
+		failErr:   errors.New("simulated write failure"),
+	}
+	services.StateFileOpsProvider = ops
+
+	job, err := pipeline.CreateJob(crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+
+	require.Error(t, err, "CreateJob must surface the second SaveJobState failure")
+	assert.Nil(t, job)
+	assert.Contains(t, err.Error(), "save job state after CRTDL preparation",
+		"Error must come from the post-PrepareCRTDL SaveJobState branch (job.go:107-109)")
+	assert.GreaterOrEqual(t, ops.writeCount, 2, "Second SaveJobState must have been attempted")
 }
 
 // TestCreateJob_NoImportStepEnabled tests CreateJob when no import step is enabled


### PR DESCRIPTION
## Summary

- Move CRTDL preparation (enrichment + copy into job dir) out of `executeTORCHExtraction` and into a dedicated `pipeline.PrepareCRTDL` invoked from `CreateJob`. Every downstream step (import, flattening, …) now reads the same effective CRTDL via `job.InputSource`.
- Reconcile state on `pipeline continue`: also call `PrepareCRTDL` after `LoadJob` so a crash between preparing the CRTDL and persisting the new `InputSource` heals on resume (idempotent).
- Add unit tests for `PrepareCRTDL` (enabled / disabled / empty enrichments / idempotency / parse error) and an integration regression test that exercises the local_import + enrichment path described in the issue.

## Why

Enrichment used to live inside `executeTORCHExtraction`. Jobs with `InputType=CRTDL` that imported via `local_import` or `http_import` (and had flattening enabled) silently skipped enrichment, so flattening read the original unenriched CRTDL — exactly the bug reported in #323. After this change, enrichment is applied once at job creation and persisted in the job directory as `enriched-crtdl.json` (or `crtdl.json` when preprocessing is disabled), so every step sees the same CRTDL.

Closes #323