### PR TITLE
docs: cover s3_upload send mode and recent feature additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ services:
     password: "your-password"
 
   dimp:
-    url: "http://your-dimp-server:32861/fhir"
+    url: "http://your-dimp-server:32861"  # server root; /fhir appended by client
 
 pipeline:
   enabled_steps:

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -26,18 +26,26 @@ services:
     batch_size_mb: integer               # default: 500
 
   send:
-    send_as: string                      # "direct_resource_load" or "transfer_load"
-    url: string
-    batch_size: integer                  # 1-1000, default: 100
-    auth:
+    send_as: string                      # "direct_resource_load", "transfer_load", or "s3_upload"
+    url: string                          # required for FHIR modes; ignored for s3_upload
+    batch_size: integer                  # 0-1000, default: 100 (direct_resource_load only)
+    auth:                                # FHIR auth, or proxy auth in s3_upload mode
       username: string
       password: string
       oauth_issuer_uri: string
       oauth_client_id: string
       oauth_client_secret: string
-    transfer:
+    transfer:                            # transfer_load only
       project_identifier: string
       organization_identifier: string
+    s3:                                  # s3_upload only
+      bucket: string                     # required
+      region: string                     # required
+      access_key_id: string              # required
+      secret_access_key: string          # required
+      endpoint: string                   # custom S3-compatible endpoint
+      use_path_style: boolean            # default: false
+      timeout: duration                  # default: PT30M
 
   validation:
     url: string
@@ -48,7 +56,7 @@ services:
   local_import:
     dir: string
 
- .json_preprocessing:
+  crtdl_preprocessing:
     enabled: boolean                       # default: false
     enrichments_path: string               # Path to external JSON file
     enrichments:                           # Inline enrichment rules
@@ -67,6 +75,10 @@ retry:
   max_attempts: integer                  # 1-10, default: 5
   initial_backoff_ms: integer            # default: 1000
   max_backoff_ms: integer                # default: 30000
+
+tls:
+  ca_cert_path: string                   # PEM bundle of additional trusted certs
+  insecure_skip_verify: boolean          # default: false
 
 compression:
   enabled: boolean                       # default: true
@@ -139,10 +151,11 @@ services:
 | `lookup_path` | string | - | Path to lookup table file |
 | `formats` | []string | ["csv"] | Output formats |
 | `timeout` | duration | 30m | Request timeout |
+| `batch_size_mb` | int | 500 | Total memory budget in MB, divided across attribute groups (0 = use default) |
 
 ### Send
 
-Destination server for uploading processed data.
+Destination server or object store for uploading processed data. Mode is selected via `send_as`.
 
 #### Direct Resource Load
 
@@ -177,18 +190,38 @@ services:
       organization_identifier: "your-org.example.de"
 ```
 
+#### S3 Upload
+
+Upload files to an S3-compatible bucket (AWS S3, MinIO, Ceph).
+
+```yaml
+services:
+  send:
+    send_as: "s3_upload"
+    s3:
+      bucket: "${S3_BUCKET}"
+      region: "eu-central-1"
+      access_key_id: "${AWS_ACCESS_KEY_ID}"
+      secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+      # endpoint: "http://minio.example.com:9000"
+      # use_path_style: true
+      # timeout: PT30M
+```
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `send_as` | string | - | `direct_resource_load` or `transfer_load` |
-| `url` | string | - | FHIR server root URL. Do not include `/fhir` — the client appends it. |
-| `batch_size` | int | 100 | Resources per transaction (direct mode, 1-1000) |
+| `send_as` | string | - | `direct_resource_load`, `transfer_load`, or `s3_upload` |
+| `url` | string | - | FHIR server root URL — required for FHIR modes, ignored for `s3_upload`. Do not include `/fhir`; the client appends it. |
+| `batch_size` | int | 100 | Resources per transaction (`direct_resource_load` only, 0-1000) |
 
-**Authentication (choose one):**
+**Authentication (choose one for FHIR modes):**
 
 | Option | Description |
 |--------|-------------|
 | `auth.username` + `auth.password` | Basic authentication |
 | `auth.oauth_issuer_uri` + `oauth_client_id` + `oauth_client_secret` | OAuth2 client credentials |
+
+In `s3_upload` mode the `auth` block is optional and used only as upstream proxy authentication (basic auth via `Proxy-Authorization`); the S3 API itself is authenticated via `s3.access_key_id` / `s3.secret_access_key`.
 
 **Transfer settings (transfer_load mode only):**
 
@@ -196,6 +229,18 @@ services:
 |--------|-------------|
 | `transfer.project_identifier` | MII project identifier |
 | `transfer.organization_identifier` | Organization identifier |
+
+**S3 settings (s3_upload mode only):**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `s3.bucket` | string | - | Target bucket name (required) |
+| `s3.region` | string | - | AWS region, e.g. `eu-central-1` (required) |
+| `s3.access_key_id` | string | - | S3 access key (required) |
+| `s3.secret_access_key` | string | - | S3 secret key (required) |
+| `s3.endpoint` | string | - | Custom endpoint URL (MinIO, Ceph, etc.). Leave empty for AWS S3. |
+| `s3.use_path_style` | bool | false | Use path-style addressing (required for MinIO and many S3-compatible stores) |
+| `s3.timeout` | duration | PT30M | Per-request timeout |
 
 ### Validation
 
@@ -239,7 +284,7 @@ Enriches CRTDL documents with additional attributes before sending to TORCH. Thi
 
 ```yaml
 services:
- .json_preprocessing:
+  crtdl_preprocessing:
     enabled: true
     enrichments:
       - group_reference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert"
@@ -351,6 +396,21 @@ retry:
 | `max_backoff_ms` | int | 30000 | - | Max backoff delay |
 
 Exponential backoff: `wait = min(initial * 2^attempt, max)`
+
+## TLS
+
+Trust custom or internal certificates and, when needed, disable verification entirely. Applied to every outgoing HTTP client (TORCH, DIMP, validation, flattening, send, HTTP import).
+
+```yaml
+tls:
+  ca_cert_path: "/path/to/certs.pem"
+  insecure_skip_verify: false
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `ca_cert_path` | string | - | PEM bundle of additional CA or server certificates to trust. System CAs remain trusted alongside these. Supports `${ENV}` substitution. |
+| `insecure_skip_verify` | bool | false | Skip TLS verification entirely. Development/testing only. |
 
 ## Compression
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -86,6 +86,23 @@ services:
       organization_identifier: "your-org.example.de"
 ```
 
+**S3 upload (AWS S3, MinIO, Ceph):**
+```yaml
+services:
+  send:
+    send_as: "s3_upload"
+    s3:
+      bucket: "${S3_BUCKET}"
+      region: "eu-central-1"
+      access_key_id: "${AWS_ACCESS_KEY_ID}"
+      secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+      # endpoint: "http://minio.example.com:9000"   # for non-AWS stores
+      # use_path_style: true                         # required for MinIO
+      # timeout: PT30M
+```
+
+See the [Send step guide](../guides/steps/send.md) for full S3 options and proxy-auth behaviour.
+
 ### Local Import
 
 ```yaml
@@ -141,6 +158,55 @@ compression:
 ```
 
 Output files use `.ndjson.zst` extension when enabled.
+
+## TLS
+
+Trust custom or internal certificates and, when needed, disable verification entirely:
+
+```yaml
+tls:
+  # PEM bundle of additional CA or server certificates to trust
+  # (system CAs are still trusted alongside these)
+  ca_cert_path: "${CA_CERT_PATH}"
+
+  # Skip certificate verification — development/testing only
+  insecure_skip_verify: false
+```
+
+`tls` applies to every outgoing HTTP client, including TORCH, DIMP, validation, flattening, send (FHIR + S3), and HTTP import.
+
+## Retry
+
+Transient failures (network errors, 5xx responses, S3 `SlowDown` / `ServiceUnavailable` / timeouts) are retried with exponential backoff:
+
+```yaml
+retry:
+  max_attempts: 5            # 1-10
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+```
+
+## CRTDL Preprocessing
+
+Enriches CRTDL files with extra attributes (e.g. pseudonymisation identifiers) before sending them to TORCH. Disabled by default.
+
+```yaml
+services:
+  crtdl_preprocessing:
+    enabled: true
+
+    # Option A: external rules file
+    enrichments_path: "/path/to/dimp-enrichments.json"
+
+    # Option B: inline rules (mutually exclusive with enrichments_path)
+    # enrichments:
+    #   - group_reference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient"
+    #     create_if_not_exists:
+    #       group_name: "Patient"
+    #     attributes_to_add:
+    #       - attribute_ref: "Patient.identifier:PseudonymisierterIdentifier"
+    #         must_have: true
+```
 
 ## Environment Variables
 

--- a/docs/guides/dimp.md
+++ b/docs/guides/dimp.md
@@ -28,7 +28,7 @@ jobs_dir: "./jobs"
 ## Running Pseudonymization
 
 ```bash
-aether pipeline start your-crtdl.json
+aether pipeline start aether.yaml your-crtdl.json
 ```
 
 Aether will:
@@ -54,7 +54,7 @@ CRTDL preprocessing automatically enriches your CRTDL with the required attribut
 
 ```yaml
 services:
- .json_preprocessing:
+  crtdl_preprocessing:
     enabled: true
     enrichments:
       - group_reference: "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/PatientPseudonymisiert"

--- a/docs/guides/steps/http-import.md
+++ b/docs/guides/steps/http-import.md
@@ -13,11 +13,12 @@ pipeline:
 ## Usage
 
 ```bash
-aether pipeline start https://example.com/fhir/Patient.ndjson
+aether pipeline start aether.yaml crtdl.json https://example.com/fhir/Patient.ndjson --allow-http-crtdl
 ```
 
 ## Notes
 
-- The URL is provided as the argument to `pipeline start`
-- Supports both HTTP and HTTPS URLs
-- Downloads files to the job directory
+- Every `aether pipeline start` invocation requires a CRTDL JSON as the second positional argument, even when the import URL already points at the data — the CRTDL is used by downstream steps such as flattening.
+- The HTTP(S) URL is provided as the third positional argument and overrides any local-import configuration.
+- HTTP import bypasses TORCH's CRTDL guarantees, so aether refuses the run unless you opt in with `--allow-http-crtdl`. Pass the flag to acknowledge that the downloaded data may not match the CRTDL query.
+- Both HTTP and HTTPS URLs are supported; downloads land in the job directory.

--- a/docs/guides/steps/local-import.md
+++ b/docs/guides/steps/local-import.md
@@ -18,22 +18,22 @@ pipeline:
 
 ```bash
 # Use directory from config
-aether pipeline start
+aether pipeline start aether.yaml crtdl.json
 
 # Override directory via flag
-aether pipeline start --dir /other/path
+aether pipeline start aether.yaml crtdl.json --dir /other/path
 
-# With CRTDL for flattening
-aether pipeline start crtdl.json --dir /path/to/data
+# Override directory as positional (deprecated, prints warning)
+aether pipeline start aether.yaml crtdl.json /other/path
 ```
 
 ## Configuration Options
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `dir` | string | Default import directory (overridable with `--dir` flag) |
+| `dir` | string | Default import directory (overridable with `--dir` flag or as the third positional argument) |
 
 ## Notes
 
-- The `--dir` flag takes precedence over the config file setting
-- When using flattening step, a CRTDL file is still required as input
+- The `--dir` flag takes precedence over the config file setting; passing the directory as a positional argument still works but is deprecated.
+- A CRTDL JSON file is always required as the second positional argument — downstream steps such as flattening and CRTDL preprocessing depend on it.

--- a/docs/guides/steps/send.md
+++ b/docs/guides/steps/send.md
@@ -1,6 +1,10 @@
 # Send
 
-Uploads pipeline output to a destination server. Supports two modes.
+Uploads pipeline output to a destination. Supports three modes selected via `send_as`:
+
+- `direct_resource_load` — POST FHIR resources to a FHIR server using transaction bundles
+- `transfer_load` — wrap files in `Binary` / `DocumentReference` resources and POST them to a DSF transfer server
+- `s3_upload` — upload files directly to an S3-compatible object store (AWS S3, MinIO, Ceph)
 
 ## Direct Resource Load
 
@@ -11,7 +15,7 @@ services:
   send:
     send_as: "direct_resource_load"
     url: "https://fhir-server.example.com"  # server root; /fhir appended by client
-    batch_size: 100  # resources per transaction (1-1000)
+    batch_size: 100  # resources per transaction (0-1000, default 100)
     auth:
       username: "${FHIR_USER}"
       password: "${FHIR_PASSWORD}"
@@ -61,17 +65,101 @@ pipeline:
 3. Creates DocumentReference linking all Binary resources
 4. Uploads to transfer server
 
+## S3 Upload
+
+Uploads pipeline output files directly to an S3-compatible bucket. Works with AWS S3, MinIO, Ceph, and any other S3-API-compatible store.
+
+```yaml
+services:
+  send:
+    send_as: "s3_upload"
+    s3:
+      bucket: "${S3_BUCKET}"
+      region: "eu-central-1"
+      access_key_id: "${AWS_ACCESS_KEY_ID}"
+      secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+
+      # Optional: custom endpoint for non-AWS stores (MinIO, Ceph)
+      # endpoint: "http://minio.example.com:9000"
+
+      # Optional: required for MinIO and most non-AWS stores
+      # use_path_style: true
+
+      # Optional: per-upload timeout (default PT30M)
+      # timeout: PT30M
+
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+    - send
+```
+
+`url` is **not** required in `s3_upload` mode — it is only used by the FHIR send modes.
+
+### How it Works
+
+1. Reads all files from input directory (recursively)
+2. Uploads each file to the configured bucket using AWS SDK v2
+3. Records the returned ETag per upload
+
+### Authentication
+
+`access_key_id` and `secret_access_key` authenticate to the S3 API itself.
+
+The optional top-level `auth` block is reused as **proxy authentication** for environments where the S3 endpoint sits behind an HTTP proxy that requires its own credentials. When `auth.username` and `auth.password` are set in `s3_upload` mode, aether attaches a `Proxy-Authorization: Basic …` header to every S3 request without disturbing the AWS SDK's own `Authorization` signing header.
+
+```yaml
+services:
+  send:
+    send_as: "s3_upload"
+    auth:                              # only used as proxy auth in s3_upload mode
+      username: "${PROXY_USER}"
+      password: "${PROXY_PASS}"
+    s3:
+      bucket: "${S3_BUCKET}"
+      region: "eu-central-1"
+      access_key_id: "${AWS_ACCESS_KEY_ID}"
+      secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+```
+
+### Transient Errors
+
+The S3 client classifies AWS responses such as `SlowDown`, `ServiceUnavailable`, `InternalError`, `RequestTimeout`, `TooManyRequests`, and connection-level failures (`connection reset`, `connection refused`, generic timeouts) as transient. These are retried according to the top-level `retry` settings; all other errors fail the step immediately.
+
 ## Configuration Options
+
+### Common
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `send_as` | string | - | `direct_resource_load` or `transfer_load` |
-| `url` | string | - | FHIR server root URL. Do not include `/fhir` — the client appends it. |
-| `batch_size` | int | 100 | Resources per transaction (direct mode, 1-1000) |
+| `send_as` | string | — | `direct_resource_load`, `transfer_load`, or `s3_upload` (required) |
+| `url` | string | — | FHIR server root URL. Required for `direct_resource_load` and `transfer_load`. Do not include `/fhir` — the client appends it. Ignored for `s3_upload`. |
+| `batch_size` | int | 100 | Resources per transaction (`direct_resource_load` only, 0–1000) |
+| `auth` | object | — | Authentication (see below) |
+
+### `transfer` (transfer_load only)
+
+| Option | Description |
+|--------|-------------|
+| `transfer.project_identifier` | MII project identifier (used in `DocumentReference.masterIdentifier`) |
+| `transfer.organization_identifier` | Organization identifier (used in `DocumentReference.author`) |
+
+### `s3` (s3_upload only)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `s3.bucket` | string | — | Target bucket name (required) |
+| `s3.region` | string | — | AWS region (required, e.g. `eu-central-1`) |
+| `s3.access_key_id` | string | — | S3 access key (required) |
+| `s3.secret_access_key` | string | — | S3 secret key (required) |
+| `s3.endpoint` | string | — | Custom endpoint URL for S3-compatible stores. Leave empty for AWS S3. Must be `http://` or `https://`. |
+| `s3.use_path_style` | bool | `false` | Use path-style addressing (required for MinIO and many S3-compatible stores) |
+| `s3.timeout` | duration | `PT30M` | Per-request timeout (ISO 8601 or Go duration format) |
 
 ## Authentication
 
-Choose one method:
+For FHIR send modes (`direct_resource_load`, `transfer_load`), choose one method:
 
 **Basic Auth:**
 ```yaml
@@ -88,9 +176,4 @@ auth:
   oauth_client_secret: "${OAUTH_CLIENT_SECRET}"
 ```
 
-## Transfer Settings (transfer_load only)
-
-| Option | Description |
-|--------|-------------|
-| `transfer.project_identifier` | MII project identifier |
-| `transfer.organization_identifier` | Organization identifier |
+For `s3_upload`, the `auth` block is optional and only used for upstream proxy auth (see [S3 Upload → Authentication](#authentication-1)). The S3 API itself is always authenticated via the keys under `s3.*`.

--- a/docs/guides/steps/torch-import.md
+++ b/docs/guides/steps/torch-import.md
@@ -22,9 +22,11 @@ services:
     base_url: "https://your-torch-server.org"
     username: "your-username"
     password: "your-password"
-    extraction_timeout: PT30M  # default
-    polling_interval: PT5S     # default
-    max_polling_interval: PT30S # default
+    extraction_timeout: PT30M    # default
+    polling_interval: PT5S       # default
+    max_polling_interval: PT30S  # default
+    file_ready_retries: 10       # default
+    file_ready_interval: PT10S   # default
 
 pipeline:
   enabled_steps:
@@ -36,13 +38,13 @@ pipeline:
 ### With CRTDL file
 
 ```bash
-aether pipeline start crtdl.json
+aether pipeline start aether.yaml crtdl.json
 ```
 
 ### With TORCH URL
 
 ```bash
-aether pipeline start "https://torch.example.com/fhir/extraction/result-123"
+aether pipeline start aether.yaml crtdl.json "https://torch.example.com/fhir/extraction/result-123"
 ```
 
 URLs containing `/fhir/extraction/` or `/fhir/result/` are automatically recognized as TORCH URLs. See the [TORCH Integration guide](../torch-integration.md#direct-torch-url-import) for details.
@@ -57,3 +59,5 @@ URLs containing `/fhir/extraction/` or `/fhir/result/` are automatically recogni
 | `extraction_timeout` | duration | PT30M | Max wait time for extraction |
 | `polling_interval` | duration | PT5S | Initial status check interval |
 | `max_polling_interval` | duration | PT30S | Max interval (exponential backoff) |
+| `file_ready_retries` | int | 10 | Retries while waiting for files to appear after extraction completes |
+| `file_ready_interval` | duration | PT10S | Interval between file-availability checks |

--- a/docs/guides/steps/wait.md
+++ b/docs/guides/steps/wait.md
@@ -29,16 +29,16 @@ pipeline:
 
 ```bash
 # Pipeline pauses automatically at wait step
-aether pipeline start crtdl.json
+aether pipeline start aether.yaml crtdl.json
 
 # Check status - shows "waiting"
-aether pipeline status <job-id>
+aether pipeline status aether.yaml <job-id>
 
 # Place modified data in the wait directory
 # e.g., jobs/<job-id>/import_wait/
 
 # Resume pipeline
-aether pipeline continue <job-id>
+aether pipeline continue aether.yaml <job-id>
 ```
 
 ## Wait Directory


### PR DESCRIPTION
## Summary
- Documents the `s3_upload` send mode end-to-end (bucket, region, credentials, custom endpoint, path-style, timeout, transient-error classification, proxy-auth reuse of the top-level `auth` block).
- Adds missing top-level sections to the docs site: `tls`, `retry`, `crtdl_preprocessing`.
- Adds `file_ready_retries` / `file_ready_interval` to TORCH docs and `batch_size_mb` to the flattening schema.
- Updates the usage examples in every step guide to the new `aether pipeline <subcmd> <config> …` positional shape introduced in PR #333.
- Documents the `--allow-http-crtdl` opt-in for HTTP import.
- Repairs `.json_preprocessing` → `crtdl_preprocessing` damage left over from the `refactor(crtdl)!` sweep, including a broken anchor in `dimp.md`.
- Drops `/fhir` from the DIMP example URL in `README.md` (the client appends it).

## Sequencing
This branch is layered on top of #333 — its examples assume the positional config-arg shape. Please review/merge after #333 lands.

Closes #237