### PR TITLE
feat(cli)!: require aether.yaml as first positional arg, drop --config flag

### DIFF
--- a/.github/scripts/continue-pipeline.sh
+++ b/.github/scripts/continue-pipeline.sh
@@ -32,4 +32,4 @@ echo "  DIMP: http://fhir-pseudonymizer:8080 (internal)"
 echo ""
 
 # Run aether continue inside the Docker network
-docker compose exec -T aether-runner /app/aether pipeline continue "$JOB_ID" --config aether.yaml
+docker compose exec -T aether-runner /app/aether pipeline continue aether.yaml "$JOB_ID"

--- a/.github/scripts/run-direct-load-e2e-test.sh
+++ b/.github/scripts/run-direct-load-e2e-test.sh
@@ -17,7 +17,7 @@ echo "Pipeline: torch → send (direct_resource_load)"
 
 # Run aether inside the Docker network where it can resolve internal hostnames
 # Capture output to extract job ID
-OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline start torch/queries/example-crtdl.json --config aether-direct-load.yaml 2>&1) || true
+OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline start aether-direct-load.yaml torch/queries/example-crtdl.json 2>&1) || true
 echo "$OUTPUT"
 
 # Extract job ID from output (format: "Created pipeline job: <YYYYMMDD_HHMM_UUID or UUID>")
@@ -40,7 +40,7 @@ if ! echo "$OUTPUT" | grep -q "Pipeline completed successfully"; then
     for i in {1..5}; do
         echo ""
         echo "Checking job status (attempt $i)..."
-        STATUS_OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline status "$JOB_ID" --config aether-direct-load.yaml 2>&1) || true
+        STATUS_OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline status aether-direct-load.yaml "$JOB_ID" 2>&1) || true
         echo "$STATUS_OUTPUT"
 
         if echo "$STATUS_OUTPUT" | grep -q "completed"; then

--- a/.github/scripts/run-e2e-test.sh
+++ b/.github/scripts/run-e2e-test.sh
@@ -36,7 +36,7 @@ echo "  Blaze (send target): http://blaze-fhir:8080/fhir (internal)"
 
 # Run aether inside the Docker network where it can resolve internal hostnames
 # Capture output to extract job ID
-OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline start torch/queries/example-crtdl.json --config aether.yaml 2>&1) || true
+OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline start aether.yaml torch/queries/example-crtdl.json 2>&1) || true
 echo "$OUTPUT"
 
 # Extract job ID from output (format: "Created pipeline job: <YYYYMMDD_HHMM_UUID or UUID>")
@@ -63,7 +63,7 @@ if echo "$OUTPUT" | grep -q "Pipeline paused at wait step"; then
     while true; do
         echo ""
         echo "Continuing pipeline..."
-        CONTINUE_OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline continue "$JOB_ID" --config aether.yaml 2>&1) || {
+        CONTINUE_OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline continue aether.yaml "$JOB_ID" 2>&1) || {
             echo "$CONTINUE_OUTPUT"
             # Check if it's just a pause at another wait step
             if echo "$CONTINUE_OUTPUT" | grep -q "Pipeline paused at wait step\|Pipeline still paused"; then

--- a/.github/scripts/run-flattening-e2e-test.sh
+++ b/.github/scripts/run-flattening-e2e-test.sh
@@ -112,7 +112,7 @@ echo "  Job ID: $JOB_ID"
 echo "  Flattener: http://fhir-flattener:8000 (internal)"
 
 # Run the pipeline continue command
-OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline continue "$JOB_ID" --config aether-flattening.yaml 2>&1) || {
+OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline continue aether-flattening.yaml "$JOB_ID" 2>&1) || {
     echo -e "${RED}Pipeline failed:${NC}"
     echo "$OUTPUT"
     exit 1
@@ -122,7 +122,7 @@ echo "$OUTPUT"
 # Check if pipeline completed
 if ! echo "$OUTPUT" | grep -q "Job completed successfully\|completed"; then
     echo -e "${YELLOW}Pipeline may not have completed. Checking job status...${NC}"
-    docker compose exec -T aether-runner /app/aether pipeline status "$JOB_ID" --config aether-flattening.yaml
+    docker compose exec -T aether-runner /app/aether pipeline status aether-flattening.yaml "$JOB_ID"
 fi
 
 echo ""

--- a/.github/scripts/run-s3-upload-e2e-test.sh
+++ b/.github/scripts/run-s3-upload-e2e-test.sh
@@ -17,7 +17,7 @@ echo ""
 echo "Pipeline: torch → send (s3_upload)"
 
 # Run aether inside the Docker network where it can resolve internal hostnames
-OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline start torch/queries/example-crtdl.json --config aether-s3-upload.yaml 2>&1) || true
+OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline start aether-s3-upload.yaml torch/queries/example-crtdl.json 2>&1) || true
 echo "$OUTPUT"
 
 # Extract job ID from output (format: "Created pipeline job: <YYYYMMDD_HHMM_UUID or UUID>")
@@ -39,7 +39,7 @@ if ! echo "$OUTPUT" | grep -q "Pipeline completed successfully"; then
     for i in {1..5}; do
         echo ""
         echo "Checking job status (attempt $i)..."
-        STATUS_OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline status "$JOB_ID" --config aether-s3-upload.yaml 2>&1) || true
+        STATUS_OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline status aether-s3-upload.yaml "$JOB_ID" 2>&1) || true
         echo "$STATUS_OUTPUT"
 
         if echo "$STATUS_OUTPUT" | grep -q "completed"; then

--- a/.github/scripts/run-validation-e2e-test.sh
+++ b/.github/scripts/run-validation-e2e-test.sh
@@ -113,7 +113,7 @@ echo ""
 # Config sets fail_on_error: false, so the pipeline should succeed.
 # Report files capture all OperationOutcomes for review.
 PIPELINE_EXIT=0
-OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline continue "$JOB_ID" --config aether-validation.yaml 2>&1) || PIPELINE_EXIT=$?
+OUTPUT=$(docker compose exec -T aether-runner /app/aether pipeline continue aether-validation.yaml "$JOB_ID" 2>&1) || PIPELINE_EXIT=$?
 echo "$OUTPUT"
 
 if [ $PIPELINE_EXIT -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ aether --help
 
 ## Configuration
 
-Create `aether.yaml` in your working directory:
+Create an `aether.yaml` file (any path is fine — pass it as the first positional arg):
 
 ```yaml
 services:
@@ -63,23 +63,25 @@ jobs_dir: "./jobs"
 
 ## Usage
 
+Every subcommand takes the path to your `aether.yaml` as the first positional argument.
+
 ### Run a Pipeline
 
 ```bash
-aether pipeline start your-crtdl.json
+aether pipeline start aether.yaml your-crtdl.json
 ```
 
 ### Check Status
 
 ```bash
-aether job list
-aether pipeline status <job-id>
+aether job list aether.yaml
+aether pipeline status aether.yaml <job-id>
 ```
 
 ### Resume a Pipeline
 
 ```bash
-aether pipeline continue <job-id>
+aether pipeline continue aether.yaml <job-id>
 ```
 
 ## More Information

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -31,9 +31,12 @@ Available subcommands:
 
 // jobListCmd represents the job list command
 var jobListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list <config>",
 	Short: "List all pipeline jobs",
 	Long: `List all pipeline jobs in the jobs directory.
+
+Arguments:
+  <config>  Path to aether.yaml (required, first positional)
 
 Shows:
   • Job ID (YYYYMMDD_HHMM_UUID or legacy UUID)
@@ -53,24 +56,29 @@ Status Symbols:
 
 Examples:
   # List all jobs
-  aether job list
+  aether job list aether.yaml
 
   # Continuously monitor all jobs
-  watch -n 5 aether job list
+  watch -n 5 aether job list aether.yaml
 
 Typical Workflow:
-  1. Start pipeline:  aether pipeline start crtdl.json
-  2. List jobs:       aether job list
+  1. Start pipeline:  aether pipeline start aether.yaml crtdl.json
+  2. List jobs:       aether job list aether.yaml
   3. Get job ID from list
-  4. Check status:    aether pipeline status <job-id>`,
+  4. Check status:    aether pipeline status aether.yaml <job-id>`,
+	Args: cobra.ExactArgs(1),
 	RunE: runJobList,
 }
 
 // jobRunCmd represents the job run command
 var jobRunCmd = &cobra.Command{
-	Use:   "run <job-id> --step <step-name>",
+	Use:   "run <config> <job-id> --step <step-name>",
 	Short: "Execute a specific pipeline step manually",
 	Long: `Execute a specific pipeline step for a job manually.
+
+Arguments:
+  <config>  Path to aether.yaml (required, first positional)
+  <job-id>  Pipeline job ID (required, second positional)
 
 This command allows you to run individual pipeline steps independently,
 useful for:
@@ -90,16 +98,16 @@ Prerequisites:
 
 Examples:
   # Run import step manually
-  aether job run abc123 --step import
+  aether job run aether.yaml abc123 --step import
 
   # Run DIMP pseudonymization step
-  aether job run abc123 --step dimp
+  aether job run aether.yaml abc123 --step dimp
 
 Error Handling:
   • Transient errors (network, 5xx) are retried automatically
   • Non-transient errors (4xx, validation) stop execution
   • Use 'pipeline status' to check step status after execution`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(2),
 	RunE: runJobRun,
 }
 
@@ -118,8 +126,9 @@ func init() {
 }
 
 func runJobList(cmd *cobra.Command, args []string) error {
-	// Load configuration
-	config, err := services.LoadConfig(cfgFile)
+	cfgPath := args[0]
+
+	config, err := services.LoadConfig(cfgPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -229,16 +238,15 @@ func formatDuration(d time.Duration) string {
 }
 
 func runJobRun(cmd *cobra.Command, args []string) error {
-	jobID := args[0]
+	cfgPath := args[0]
+	jobID := args[1]
 
-	// Validate step name
 	stepName, err := validateStepName(stepFlag)
 	if err != nil {
 		return err
 	}
 
-	// Load configuration
-	config, err := services.LoadConfig(cfgFile)
+	config, err := services.LoadConfig(cfgPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -35,55 +35,61 @@ Available subcommands:
 
 // pipelineStartCmd represents the pipeline start command
 var pipelineStartCmd = &cobra.Command{
-	Use:   "start <crtdl> [input]",
+	Use:   "start <config> <crtdl> [input]",
 	Short: "Start a new pipeline job",
 	Long: `Start a new Data Use Process pipeline job.
 
-The CRTDL file is always required as the first positional argument. The
-optional second positional is the input source for the enabled import step:
-  • omitted (torch_import): CRTDL is submitted to TORCH for extraction
-  • omitted (local_import): data dir is read from --dir or config
-  • local directory path (local_import): files imported from disk
-  • HTTP(S) URL (http_import): single NDJSON file downloaded
-  • TORCH result URL (torch_import): auto-detected when the URL contains
-    /fhir/extraction/ or /fhir/result/; extraction is skipped and results
-    are polled directly
+Arguments:
+  <config>  Path to aether.yaml (required, first positional)
+  <crtdl>   CRTDL JSON file (required, second positional)
+  [input]   Optional input source for the enabled import step:
+              • omitted (torch_import): CRTDL is submitted to TORCH
+              • omitted (local_import): data dir is read from --dir or config
+              • local directory path (local_import): files imported from disk
+              • HTTP(S) URL (http_import): single NDJSON file downloaded
+              • TORCH result URL (torch_import): auto-detected when the URL
+                contains /fhir/extraction/ or /fhir/result/; extraction is
+                skipped and results are polled directly
 
 Combining http_import with a CRTDL requires --allow-http-crtdl since HTTP
 data may not match the CRTDL query.
 
 Examples:
   # Extract data using CRTDL query via TORCH
-  aether pipeline start crtdl.json
+  aether pipeline start aether.yaml crtdl.json
 
   # Local import with CRTDL for flattening (data dir from config)
-  aether pipeline start crtdl.json
+  aether pipeline start aether.yaml crtdl.json
 
   # Local import with CRTDL (data dir as positional)
-  aether pipeline start crtdl.json /path/to/fhir/data
+  aether pipeline start aether.yaml crtdl.json /path/to/fhir/data
 
   # Local import with CRTDL (data dir via flag)
-  aether pipeline start crtdl.json --dir /path/to/fhir/data
+  aether pipeline start aether.yaml crtdl.json --dir /path/to/fhir/data
 
   # HTTP import piped through flattening (acknowledges data/CRTDL mismatch)
-  aether pipeline start crtdl.json https://example.com/fhir/Patient.ndjson \
+  aether pipeline start aether.yaml crtdl.json https://example.com/fhir/Patient.ndjson \
       --allow-http-crtdl
 
   # Direct TORCH URL (skip extraction, poll and download results)
-  aether pipeline start crtdl.json \
+  aether pipeline start aether.yaml crtdl.json \
       "https://torch.example.com/fhir/extraction/result-123"
 
   # Start without progress indicators
-  aether pipeline start crtdl.json --no-progress`,
-	Args: cobra.RangeArgs(1, 2),
+  aether pipeline start aether.yaml crtdl.json --no-progress`,
+	Args: cobra.RangeArgs(2, 3),
 	RunE: runPipelineStart,
 }
 
 // pipelineStatusCmd represents the pipeline status command
 var pipelineStatusCmd = &cobra.Command{
-	Use:   "status [job-id]",
+	Use:   "status <config> <job-id>",
 	Short: "Check pipeline job status",
 	Long: `Display the current status of a pipeline job.
+
+Arguments:
+  <config>  Path to aether.yaml (required, first positional)
+  <job-id>  Pipeline job ID (required, second positional)
 
 Shows:
   • Job ID and current status
@@ -94,23 +100,27 @@ Shows:
 
 The status command is designed for quick checks (<2s response time).
 Use 'watch' for continuous monitoring:
-  watch -n 5 aether pipeline status <job-id>
+  watch -n 5 aether pipeline status aether.yaml <job-id>
 
 Examples:
   # Check job status
-  aether pipeline status abc-123-def
+  aether pipeline status aether.yaml abc-123-def
 
   # Continuous monitoring (every 5 seconds)
-  watch -n 5 aether pipeline status abc-123-def`,
-	Args: cobra.ExactArgs(1),
+  watch -n 5 aether pipeline status aether.yaml abc-123-def`,
+	Args: cobra.ExactArgs(2),
 	RunE: runPipelineStatus,
 }
 
 // pipelineContinueCmd represents the pipeline continue command
 var pipelineContinueCmd = &cobra.Command{
-	Use:   "continue [job-id]",
+	Use:   "continue <config> <job-id>",
 	Short: "Resume a pipeline job",
 	Long: `Resume pipeline execution from the next enabled step.
+
+Arguments:
+  <config>  Path to aether.yaml (required, first positional)
+  <job-id>  Pipeline job ID (required, second positional)
 
 This command is useful for:
   • Resuming after terminal close (session-independent)
@@ -125,24 +135,24 @@ Common Scenarios:
 
   1. Resume after closing terminal:
      Terminal closed mid-pipeline? Just run continue:
-       aether pipeline continue <job-id>
+       aether pipeline continue aether.yaml <job-id>
 
   2. Retry after fixing transient error:
      Service was down and retries exhausted? Fix the issue, then:
-       aether pipeline continue <job-id>
+       aether pipeline continue aether.yaml <job-id>
 
   3. Continue after manual data correction:
      Fixed malformed FHIR data? Resume processing:
-       aether pipeline continue <job-id>
+       aether pipeline continue aether.yaml <job-id>
 
 Examples:
   # Resume a paused job
-  aether pipeline continue abc-123-def
+  aether pipeline continue aether.yaml abc-123-def
 
   # Check status first, then resume
-  aether pipeline status abc-123-def
-  aether pipeline continue abc-123-def`,
-	Args: cobra.ExactArgs(1),
+  aether pipeline status aether.yaml abc-123-def
+  aether pipeline continue aether.yaml abc-123-def`,
+	Args: cobra.ExactArgs(2),
 	RunE: runPipelineContinue,
 }
 
@@ -319,7 +329,7 @@ func executeStep(job *models.PipelineJob, stepName models.StepName, config *mode
 		fmt.Printf("\n⏸ Pipeline paused at wait step\n")
 		fmt.Printf("  Wait directory: %s\n", waitDir)
 		fmt.Printf("  The directory is EMPTY - place your modified data there\n")
-		fmt.Printf("\n  To continue: aether pipeline continue %s\n", job.JobID)
+		fmt.Printf("\n  To continue: aether pipeline continue <config> %s\n", job.JobID)
 		return errPipelinePaused // Signal to break out of pipeline loop
 
 	default:
@@ -328,21 +338,22 @@ func executeStep(job *models.PipelineJob, stepName models.StepName, config *mode
 }
 
 func runPipelineStart(cmd *cobra.Command, args []string) error {
-	// First positional is always the CRTDL; second (optional) is the input
-	// source for the enabled import step.
-	crtdlPath := args[0]
+	// Positional contract: <config> <crtdl> [input]. The third positional, if
+	// supplied, is the input source for the enabled import step.
+	cfgPath := args[0]
+	crtdlPath := args[1]
 	var inputSource string
-	if len(args) > 1 {
-		inputSource = args[1]
+	if len(args) > 2 {
+		inputSource = args[2]
 	}
 
 	if t, err := lib.DetectInputType(crtdlPath); err != nil {
 		return fmt.Errorf("invalid CRTDL argument %q: %w", crtdlPath, err)
 	} else if t != models.InputTypeCRTDL {
-		return fmt.Errorf("first argument must be a CRTDL file, got %s: %q", t, crtdlPath)
+		return fmt.Errorf("second argument must be a CRTDL file, got %s: %q", t, crtdlPath)
 	}
 
-	config, err := services.LoadConfig(cfgFile)
+	config, err := services.LoadConfig(cfgPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -356,7 +367,7 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	if config.Pipeline.IsStepEnabled(models.StepLocalImport) && !config.Pipeline.IsStepEnabled(models.StepTorchImport) {
 		hasSourceDir := config.Services.LocalImport.Dir != "" || inputSource != ""
 		if !hasSourceDir {
-			return fmt.Errorf("local_import step enabled but no directory specified\n\nProvide directory via:\n  1. Positional: aether pipeline start <crtdl> /path/to/data\n  2. --dir flag: aether pipeline start <crtdl> --dir /path/to/data\n  3. Config file: services.local_import.dir in aether.yaml")
+			return fmt.Errorf("local_import step enabled but no directory specified\n\nProvide directory via:\n  1. Positional: aether pipeline start <config> <crtdl> /path/to/data\n  2. --dir flag: aether pipeline start <config> <crtdl> --dir /path/to/data\n  3. Config file: services.local_import.dir in aether.yaml")
 		}
 	}
 
@@ -480,9 +491,10 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 }
 
 func runPipelineStatus(cmd *cobra.Command, args []string) error {
-	jobID := args[0]
+	cfgPath := args[0]
+	jobID := args[1]
 
-	config, err := services.LoadConfig(cfgFile)
+	config, err := services.LoadConfig(cfgPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -518,9 +530,10 @@ func runPipelineStatus(cmd *cobra.Command, args []string) error {
 }
 
 func runPipelineContinue(cmd *cobra.Command, args []string) error {
-	jobID := args[0]
+	cfgPath := args[0]
+	jobID := args[1]
 
-	config, err := services.LoadConfig(cfgFile)
+	config, err := services.LoadConfig(cfgPath)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -633,7 +646,7 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\n⏸ Pipeline still paused at wait step\n")
 			fmt.Printf("  Wait directory: %s\n", waitDir)
 			fmt.Printf("  The directory is EMPTY - place your modified data there\n")
-			fmt.Printf("\n  To continue: aether pipeline continue %s\n", job.JobID)
+			fmt.Printf("\n  To continue: aether pipeline continue <config> %s\n", job.JobID)
 			return errPipelinePaused
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,7 @@ import (
 )
 
 var (
-	// Global flags
-	cfgFile string
+	// verbose toggles debug-level logging across all subcommands.
 	verbose bool
 
 	// version is set via SetVersion before Execute
@@ -43,22 +42,22 @@ Quick Start:
        cp config/aether.example.yaml aether.yaml
 
   2. Start a pipeline:
-       aether pipeline start crtdl.json
+       aether pipeline start aether.yaml crtdl.json
 
   3. Check status:
-       aether pipeline status <job-id>
+       aether pipeline status aether.yaml <job-id>
 
   4. List all jobs:
-       aether job list
+       aether job list aether.yaml
 
   5. Resume a job:
-       aether pipeline continue <job-id>
+       aether pipeline continue aether.yaml <job-id>
 
 Configuration:
-  The CLI looks for configuration in the following order:
-    1. --config flag
-    2. ./aether.yaml (current directory)
-    3. ~/.config/aether/aether.yaml (user config directory)
+  Every command that needs configuration takes the path to your
+  aether.yaml as the first positional argument. There is no
+  --config flag and no implicit discovery of ./aether.yaml or
+  ~/.config/aether/aether.yaml — point at the file explicitly.
 
 For more information:
   Documentation: https://github.com/medizininformatik-initiative/aether
@@ -84,7 +83,6 @@ func Execute() {
 
 func init() {
 	// Persistent flags (available to all subcommands)
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ./aether.yaml, ~/.config/aether/aether.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging")
 
 	// Add version template

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -5,13 +5,16 @@ Reference for Aether CLI commands.
 ## Global Options
 
 ```bash
-aether [global-options] <command> [command-options]
+aether [global-options] <command> ...
 ```
 
-- `--config FILE` - Path to configuration file (default: ./aether.yaml)
 - `--verbose, -v` - Enable verbose logging
 - `--help, -h` - Show help
 - `--version` - Show version
+
+Every subcommand that needs configuration takes the path to `aether.yaml` as
+its first positional argument. There is no `--config` flag and no implicit
+discovery of `./aether.yaml` or `~/.config/aether/aether.yaml`.
 
 ## Pipeline Commands
 
@@ -20,11 +23,12 @@ aether [global-options] <command> [command-options]
 Start a new pipeline job.
 
 ```bash
-aether pipeline start .json> [input] [options]
+aether pipeline start <config> <crtdl> [input] [options]
 ```
 
 **Arguments:**
-- `.json>` - CRTDL file path. Required for every pipeline run.
+- `<config>` - Path to `aether.yaml` (required, first positional)
+- `<crtdl>` - CRTDL JSON file (required, second positional)
 - `[input]` - Optional import-step input:
   - omitted: torch_import submits the CRTDL; local_import uses `--dir`/config
   - local directory (local_import)
@@ -34,27 +38,27 @@ aether pipeline start .json> [input] [options]
 **Options:**
 - `--no-progress` - Disable progress indicators
 - `--dir PATH` - Directory for local import (overrides config)
-- `--allow-http.json` - Acknowledge that HTTP data may not match the CRTDL query (required when `http_import` is enabled)
+- `--allow-http-crtdl` - Acknowledge that HTTP data may not match the CRTDL query (required when `http_import` is enabled)
 
 **Examples:**
 ```bash
 # TORCH extraction with CRTDL
-aether pipeline start crtdl.json
+aether pipeline start aether.yaml crtdl.json
 
 # Direct TORCH URL (skip extraction, poll and download results)
-aether pipeline start crtdl.json "https://torch.example.com/fhir/extraction/result-123"
+aether pipeline start aether.yaml crtdl.json "https://torch.example.com/fhir/extraction/result-123"
 
 # Local import with CRTDL for flattening (dir from flag)
-aether pipeline start crtdl.json --dir /path/to/data
+aether pipeline start aether.yaml crtdl.json --dir /path/to/data
 
 # Local import with CRTDL for flattening (dir as positional)
-aether pipeline start crtdl.json /path/to/data
+aether pipeline start aether.yaml crtdl.json /path/to/data
 
 # HTTP download piped through flattening
-aether pipeline start crtdl.json https://example.com/fhir/data.ndjson --allow-http.json
+aether pipeline start aether.yaml crtdl.json https://example.com/fhir/data.ndjson --allow-http-crtdl
 
 # Disable progress bars
-aether pipeline start crtdl.json --no-progress
+aether pipeline start aether.yaml crtdl.json --no-progress
 ```
 
 ### aether pipeline status
@@ -62,7 +66,7 @@ aether pipeline start crtdl.json --no-progress
 Check pipeline job status.
 
 ```bash
-aether pipeline status <job-id>
+aether pipeline status <config> <job-id>
 ```
 
 **Output:**
@@ -73,7 +77,7 @@ aether pipeline status <job-id>
 
 **Example:**
 ```bash
-aether pipeline status abc-123-def
+aether pipeline status aether.yaml abc-123-def
 ```
 
 ### aether pipeline continue
@@ -81,7 +85,7 @@ aether pipeline status abc-123-def
 Resume a paused or failed pipeline.
 
 ```bash
-aether pipeline continue <job-id>
+aether pipeline continue <config> <job-id>
 ```
 
 **Use cases:**
@@ -92,10 +96,10 @@ aether pipeline continue <job-id>
 **Examples:**
 ```bash
 # Resume failed job
-aether pipeline continue abc-123-def
+aether pipeline continue aether.yaml abc-123-def
 
 # Resume from wait step (after placing files)
-aether pipeline continue abc-123-def
+aether pipeline continue aether.yaml abc-123-def
 ```
 
 ## Job Commands
@@ -105,7 +109,7 @@ aether pipeline continue abc-123-def
 List all pipeline jobs.
 
 ```bash
-aether job list
+aether job list <config>
 ```
 
 **Output columns:**
@@ -123,7 +127,7 @@ aether job list
 
 **Example:**
 ```bash
-aether job list
+aether job list aether.yaml
 ```
 
 ### aether job run
@@ -131,7 +135,7 @@ aether job list
 Execute a specific pipeline step manually.
 
 ```bash
-aether job run <job-id> --step <step-name>
+aether job run <config> <job-id> --step <step-name>
 ```
 
 **Options:**
@@ -142,10 +146,10 @@ aether job run <job-id> --step <step-name>
 **Examples:**
 ```bash
 # Run DIMP step manually
-aether job run abc-123-def --step dimp
+aether job run aether.yaml abc-123-def --step dimp
 
 # Run import step manually
-aether job run abc-123-def --step local_import
+aether job run aether.yaml abc-123-def --step local_import
 ```
 
 ## Other Commands
@@ -194,10 +198,10 @@ aether help pipeline start
 
 ## Configuration Loading
 
-Aether loads configuration in this order:
-1. `--config` flag
-2. `./aether.yaml` (current directory)
-3. `~/.config/aether/aether.yaml` (user config)
+The path to `aether.yaml` is the first positional argument of every command
+that needs configuration; aether does not auto-discover it. CLI flags and
+`AETHER_*` environment variables still override individual values from the
+file.
 
 ## Environment Variables
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Aether uses a YAML configuration file. Create `aether.yaml` in your working directory.
+Aether uses a YAML configuration file. Create an `aether.yaml` anywhere on disk and pass its path as the first positional argument on every command. Aether does not auto-discover config files.
 
 ## Basic Configuration
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -4,7 +4,8 @@ Get Aether running in 5 minutes.
 
 ## 1. Create Configuration
 
-Create `aether.yaml` in your working directory:
+Create an `aether.yaml` somewhere on disk. Every command takes the path to this
+file as its first positional argument:
 
 ```yaml
 services:
@@ -29,7 +30,7 @@ Replace URLs and credentials with your actual server details.
 ## 2. Run a Pipeline
 
 ```bash
-aether pipeline start your-crtdl.json
+aether pipeline start aether.yaml your-crtdl.json
 ```
 
 Aether will:
@@ -45,10 +46,10 @@ Output files use `.ndjson.zst` extension (zstd compressed).
 
 ```bash
 # List all jobs
-aether job list
+aether job list aether.yaml
 
 # Check a specific job
-aether pipeline status <job-id>
+aether pipeline status aether.yaml <job-id>
 ```
 
 ## 4. Resume if Needed
@@ -56,7 +57,7 @@ aether pipeline status <job-id>
 If a pipeline fails or pauses, resume it:
 
 ```bash
-aether pipeline continue <job-id>
+aether pipeline continue aether.yaml <job-id>
 ```
 
 ## Alternative: Direct TORCH URL
@@ -64,7 +65,7 @@ aether pipeline continue <job-id>
 If you already have a TORCH extraction URL, skip the CRTDL submission:
 
 ```bash
-aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+aether pipeline start aether.yaml crtdl.json "https://torch.example.com/fhir/extraction/result-123"
 ```
 
 Aether auto-detects URLs containing `/fhir/extraction/` or `/fhir/result/` and polls them directly. See [TORCH Integration](../guides/torch-integration.md#direct-torch-url-import) for details.
@@ -88,10 +89,10 @@ pipeline:
 
 ```bash
 # Use config directory
-aether pipeline start
+aether pipeline start aether.yaml crtdl.json
 
 # Or override with --dir flag
-aether pipeline start --dir /other/path
+aether pipeline start aether.yaml crtdl.json --dir /other/path
 ```
 
 ## Next Steps

--- a/docs/guides/pipeline-steps.md
+++ b/docs/guides/pipeline-steps.md
@@ -71,17 +71,17 @@ pipeline:
 
 ```bash
 # List all jobs
-aether job list
+aether job list aether.yaml
 
 # Check specific job
-aether pipeline status <job-id>
+aether pipeline status aether.yaml <job-id>
 ```
 
 ## Resuming
 
 ```bash
 # Resume failed or paused job
-aether pipeline continue <job-id>
+aether pipeline continue aether.yaml <job-id>
 ```
 
 Completed steps are not re-run.

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -29,7 +29,7 @@ pipeline:
 ## Running a TORCH Query
 
 ```bash
-aether pipeline start your-crtdl.json
+aether pipeline start aether.yaml your-crtdl.json
 ```
 
 Aether will show progress as it:
@@ -71,7 +71,7 @@ During status polling, transient HTTP errors (timeouts, connection resets) are t
 If you already have a TORCH extraction or result URL, you can pass it directly to skip the CRTDL submission step:
 
 ```bash
-aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+aether pipeline start aether.yaml crtdl.json "https://torch.example.com/fhir/extraction/result-123"
 ```
 
 Aether auto-detects TORCH URLs by looking for `/fhir/extraction/` or `/fhir/result/` in the URL (case-sensitive). When a TORCH URL is provided, Aether:

--- a/docs/performance-validation-plan.md
+++ b/docs/performance-validation-plan.md
@@ -259,7 +259,7 @@ aether --version
 
 **Step 2: Configuration**
 ```bash
-cp config/aether.example.yaml ~/.config/aether/aether.yaml
+cp config/aether.example.yaml ./aether.yaml
 # Edit configuration with service URLs
 ```
 - ✅ Example config file exists

--- a/docs/shell-completions.md
+++ b/docs/shell-completions.md
@@ -109,7 +109,7 @@ Aether completions provide suggestions for:
   - `pipeline start`, `pipeline status`, `pipeline continue`
   - `job list`, `job run`
   - `completion bash`, `completion zsh`, `completion fish`, `completion powershell`
-- **Flags**: `--config`, `--verbose`, `--help`, `--version`, `--no-progress`, `--step`
+- **Flags**: `--verbose`, `--help`, `--version`, `--no-progress`, `--dir`, `--allow-http-crtdl`, `--step`
 - **Job IDs**: Tab-complete existing job IDs for `pipeline status` and `pipeline continue`
 - **File paths**: Autocomplete paths for `pipeline start` input
 
@@ -130,7 +130,7 @@ aether pipeline start <TAB>
 # Shows: files and directories in current path
 
 aether --<TAB>
-# Shows: --config  --verbose  --help  --version
+# Shows: --verbose  --help  --version
 ```
 
 ## Troubleshooting

--- a/internal/lib/errors.go
+++ b/internal/lib/errors.go
@@ -255,7 +255,7 @@ func ErrJobNotFound(jobID string) *AetherError {
 		Message:  fmt.Sprintf("Job '%s' not found", jobID),
 		Guidance: []string{
 			"Check the job ID is correct",
-			"Use 'aether job list' to see all available jobs",
+			"Use 'aether job list <config>' to see all available jobs",
 			"The job may have been deleted",
 		},
 		IsRetryable: false,
@@ -285,8 +285,8 @@ func ErrStepPrerequisiteNotMet(stepName models.StepName, prerequisite models.Ste
 		Message:  fmt.Sprintf("Cannot run %s: prerequisite step %s has not completed", stepName, prerequisite),
 		Guidance: []string{
 			fmt.Sprintf("Ensure %s step completes successfully first", prerequisite),
-			"Use 'aether pipeline status <job-id>' to check step progress",
-			fmt.Sprintf("Run 'aether pipeline continue <job-id>' to resume from %s", prerequisite),
+			"Use 'aether pipeline status <config> <job-id>' to check step progress",
+			fmt.Sprintf("Run 'aether pipeline continue <config> <job-id>' to resume from %s", prerequisite),
 		},
 		IsRetryable: false,
 	}

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -51,38 +51,26 @@ func ExpandEnvVars(s string) string {
 	return expanded
 }
 
-// LoadConfig loads configuration from file and merges with CLI flags
+// LoadConfig loads configuration from the given file and merges with CLI flags.
+// The config file path is required; auto-discovery of ./aether.yaml or
+// ~/.config/aether/aether.yaml is intentionally not performed.
 // Priority order (highest to lowest):
 //  1. CLI flags (via viper bindings)
 //  2. Environment variables
 //  3. Configuration file
 //  4. Default values
 func LoadConfig(configFile string) (*models.ProjectConfig, error) {
-	// Set config file path if provided
-	if configFile != "" {
-		viper.SetConfigFile(configFile)
-	} else {
-		// Search for config in standard locations
-		viper.SetConfigName("aether")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-		viper.AddConfigPath("$HOME/.config/aether")
-		viper.AddConfigPath("/etc/aether")
+	if configFile == "" {
+		return nil, fmt.Errorf("config file is required: pass aether.yaml as the first positional argument (e.g. `aether pipeline start aether.yaml crtdl.json`)")
 	}
+	viper.SetConfigFile(configFile)
 
 	// Enable environment variable override with AETHER_ prefix
 	viper.SetEnvPrefix("AETHER")
 	viper.AutomaticEnv()
 
-	// Read config file (optional - don't fail if not found)
-	configFound := true
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			// Config file was found but couldn't be read
-			return nil, fmt.Errorf("failed to read config file: %w", err)
-		}
-		// Config file not found - use defaults only
-		configFound = false
+		return nil, fmt.Errorf("failed to read config file %q: %w", configFile, err)
 	}
 
 	// Build config manually from viper values
@@ -183,100 +171,67 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 		config.Pipeline.EnabledSteps = append(config.Pipeline.EnabledSteps, models.StepName(stepStr))
 	}
 
-	// Apply defaults for missing fields only if config wasn't found
-	if !configFound {
-		defaults := models.DefaultConfig()
-		if len(config.Pipeline.EnabledSteps) == 0 {
-			config.Pipeline.EnabledSteps = defaults.Pipeline.EnabledSteps
-		}
-		if config.Services.DIMP.URL == "" && defaults.Services.DIMP.URL != "" {
-			config.Services.DIMP.URL = defaults.Services.DIMP.URL
-		}
-		if config.Services.DIMP.BundleSplitThresholdMB == 0 {
-			config.Services.DIMP.BundleSplitThresholdMB = defaults.Services.DIMP.BundleSplitThresholdMB
-		}
-		if config.Retry.MaxAttempts == 0 {
-			config.Retry = defaults.Retry
-		}
-		if config.JobsDir == "" {
-			config.JobsDir = defaults.JobsDir
-		}
-		if config.Compression.Level == "" {
-			config.Compression.Level = defaults.Compression.Level
-		}
-		if config.Services.Flattening.BatchSizeMB == 0 {
-			config.Services.Flattening.BatchSizeMB = defaults.Services.Flattening.BatchSizeMB
-		}
-	} else {
-		// Config was loaded, apply defaults only for truly missing values
-		if config.Retry.MaxAttempts == 0 {
-			config.Retry.MaxAttempts = 5
-		}
-		if config.Retry.InitialBackoffMs == 0 {
-			config.Retry.InitialBackoffMs = 1000
-		}
-		if config.Retry.MaxBackoffMs == 0 {
-			config.Retry.MaxBackoffMs = 30000
-		}
-		if config.JobsDir == "" {
-			config.JobsDir = "./jobs"
-		}
-		// Apply TORCH defaults for missing values
-		if config.Services.TORCH.ExtractionTimeout == 0 {
-			config.Services.TORCH.ExtractionTimeout = 30 * time.Minute
-		}
-		if config.Services.TORCH.PollingInterval == 0 {
-			config.Services.TORCH.PollingInterval = 5 * time.Second
-		}
-		if config.Services.TORCH.MaxPollingInterval == 0 {
-			config.Services.TORCH.MaxPollingInterval = 30 * time.Second
-		}
-		if config.Services.TORCH.FileReadyRetries == 0 {
-			config.Services.TORCH.FileReadyRetries = 10
-		}
-		if config.Services.TORCH.FileReadyInterval == 0 {
-			config.Services.TORCH.FileReadyInterval = 10 * time.Second
-		}
-		// Apply DIMP Bundle split threshold default if not set
-		if config.Services.DIMP.BundleSplitThresholdMB == 0 {
-			config.Services.DIMP.BundleSplitThresholdMB = 10 // 10MB default
-		}
-		// Apply validation defaults if not set
-		if config.Services.Validation.MaxConcurrentRequests == 0 {
-			config.Services.Validation.MaxConcurrentRequests = 4
-		}
-		if config.Services.Validation.BundleChunkSizeMB == 0 {
-			config.Services.Validation.BundleChunkSizeMB = 10 // 10MB default, same as DIMP threshold
-		}
-		if config.Services.Validation.FailOnError == nil {
-			defaultFailOnError := true
-			config.Services.Validation.FailOnError = &defaultFailOnError
-		}
-		// Apply compression level default if not set
-		if config.Compression.Level == "" {
-			config.Compression.Level = "default"
-		}
-		// Apply Flattening defaults if not set
-		if config.Services.Flattening.Timeout == 0 {
-			config.Services.Flattening.Timeout = 30 * time.Minute
-		}
-		if len(config.Services.Flattening.Formats) == 0 {
-			config.Services.Flattening.Formats = []string{"csv"}
-		}
-		if config.Services.Flattening.BatchSizeMB == 0 {
-			config.Services.Flattening.BatchSizeMB = 500
-		}
-		// Apply Send batch size default if not set
-		if config.Services.Send.BatchSize == 0 {
-			config.Services.Send.BatchSize = 100
-		}
-		// Apply S3 defaults if not set
-		if config.Services.Send.S3.Region == "" {
-			config.Services.Send.S3.Region = "eu-central-1"
-		}
-		if config.Services.Send.S3.Timeout == 0 {
-			config.Services.Send.S3.Timeout = 30 * time.Minute
-		}
+	// Apply defaults for any values missing from the loaded config file.
+	if config.Retry.MaxAttempts == 0 {
+		config.Retry.MaxAttempts = 5
+	}
+	if config.Retry.InitialBackoffMs == 0 {
+		config.Retry.InitialBackoffMs = 1000
+	}
+	if config.Retry.MaxBackoffMs == 0 {
+		config.Retry.MaxBackoffMs = 30000
+	}
+	if config.JobsDir == "" {
+		config.JobsDir = "./jobs"
+	}
+	if config.Services.TORCH.ExtractionTimeout == 0 {
+		config.Services.TORCH.ExtractionTimeout = 30 * time.Minute
+	}
+	if config.Services.TORCH.PollingInterval == 0 {
+		config.Services.TORCH.PollingInterval = 5 * time.Second
+	}
+	if config.Services.TORCH.MaxPollingInterval == 0 {
+		config.Services.TORCH.MaxPollingInterval = 30 * time.Second
+	}
+	if config.Services.TORCH.FileReadyRetries == 0 {
+		config.Services.TORCH.FileReadyRetries = 10
+	}
+	if config.Services.TORCH.FileReadyInterval == 0 {
+		config.Services.TORCH.FileReadyInterval = 10 * time.Second
+	}
+	if config.Services.DIMP.BundleSplitThresholdMB == 0 {
+		config.Services.DIMP.BundleSplitThresholdMB = 10
+	}
+	if config.Services.Validation.MaxConcurrentRequests == 0 {
+		config.Services.Validation.MaxConcurrentRequests = 4
+	}
+	if config.Services.Validation.BundleChunkSizeMB == 0 {
+		config.Services.Validation.BundleChunkSizeMB = 10
+	}
+	if config.Services.Validation.FailOnError == nil {
+		defaultFailOnError := true
+		config.Services.Validation.FailOnError = &defaultFailOnError
+	}
+	if config.Compression.Level == "" {
+		config.Compression.Level = "default"
+	}
+	if config.Services.Flattening.Timeout == 0 {
+		config.Services.Flattening.Timeout = 30 * time.Minute
+	}
+	if len(config.Services.Flattening.Formats) == 0 {
+		config.Services.Flattening.Formats = []string{"csv"}
+	}
+	if config.Services.Flattening.BatchSizeMB == 0 {
+		config.Services.Flattening.BatchSizeMB = 500
+	}
+	if config.Services.Send.BatchSize == 0 {
+		config.Services.Send.BatchSize = 100
+	}
+	if config.Services.Send.S3.Region == "" {
+		config.Services.Send.S3.Region = "eu-central-1"
+	}
+	if config.Services.Send.S3.Timeout == 0 {
+		config.Services.Send.S3.Timeout = 30 * time.Minute
 	}
 
 	// Validate the configuration

--- a/tests/unit/config_service_test.go
+++ b/tests/unit/config_service_test.go
@@ -73,38 +73,15 @@ func TestExpandEnvVars(t *testing.T) {
 	}
 }
 
-// TestLoadConfig_NoConfigFile tests loading with default values when no config file exists
-func TestLoadConfig_NoConfigFile(t *testing.T) {
-	// Clear any existing config
+// TestLoadConfig_EmptyPath verifies LoadConfig errors when no config path is supplied.
+// Auto-discovery of ./aether.yaml and ~/.config/aether/aether.yaml was removed: the
+// caller must always pass an explicit config path (now a positional argument).
+func TestLoadConfig_EmptyPath(t *testing.T) {
 	viper.Reset()
 
-	// Use an existing directory so viper looks for config in standard locations
-	tmpDir := t.TempDir()
-	jobsDir := filepath.Join(tmpDir, "jobs")
-	require.NoError(t, os.MkdirAll(jobsDir, 0755))
-
-	// Load config - since it won't find one in standard locations, it should use defaults
-	config, err := services.LoadConfig("")
-	require.NoError(t, err)
-	require.NotNil(t, config)
-
-	// Verify default values are applied
-	assert.NotNil(t, config.Pipeline.EnabledSteps)
-}
-
-// TestLoadConfig_ConfigFileNotFound_UsesDefaults tests that defaults are used when file not found
-func TestLoadConfig_ConfigFileNotFound_UsesDefaults(t *testing.T) {
-	// Clear any existing config
-	viper.Reset()
-
-	config, err := services.LoadConfig("")
-	require.NoError(t, err)
-	require.NotNil(t, config)
-
-	// Verify defaults are applied
-	assert.True(t, len(config.Pipeline.EnabledSteps) > 0)
-	assert.Greater(t, config.Services.DIMP.BundleSplitThresholdMB, 0)
-	assert.Greater(t, config.Retry.MaxAttempts, 0)
+	_, err := services.LoadConfig("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config file is required")
 }
 
 // TestLoadConfig_CreateJobsDir tests that jobs directory is created if it doesn't exist


### PR DESCRIPTION
## Summary
Two related breaking changes that together make the configuration contract explicit:

1. **`LoadConfig` requires a path.** Auto-discovery of `./aether.yaml`, `~/.config/aether/aether.yaml`, and `/etc/aether/aether.yaml` is removed. Empty path → `config file is required: pass aether.yaml as the first positional argument`.
2. **The path moves from `--config` flag to first positional.** Now that the file is mandatory, the flag was pure ceremony.

New invocation shape:

| command | shape |
|---|---|
| pipeline start | `aether pipeline start <config> <crtdl> [input]` |
| pipeline status | `aether pipeline status <config> <job-id>` |
| pipeline continue | `aether pipeline continue <config> <job-id>` |
| job list | `aether job list <config>` |
| job run | `aether job run <config> <job-id> --step <name>` |

## What changed
- `internal/services/config.go`: `LoadConfig` errors on empty path, drops viper search-path fallback, collapses two-branch defaults block into one always-applied pass.
- `cmd/root.go`: drops `cfgFile`/`--config`, updates Long help.
- `cmd/pipeline.go`, `cmd/job.go`: each leaf `RunE` reads `args[0]` as config path; `Args` validators bumped (`RangeArgs(2,3)`, `ExactArgs(1|2)`); `Use:` strings, Long help, examples updated. Wait-step paused output now prints `aether pipeline continue <config> <job-id>`.
- `internal/lib/errors.go`: error guidance strings reference the new positional shape.
- E2E scripts (`.github/scripts/*.sh`) all updated to new positional order.
- Docs (README, quick-start, configuration, api-reference, pipeline-steps, torch-integration, shell-completions) rewritten for the new shape.
- `tests/unit/config_service_test.go`: stale "no config = defaults" tests replaced by `TestLoadConfig_EmptyPath`, which asserts the new error.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `golangci-lint run ./...` → 0 issues.
- All unit + integration tests pass (`./tests/unit/...`, `./tests/integration/...`).
- Built binary verified: `aether pipeline start` (no args) errors with `accepts between 2 and 3 arg(s), received 0`; `aether help pipeline start` renders the new positional contract.

BREAKING CHANGE: every aether invocation must now pass `aether.yaml` as the first positional argument. The `--config` flag is gone. `aether pipeline start crtdl.json --config a.yaml` becomes `aether pipeline start a.yaml crtdl.json`.

Closes #329