### PR TITLE
refactor(ndjson)!: replace bufio.Scanner with json.Decoder

### DIFF
--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -237,12 +237,6 @@ pipeline:
     - flattening      # Transform FHIR to CSV using fhir-flattener (CRTDL input only)
     # - send           # Uncomment to send data to DSF transfer server
 
-  # Maximum NDJSON line size in megabytes (MB)
-  # FHIR Bundles with many resources can produce very large single-line JSON objects.
-  # Increase this if you encounter "token too long" errors when reading NDJSON files.
-  # Default: 100 MB (omit or set to 0 for default)
-  # max_ndjson_line_size_mb: 100
-
 retry:
   # Maximum number of retry attempts for transient errors (network, 5xx)
   # Range: 1-10

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -62,7 +62,6 @@ services:
 
 pipeline:
   enabled_steps: [string]
-  max_ndjson_line_size_mb: integer           # default: 100
 
 retry:
   max_attempts: integer                  # 1-10, default: 5
@@ -312,13 +311,11 @@ pipeline:
     - local_import
     - dimp
     - flattening
-  max_ndjson_line_size_mb: 100
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled_steps` | []string | - | Pipeline steps to execute in order |
-| `max_ndjson_line_size_mb` | int | 100 | Maximum NDJSON line size in MB. Increase if you encounter "token too long" errors when reading large FHIR Bundles. Set to 0 to use default. |
 
 **Available steps:**
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -226,8 +226,7 @@ Persisted Results
 
 ### Memory Usage
 
-- Streams FHIR NDJSON line-by-line (no buffering entire files)
-- NDJSON scanner buffer supports lines up to 100MB by default (configurable via `pipeline.max_ndjson_line_size_mb`) to handle large FHIR Bundles
+- Streams FHIR NDJSON resource-by-resource via `json.Decoder` (memory bounded by the largest individual resource, no per-line cap)
 - Job state loaded only when needed
 - Progress bars updated incrementally
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -114,10 +114,6 @@ pipeline:
     - wait          # Pause for inspection (optional)
     - flattening    # FHIR to CSV (requires CRTDL)
     - send          # Upload to destination
-
-  # Max NDJSON line size in MB (default: 100)
-  # Increase if you encounter "token too long" errors with large Bundles
-  # max_ndjson_line_size_mb: 100
 ```
 
 ### Step Placement Rules

--- a/internal/lib/fhir.go
+++ b/internal/lib/fhir.go
@@ -1,12 +1,10 @@
 package lib
 
 import (
-	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-
-	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 // FHIRResource represents a generic FHIR resource as a map
@@ -43,24 +41,10 @@ func (r FHIRResource) GetID() (string, error) {
 	return idStr, nil
 }
 
-// ParseNDJSONLine parses a single line of NDJSON into a FHIR resource
-func ParseNDJSONLine(line []byte) (FHIRResource, error) {
-	if len(line) == 0 {
-		return nil, fmt.Errorf("empty line")
-	}
-
-	var resource FHIRResource
-	if err := json.Unmarshal(line, &resource); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON: %w", err)
-	}
-
-	return resource, nil
-}
-
-// ReadNDJSONFile reads a FHIR NDJSON file line-by-line
-// Calls the callback function for each valid resource
-// Returns total lines processed and any fatal error
-// Automatically handles both compressed (.ndjson.zst) and uncompressed (.ndjson) files
+// ReadNDJSONFile reads a FHIR NDJSON file as a stream of JSON resources.
+// Calls the callback function for each parsed resource.
+// Returns the total number of resources processed and any fatal error.
+// Automatically handles both compressed (.ndjson.zst) and uncompressed (.ndjson) files.
 func ReadNDJSONFile(filePath string, callback func(FHIRResource) error) (int, error) {
 	reader, err := OpenFileForReading(filePath)
 	if err != nil {
@@ -71,62 +55,29 @@ func ReadNDJSONFile(filePath string, callback func(FHIRResource) error) (int, er
 	return ReadNDJSON(reader, callback)
 }
 
-// DefaultMaxNDJSONLineSize is an alias for models.DefaultMaxNDJSONLineSize.
-// Kept here for convenience so callers of the scanner API don't need to import models.
-const DefaultMaxNDJSONLineSize = models.DefaultMaxNDJSONLineSize
-
-// NewNDJSONScanner creates a bufio.Scanner configured to handle large FHIR NDJSON lines.
-// Uses DefaultMaxNDJSONLineSize (100MB) as the maximum line size.
-func NewNDJSONScanner(r io.Reader) *bufio.Scanner {
-	return NewNDJSONScannerWithMaxSize(r, DefaultMaxNDJSONLineSize)
-}
-
-// NewNDJSONScannerWithMaxSize creates a bufio.Scanner with a custom maximum line size.
-// The buffer starts at min(64KB, maxSize) and grows on demand up to maxSize bytes.
-func NewNDJSONScannerWithMaxSize(r io.Reader, maxSize int) *bufio.Scanner {
-	scanner := bufio.NewScanner(r)
-	initialSize := bufio.MaxScanTokenSize
-	if maxSize < initialSize {
-		initialSize = maxSize
-	}
-	buf := make([]byte, initialSize)
-	scanner.Buffer(buf, maxSize)
-	return scanner
-}
-
-// ReadNDJSON reads FHIR NDJSON from an io.Reader
-// Calls the callback function for each valid resource
-// Returns total lines processed and any fatal error
+// ReadNDJSON streams FHIR resources from an io.Reader using json.Decoder.
+// Each successfully decoded value is passed to callback. Memory is bounded
+// by the largest individual JSON value rather than by a single line buffer,
+// so resource size is not capped.
+// Accepts NDJSON (newline-delimited) and concatenated JSON streams alike,
+// because json.Decoder ignores whitespace between values.
 func ReadNDJSON(reader io.Reader, callback func(FHIRResource) error) (int, error) {
-	scanner := NewNDJSONScanner(reader)
-
-	lineNum := 0
-	for scanner.Scan() {
-		lineNum++
-		line := scanner.Bytes()
-
-		// Skip empty lines
-		if len(line) == 0 {
-			continue
+	dec := json.NewDecoder(reader)
+	count := 0
+	for {
+		var resource FHIRResource
+		if err := dec.Decode(&resource); err != nil {
+			if errors.Is(err, io.EOF) {
+				return count, nil
+			}
+			return count, fmt.Errorf("decode at resource %d: %w", count+1, err)
 		}
+		count++
 
-		// Parse FHIR resource
-		resource, err := ParseNDJSONLine(line)
-		if err != nil {
-			return lineNum, fmt.Errorf("line %d: %w", lineNum, err)
-		}
-
-		// Call callback with parsed resource
 		if err := callback(resource); err != nil {
-			return lineNum, fmt.Errorf("callback failed at line %d: %w", lineNum, err)
+			return count, fmt.Errorf("callback failed at resource %d: %w", count, err)
 		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return lineNum, fmt.Errorf("scanner error: %w", err)
-	}
-
-	return lineNum, nil
 }
 
 // WriteNDJSONLine writes a single FHIR resource as NDJSON to a writer

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -306,23 +306,9 @@ func (c *SendConfig) GetBatchSize() int {
 	return c.BatchSize
 }
 
-// DefaultMaxNDJSONLineSize is the default maximum line size for NDJSON scanning (100MB).
-// FHIR Bundles with hundreds of resources can produce multi-megabyte lines.
-const DefaultMaxNDJSONLineSize = 100 * 1024 * 1024
-
 // PipelineConfig defines which steps are enabled and their execution order
 type PipelineConfig struct {
-	EnabledSteps        []StepName `yaml:"enabled_steps" json:"enabled_steps"`
-	MaxNDJSONLineSizeMB int        `yaml:"max_ndjson_line_size_mb" json:"max_ndjson_line_size_mb" mapstructure:"max_ndjson_line_size_mb"`
-}
-
-// MaxNDJSONLineSize returns the maximum NDJSON line size in bytes.
-// Defaults to DefaultMaxNDJSONLineSize (100MB) if not configured.
-func (c PipelineConfig) MaxNDJSONLineSize() int {
-	if c.MaxNDJSONLineSizeMB <= 0 {
-		return DefaultMaxNDJSONLineSize
-	}
-	return c.MaxNDJSONLineSizeMB * 1024 * 1024
+	EnabledSteps []StepName `yaml:"enabled_steps" json:"enabled_steps"`
 }
 
 // RetryConfig controls retry behavior for transient errors

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -2,10 +2,11 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
@@ -171,24 +172,22 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 	thresholdBytes := thresholdMB * 1024 * 1024
 
 	processor := NewResourceProcessor(dimpClient, logger, thresholdBytes, inputFile)
-	scanner := lib.NewNDJSONScannerWithMaxSize(fileCtx.InFile, job.Config.Pipeline.MaxNDJSONLineSize())
+	dec := json.NewDecoder(fileCtx.InFile)
 
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-
+	for {
 		var resource map[string]any
-		if err := json.Unmarshal([]byte(line), &resource); err != nil {
+		if err := dec.Decode(&resource); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
 			if progressBar != nil {
 				_ = progressBar.Clear()
 			}
 			logger.Error("Failed to parse FHIR resource",
 				"file", filepath.Base(inputFile),
-				"line_number", processor.GetResourceCount()+1,
+				"resource_number", processor.GetResourceCount()+1,
 				"error", err)
-			return processor.GetResourceCount(), fmt.Errorf("failed to parse resource at line %d: %w", processor.GetResourceCount()+1, err)
+			return processor.GetResourceCount(), fmt.Errorf("failed to parse resource %d: %w", processor.GetResourceCount()+1, err)
 		}
 
 		resourceType, _ := resource["resourceType"].(string)
@@ -196,11 +195,12 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 
 		logger.Debug("Processing FHIR resource",
 			"file", filepath.Base(inputFile),
-			"line_number", processor.GetResourceCount()+1,
+			"resource_number", processor.GetResourceCount()+1,
 			"resourceType", resourceType,
 			"id", resourceID)
 
 		var pseudonymized map[string]any
+		var err error
 
 		if resourceType == "Bundle" {
 			pseudonymized, err = processor.ProcessBundle(resource, resourceID)
@@ -214,7 +214,7 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 			}
 
 			fmt.Printf("\n✗ DIMP pseudonymization failed\n")
-			fmt.Printf("  File: %s (line %d)\n", filepath.Base(inputFile), processor.GetResourceCount()+1)
+			fmt.Printf("  File: %s (resource %d)\n", filepath.Base(inputFile), processor.GetResourceCount()+1)
 			fmt.Printf("  Resource: %s/%s\n", resourceType, resourceID)
 			fmt.Printf("  Error: %v\n\n", err)
 
@@ -230,10 +230,6 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 		if progressBar != nil {
 			_ = progressBar.Add(1)
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return processor.GetResourceCount(), fmt.Errorf("error reading file: %w", err)
 	}
 
 	if progressBar != nil {

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
@@ -118,7 +118,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		"job_id", job.JobID)
 
 	// Pass 1: scan input files for provenance index
-	provenanceIndex, err := scanProvenanceIndex(files, logger, job.Config.Pipeline.MaxNDJSONLineSize())
+	provenanceIndex, err := scanProvenanceIndex(files)
 	if err != nil {
 		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
 		recordStepError(step, err, models.ErrorTypeNonTransient)
@@ -183,7 +183,6 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		flattenerClient,
 		csvWriter,
 		logger,
-		job.Config.Pipeline.MaxNDJSONLineSize(),
 		job.Config.Services.Flattening.GetBatchSizeBytes(),
 	)
 	if err != nil {
@@ -224,45 +223,22 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 // scanProvenanceIndex performs a lightweight first pass over all input files,
 // extracting only Provenance resources from Bundles to build the provenance index.
 // Clinical resources are discarded to keep memory usage minimal.
-func scanProvenanceIndex(files []string, logger *lib.Logger, maxLineSize int) (models.ProvenanceIndex, error) {
+func scanProvenanceIndex(files []string) (models.ProvenanceIndex, error) {
 	mergedIndex := make(models.ProvenanceIndex)
 
 	for _, filePath := range files {
-		reader, err := lib.OpenFileForReading(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), fmt.Errorf("failed to open file: %w", err))
-		}
-
-		scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
-		lineNum := 0
-
-		for scanner.Scan() {
-			lineNum++
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
-				continue
-			}
-
-			var resource map[string]any
-			if err := json.Unmarshal([]byte(line), &resource); err != nil {
-				continue // skip invalid JSON during provenance scan
-			}
-
-			// Only Bundles contain Provenance resources
-			if resourceType, ok := resource["resourceType"].(string); ok && resourceType == "Bundle" {
+		_, err := lib.ReadNDJSONFile(filePath, func(resource lib.FHIRResource) error {
+			if rt, ok := resource["resourceType"].(string); ok && rt == "Bundle" {
 				_, bundleIndex := extractBundleResources(resource)
 				for k, v := range bundleIndex {
 					mergedIndex[k] = append(mergedIndex[k], v...)
 				}
 			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), err)
 		}
-
-		if err := scanner.Err(); err != nil {
-			_ = reader.Close()
-			return nil, fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), fmt.Errorf("error reading file: %w", err))
-		}
-
-		_ = reader.Close()
 	}
 
 	return mergedIndex, nil
@@ -282,7 +258,6 @@ func streamAndFlattenResources(
 	flattenerClient *services.FlattenerClient,
 	csvWriter *services.CSVWriter,
 	logger *lib.Logger,
-	maxLineSize int,
 	batchSizeBytes int,
 ) ([]int, error) {
 	numGroups := len(groups)
@@ -302,75 +277,65 @@ func streamAndFlattenResources(
 
 	// Stream through all files
 	for _, filePath := range files {
-		reader, err := lib.OpenFileForReading(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load resources: %w", fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), fmt.Errorf("failed to open file: %w", err)))
-		}
-
-		scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
-		lineNum := 0
-
-		for scanner.Scan() {
-			lineNum++
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
-				continue
+		err := func() error {
+			reader, err := lib.OpenFileForReading(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), err)
 			}
+			defer func() { _ = reader.Close() }()
 
-			var resource map[string]any
-			if err := json.Unmarshal([]byte(line), &resource); err != nil {
-				logger.Warn("Failed to parse resource",
-					"file", filepath.Base(filePath),
-					"line", lineNum,
-					"error", err)
-				continue
-			}
+			dec := json.NewDecoder(reader)
 
-			// If resource is a Bundle, extract clinical entries (skip Provenance)
-			if resourceType, ok := resource["resourceType"].(string); ok && resourceType == "Bundle" {
-				clinicalResources, _ := extractBundleResources(resource)
-				for _, entryResource := range clinicalResources {
-					entryBytes, marshalErr := json.Marshal(entryResource)
-					if marshalErr != nil {
-						continue
+			for {
+				startOffset := dec.InputOffset()
+				var resource map[string]any
+				if err := dec.Decode(&resource); err != nil {
+					if errors.Is(err, io.EOF) {
+						return nil
 					}
-					for _, groupIdx := range routeResourceToGroups(entryResource, provenanceIndex, groupIDToIndex, viewDefs) {
-						batches[groupIdx].resources = append(batches[groupIdx].resources, entryResource)
-						batches[groupIdx].byteSize += len(entryBytes)
+					return fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), err)
+				}
+				resourceSize := int(dec.InputOffset() - startOffset)
+
+				// If resource is a Bundle, extract clinical entries (skip Provenance)
+				if resourceType, ok := resource["resourceType"].(string); ok && resourceType == "Bundle" {
+					clinicalResources, _ := extractBundleResources(resource)
+					for _, entryResource := range clinicalResources {
+						entryBytes, marshalErr := json.Marshal(entryResource)
+						if marshalErr != nil {
+							continue
+						}
+						for _, groupIdx := range routeResourceToGroups(entryResource, provenanceIndex, groupIDToIndex, viewDefs) {
+							batches[groupIdx].resources = append(batches[groupIdx].resources, entryResource)
+							batches[groupIdx].byteSize += len(entryBytes)
+							totals[groupIdx]++
+
+							if batches[groupIdx].byteSize >= perGroupBytes {
+								if err := flushGroupBatch(&batches[groupIdx], viewDefs[groupIdx], headers[groupIdx], filenames[groupIdx], flattenerClient, csvWriter, logger, groups[groupIdx].Name); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				} else {
+					// Non-Bundle resource: route via provenance index
+					for _, groupIdx := range routeResourceToGroups(resource, provenanceIndex, groupIDToIndex, viewDefs) {
+						batches[groupIdx].resources = append(batches[groupIdx].resources, resource)
+						batches[groupIdx].byteSize += resourceSize
 						totals[groupIdx]++
 
 						if batches[groupIdx].byteSize >= perGroupBytes {
 							if err := flushGroupBatch(&batches[groupIdx], viewDefs[groupIdx], headers[groupIdx], filenames[groupIdx], flattenerClient, csvWriter, logger, groups[groupIdx].Name); err != nil {
-								_ = reader.Close()
-								return nil, err
+								return err
 							}
 						}
 					}
 				}
-			} else {
-				// Non-Bundle resource: route via provenance index
-				resourceSize := len(scanner.Bytes())
-				for _, groupIdx := range routeResourceToGroups(resource, provenanceIndex, groupIDToIndex, viewDefs) {
-					batches[groupIdx].resources = append(batches[groupIdx].resources, resource)
-					batches[groupIdx].byteSize += resourceSize
-					totals[groupIdx]++
-
-					if batches[groupIdx].byteSize >= perGroupBytes {
-						if err := flushGroupBatch(&batches[groupIdx], viewDefs[groupIdx], headers[groupIdx], filenames[groupIdx], flattenerClient, csvWriter, logger, groups[groupIdx].Name); err != nil {
-							_ = reader.Close()
-							return nil, err
-						}
-					}
-				}
 			}
+		}()
+		if err != nil {
+			return nil, err
 		}
-
-		if err := scanner.Err(); err != nil {
-			_ = reader.Close()
-			return nil, fmt.Errorf("failed to load resources: %w", fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), fmt.Errorf("error reading file: %w", err)))
-		}
-
-		_ = reader.Close()
 	}
 
 	// Flush remaining non-empty batches
@@ -449,12 +414,12 @@ func flushGroupBatch(
 // LoadAllResources loads all FHIR resources from the given NDJSON files.
 // Returns clinical resources (excluding Provenance) and a provenance index
 // that maps resource references to CRTDL attribute group IDs.
-func LoadAllResources(files []string, logger *lib.Logger, maxLineSize int) ([]map[string]any, models.ProvenanceIndex, error) {
+func LoadAllResources(files []string, logger *lib.Logger) ([]map[string]any, models.ProvenanceIndex, error) {
 	var allResources []map[string]any
 	mergedIndex := make(models.ProvenanceIndex)
 
 	for _, filePath := range files {
-		resources, index, err := LoadResourcesFromFile(filePath, logger, maxLineSize)
+		resources, index, err := LoadResourcesFromFile(filePath, logger)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to load %s: %w", filepath.Base(filePath), err)
 		}
@@ -471,7 +436,7 @@ func LoadAllResources(files []string, logger *lib.Logger, maxLineSize int) ([]ma
 // Handles both compressed (.ndjson.zst) and uncompressed (.ndjson) files.
 // For Bundles, Provenance resources are separated into a provenance index
 // and excluded from the returned resource list.
-func LoadResourcesFromFile(filePath string, logger *lib.Logger, maxLineSize int) ([]map[string]any, models.ProvenanceIndex, error) {
+func LoadResourcesFromFile(filePath string, logger *lib.Logger) ([]map[string]any, models.ProvenanceIndex, error) {
 	reader, err := lib.OpenFileForReading(filePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open file: %w", err)
@@ -480,21 +445,24 @@ func LoadResourcesFromFile(filePath string, logger *lib.Logger, maxLineSize int)
 
 	var resources []map[string]any
 	index := make(models.ProvenanceIndex)
-	scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
+	dec := json.NewDecoder(reader)
+	resourceNum := 0
 
-	lineNum := 0
-	for scanner.Scan() {
-		lineNum++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+	for {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, nil, fmt.Errorf("error reading file: %w", err)
 		}
+		resourceNum++
 
 		var resource map[string]any
-		if err := json.Unmarshal([]byte(line), &resource); err != nil {
+		if err := json.Unmarshal(raw, &resource); err != nil {
 			logger.Warn("Failed to parse resource",
 				"file", filepath.Base(filePath),
-				"line", lineNum,
+				"resource_number", resourceNum,
 				"error", err)
 			continue
 		}
@@ -509,10 +477,6 @@ func LoadResourcesFromFile(filePath string, logger *lib.Logger, maxLineSize int)
 		} else {
 			resources = append(resources, resource)
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, nil, fmt.Errorf("error reading file: %w", err)
 	}
 
 	return resources, index, nil

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -253,7 +253,6 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 
 	// Create FHIR client
 	fhirClient := services.NewFHIRClient(job.Config.Services.Send, httpClient, logger)
-	fhirClient.MaxLineSize = job.Config.Pipeline.MaxNDJSONLineSize()
 
 	fhirURL := job.Config.Services.Send.URL
 	fmt.Printf("Uploading %d NDJSON file(s) to FHIR server: %s\n\n", len(orderedFiles), fhirURL)

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -3,7 +3,9 @@ package pipeline
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,27 +192,18 @@ func validateFile(inputFile, reportFile string, client *services.ValidationClien
 	defer func() { _ = inFile.Close() }()
 
 	// Parse all resources from NDJSON
-	scanner := lib.NewNDJSONScanner(inFile)
+	dec := json.NewDecoder(inFile)
 	var resources []map[string]any
-	lineNum := 0
 
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-
+	for {
 		var resource map[string]any
-		if err := json.Unmarshal([]byte(line), &resource); err != nil {
-			return lineNum, 0, fmt.Errorf("failed to parse resource at line %d: %w", lineNum+1, err)
+		if err := dec.Decode(&resource); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return len(resources), 0, fmt.Errorf("failed to parse resource %d: %w", len(resources)+1, err)
 		}
-
 		resources = append(resources, resource)
-		lineNum++
-	}
-
-	if err := scanner.Err(); err != nil {
-		return 0, 0, fmt.Errorf("error reading file: %w", err)
 	}
 
 	if len(resources) == 0 {

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -183,9 +183,6 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 		config.Pipeline.EnabledSteps = append(config.Pipeline.EnabledSteps, models.StepName(stepStr))
 	}
 
-	// Get max NDJSON line size (optional, defaults to 100MB via MaxNDJSONLineSize())
-	config.Pipeline.MaxNDJSONLineSizeMB = viper.GetInt("pipeline.max_ndjson_line_size_mb")
-
 	// Apply defaults for missing fields only if config wasn't found
 	if !configFound {
 		defaults := models.DefaultConfig()

--- a/internal/services/fhir_client.go
+++ b/internal/services/fhir_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,12 +17,11 @@ import (
 
 // FHIRClient handles sending NDJSON files to a FHIR server
 type FHIRClient struct {
-	url         string
-	batchSize   int
-	auth        models.AuthConfig
-	httpClient  *HTTPClient
-	logger      *lib.Logger
-	MaxLineSize int // Maximum NDJSON line size in bytes; 0 uses models.DefaultMaxNDJSONLineSize
+	url        string
+	batchSize  int
+	auth       models.AuthConfig
+	httpClient *HTTPClient
+	logger     *lib.Logger
 }
 
 // FHIRUploadStats contains statistics from uploading an NDJSON file
@@ -79,22 +79,20 @@ func (c *FHIRClient) UploadNDJSON(filePath string, reader io.Reader) (*FHIRUploa
 		batchSize = 100 // default
 	}
 
-	maxLineSize := c.MaxLineSize
-	if maxLineSize <= 0 {
-		maxLineSize = models.DefaultMaxNDJSONLineSize
-	}
-	scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxLineSize)
-
+	dec := json.NewDecoder(reader)
 	var batch []json.RawMessage
 	stats := &FHIRUploadStats{}
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(bytes.TrimSpace(line)) == 0 {
-			continue
+	for {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return stats, fmt.Errorf("error reading %s: %w", filepath.Base(filePath), err)
 		}
 
-		batch = append(batch, json.RawMessage(line))
+		batch = append(batch, raw)
 
 		if len(batch) >= batchSize {
 			if err := c.sendBatch(batch); err != nil {
@@ -104,10 +102,6 @@ func (c *FHIRClient) UploadNDJSON(filePath string, reader io.Reader) (*FHIRUploa
 			stats.BatchesSent++
 			batch = nil
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return stats, fmt.Errorf("error reading %s: %w", filepath.Base(filePath), err)
 	}
 
 	// Send remaining resources

--- a/tests/integration/pipeline_flattening_multi_group_test.go
+++ b/tests/integration/pipeline_flattening_multi_group_test.go
@@ -91,7 +91,7 @@ func TestMultiGroupSameResourceType_ProvenanceRouting(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filePath, append(data, '\n'), 0644))
 
-	resources, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+	resources, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 	require.NoError(t, err)
 
 	assert.Len(t, resources, 2, "expected 2 Procedure resources (Provenance filtered out)")
@@ -114,7 +114,7 @@ func TestMultiGroupSameResourceType_WithTorchOutput(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
-	resources, index, err := pipeline.LoadResourcesFromFile(ndjsonPath, logger, lib.DefaultMaxNDJSONLineSize)
+	resources, index, err := pipeline.LoadResourcesFromFile(ndjsonPath, logger)
 	require.NoError(t, err)
 
 	// Torch output: 2 Conditions, 2 Encounters, 1 Patient, 2 Procedures (+ 5 Provenances excluded)
@@ -266,7 +266,7 @@ func TestMultiGroupSameResourceType_WithTesterCRTDL(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filePath, append(bundleData, '\n'), 0644))
 
-	resources, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+	resources, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 	require.NoError(t, err)
 
 	assert.Len(t, resources, 5, "expected 5 clinical resources")

--- a/tests/integration/pipeline_flattening_test.go
+++ b/tests/integration/pipeline_flattening_test.go
@@ -468,3 +468,123 @@ func TestExecuteFlatteningStep_FlattenerServiceError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flattener failed")
 }
+
+// TestExecuteFlatteningStep_NonBundleStreamRouting exercises the streaming path
+// where clinical resources arrive in NDJSON as top-level (non-Bundle) objects
+// and are routed via a provenance index sourced from a separate Bundle file.
+// Covers the non-Bundle branch in streamAndFlattenResources.
+func TestExecuteFlatteningStep_NonBundleStreamRouting(t *testing.T) {
+	flushed := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fhir/ViewDefinition/$run" {
+			flushed = true
+			w.Header().Set("Content-Type", "text/csv")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("1,Alice\n2,Bob\n"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-non-bundle-routing"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	outputDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	groupID := "group-patient-nb"
+
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	crtdlContent := `{
+		"dataExtraction": {
+			"attributeGroups": [{
+				"id": "` + groupID + `",
+				"name": "Patients",
+				"groupReference": "https://example.com/Patient",
+				"attributes": [
+					{"attributeRef": "Patient.id", "mustHave": true},
+					{"attributeRef": "Patient.name", "mustHave": false}
+				]
+			}]
+		}
+	}`
+	require.NoError(t, os.WriteFile(crtdlPath, []byte(crtdlContent), 0644))
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	lookupContent := `[{
+		"url": "https://example.com/Patient",
+		"resourceType": "Patient",
+		"elements": {
+			"Patient.id": {"viewDefinition": {"select": [{"column": [{"name": "id", "path": "id"}]}]}},
+			"Patient.name": {"viewDefinition": {"select": [{"column": [{"name": "name", "path": "name[0].text"}]}]}}
+		}
+	}]`
+	require.NoError(t, os.WriteFile(lookupPath, []byte(lookupContent), 0644))
+
+	// File A: Bundle containing only Provenance entries (builds provenance index in pass 1).
+	provBundle := makeBundle("prov-bundle",
+		makeProvenance("prov-a", "Patient/1", groupID),
+		makeProvenance("prov-b", "Patient/2", groupID),
+	)
+	provData, err := json.Marshal(provBundle)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "01-prov.ndjson"), append(provData, '\n'), 0644))
+
+	// File B: NDJSON of raw, top-level Patient resources (exercises non-Bundle pass 2 routing).
+	patientFile, err := os.Create(filepath.Join(inputDir, "02-patients.ndjson"))
+	require.NoError(t, err)
+	for _, p := range []map[string]any{
+		{
+			"resourceType": "Patient", "id": "1",
+			"meta": map[string]any{"profile": []any{"https://example.com/Patient"}},
+			"name": []any{map[string]any{"text": "Alice"}},
+		},
+		{
+			"resourceType": "Patient", "id": "2",
+			"meta": map[string]any{"profile": []any{"https://example.com/Patient"}},
+			"name": []any{map[string]any{"text": "Bob"}},
+		},
+	} {
+		b, mErr := json.Marshal(p)
+		require.NoError(t, mErr)
+		_, wErr := patientFile.Write(append(b, '\n'))
+		require.NoError(t, wErr)
+	}
+	require.NoError(t, patientFile.Close())
+
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		Status:      models.JobStatusInProgress,
+		InputSource: crtdlPath,
+		InputType:   models.InputTypeCRTDL,
+		CRTDLPath:   crtdlPath,
+		Config: models.ProjectConfig{
+			Services: models.ServiceConfig{
+				Flattening: models.FlatteningConfig{
+					ServiceURL: server.URL,
+					LookupPath: lookupPath,
+					Formats:    []string{"csv"},
+					Timeout:    30 * time.Second,
+					// Tiny memory budget forces a flush inside the non-Bundle branch
+					// after each resource is appended.
+					BatchSizeMB: 1,
+				},
+			},
+			Pipeline: models.PipelineConfig{
+				EnabledSteps: []models.StepName{models.StepLocalImport, models.StepFlattening},
+			},
+			Retry: models.RetryConfig{MaxAttempts: 1},
+		},
+	}
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	err = pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	require.NoError(t, err)
+	assert.True(t, flushed, "flattener service should have been called")
+
+	csvFiles, err := filepath.Glob(filepath.Join(outputDir, "*.csv"))
+	require.NoError(t, err)
+	require.Len(t, csvFiles, 1)
+}

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -2109,65 +2109,6 @@ jobs_dir: "` + jobsDir + `"
 	assert.Equal(t, "/custom/certs/ca.pem", config.TLS.CACertPath, "TLS CA cert path should expand env var")
 }
 
-// TestConfigLoading_MaxNDJSONLineSize verifies max_ndjson_line_size_mb is loaded
-func TestConfigLoading_MaxNDJSONLineSize(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	jobsDir := filepath.Join(tmpDir, "jobs")
-	_ = os.MkdirAll(jobsDir, 0755)
-
-	configContent := `
-pipeline:
-  enabled_steps:
-    - local_import
-  max_ndjson_line_size_mb: 200
-
-retry:
-  max_attempts: 5
-  initial_backoff_ms: 1000
-  max_backoff_ms: 30000
-
-jobs_dir: "` + jobsDir + `"
-`
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
-	require.NoError(t, err)
-
-	config, err := services.LoadConfig(configFile)
-	require.NoError(t, err, "Config should load without error")
-
-	assert.Equal(t, 200, config.Pipeline.MaxNDJSONLineSizeMB, "MaxNDJSONLineSizeMB should be loaded from config")
-	assert.Equal(t, 200*1024*1024, config.Pipeline.MaxNDJSONLineSize(), "MaxNDJSONLineSize() should return bytes")
-}
-
-// TestConfigLoading_MaxNDJSONLineSizeDefault verifies default when not specified
-func TestConfigLoading_MaxNDJSONLineSizeDefault(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	jobsDir := filepath.Join(tmpDir, "jobs")
-	_ = os.MkdirAll(jobsDir, 0755)
-
-	configContent := `
-pipeline:
-  enabled_steps:
-    - local_import
-
-retry:
-  max_attempts: 5
-  initial_backoff_ms: 1000
-  max_backoff_ms: 30000
-
-jobs_dir: "` + jobsDir + `"
-`
-	err := os.WriteFile(configFile, []byte(configContent), 0644)
-	require.NoError(t, err)
-
-	config, err := services.LoadConfig(configFile)
-	require.NoError(t, err, "Config should load without error")
-
-	assert.Equal(t, 0, config.Pipeline.MaxNDJSONLineSizeMB, "MaxNDJSONLineSizeMB should be 0 when not set")
-	assert.Equal(t, 100*1024*1024, config.Pipeline.MaxNDJSONLineSize(), "MaxNDJSONLineSize() should default to 100MB")
-}
-
 // TestConfigLoading_ValidationConfig verifies that validation config including
 // bundle_chunk_size_mb is properly loaded from YAML
 func TestConfigLoading_ValidationConfig(t *testing.T) {

--- a/tests/unit/fhir_client_test.go
+++ b/tests/unit/fhir_client_test.go
@@ -399,13 +399,12 @@ func TestFHIRClient_CreateTransactionBundle_InvalidJSON(t *testing.T) {
 	}
 	client := services.NewFHIRClient(config, httpClient, logger)
 
-	// Invalid JSON in the NDJSON line - JSON marshaling of raw message will fail
+	// Invalid JSON in the NDJSON stream - json.Decoder rejects it at decode time
 	reader := strings.NewReader(`{invalid json}`)
 
 	_, err := client.UploadNDJSON("test.ndjson", reader)
-	// The invalid JSON will cause marshal error
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "marshal")
+	assert.Contains(t, err.Error(), "error reading test.ndjson")
 }
 
 func TestFHIRClient_CreateTransactionBundle_EmptyID(t *testing.T) {

--- a/tests/unit/ndjson_scanner_test.go
+++ b/tests/unit/ndjson_scanner_test.go
@@ -15,87 +15,82 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 )
 
-// TestNewNDJSONScanner_DefaultBuffer verifies the scanner handles lines larger than
-// the old 1MB limit (regression test for issue #195)
-func TestNewNDJSONScanner_DefaultBuffer(t *testing.T) {
-	// Create a FHIR Bundle JSON line that exceeds 1MB
-	largeBundle := generateLargeFHIRBundle(1500)
-	bundleJSON, err := json.Marshal(largeBundle)
-	require.NoError(t, err)
-	require.Greater(t, len(bundleJSON), 1024*1024, "Test bundle must exceed 1MB to test the fix")
-
-	reader := bytes.NewReader(bundleJSON)
-	scanner := lib.NewNDJSONScanner(reader)
-
-	// Should successfully scan the large line
-	assert.True(t, scanner.Scan(), "Scanner should handle lines > 1MB")
-	assert.NoError(t, scanner.Err())
-	assert.Equal(t, len(bundleJSON), len(scanner.Bytes()))
-}
-
-// TestNewNDJSONScannerWithMaxSize_CustomSize verifies custom buffer size works
-func TestNewNDJSONScannerWithMaxSize_CustomSize(t *testing.T) {
-	smallLine := []byte(`{"resourceType":"Patient","id":"1"}`)
-	reader := bytes.NewReader(smallLine)
-	scanner := lib.NewNDJSONScannerWithMaxSize(reader, 1024)
-
-	assert.True(t, scanner.Scan())
-	assert.NoError(t, scanner.Err())
-	assert.Equal(t, string(smallLine), scanner.Text())
-}
-
-// TestNewNDJSONScannerWithMaxSize_ExceedsLimit verifies scanner fails gracefully
-// when a line exceeds the configured max
-func TestNewNDJSONScannerWithMaxSize_ExceedsLimit(t *testing.T) {
-	maxSize := 4096
-	// Create a line larger than maxSize (no newline, so scanner must buffer it all)
-	largeLine := strings.Repeat("x", maxSize*2)
-	reader := bytes.NewReader([]byte(largeLine))
-	scanner := lib.NewNDJSONScannerWithMaxSize(reader, maxSize)
-
-	// Should fail since line exceeds max
-	assert.False(t, scanner.Scan())
-	assert.Error(t, scanner.Err())
-	assert.Contains(t, scanner.Err().Error(), "token too long")
-}
-
-// TestDefaultMaxNDJSONLineSize verifies the constant is 100MB
-func TestDefaultMaxNDJSONLineSize(t *testing.T) {
-	assert.Equal(t, 100*1024*1024, lib.DefaultMaxNDJSONLineSize)
-}
-
-// TestReadNDJSON_LargeBundle verifies ReadNDJSON handles Bundles > 1MB
-// This is the core regression test for issue #195
+// TestReadNDJSON_LargeBundle verifies ReadNDJSON parses a Bundle whose
+// serialized size exceeds the prior 100MB scanner cap. This is the regression
+// test for issue #335 — json.Decoder does not impose a per-line buffer limit.
 func TestReadNDJSON_LargeBundle(t *testing.T) {
-	largeBundle := generateLargeFHIRBundle(1500)
+	if testing.Short() {
+		t.Skip("skipping >100MB test in short mode")
+	}
+
+	// Generate a Bundle that serializes to >100MB to prove the old cap is gone.
+	largeBundle := generateLargeFHIRBundle(120000)
 	bundleJSON, err := json.Marshal(largeBundle)
 	require.NoError(t, err)
-	require.Greater(t, len(bundleJSON), 1024*1024, "Test bundle must exceed 1MB")
+	require.Greater(t, len(bundleJSON), 100*1024*1024,
+		"test bundle must exceed 100MB to verify the cap removal")
 
 	reader := bytes.NewReader(append(bundleJSON, '\n'))
 
-	var resources []lib.FHIRResource
-	lineCount, err := lib.ReadNDJSON(reader, func(r lib.FHIRResource) error {
-		resources = append(resources, r)
+	count, err := lib.ReadNDJSON(reader, func(r lib.FHIRResource) error {
+		rt, terr := r.GetResourceType()
+		require.NoError(t, terr)
+		assert.Equal(t, "Bundle", rt)
 		return nil
 	})
-
-	require.NoError(t, err, "ReadNDJSON should handle lines > 1MB (issue #195)")
-	assert.Equal(t, 1, lineCount)
-	assert.Len(t, resources, 1)
-
-	resourceType, err := resources[0].GetResourceType()
 	require.NoError(t, err)
-	assert.Equal(t, "Bundle", resourceType)
+	assert.Equal(t, 1, count)
+}
+
+// TestReadNDJSON_MultipleResources confirms decoding a multi-line stream still
+// yields one resource per JSON value.
+func TestReadNDJSON_MultipleResources(t *testing.T) {
+	patient := []byte(`{"resourceType":"Patient","id":"p1"}`)
+	observation := []byte(`{"resourceType":"Observation","id":"o1","status":"final"}`)
+
+	var content []byte
+	content = append(content, patient...)
+	content = append(content, '\n')
+	content = append(content, observation...)
+	content = append(content, '\n')
+
+	var seen []string
+	count, err := lib.ReadNDJSON(bytes.NewReader(content), func(r lib.FHIRResource) error {
+		rt, _ := r.GetResourceType()
+		seen = append(seen, rt)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+	assert.Equal(t, []string{"Patient", "Observation"}, seen)
+}
+
+// TestReadNDJSON_ConcatenatedJSON confirms json.Decoder accepts both
+// newline-delimited and concatenated JSON streams (no separator required).
+func TestReadNDJSON_ConcatenatedJSON(t *testing.T) {
+	concat := []byte(`{"resourceType":"Patient","id":"p1"}{"resourceType":"Patient","id":"p2"}`)
+
+	count, err := lib.ReadNDJSON(bytes.NewReader(concat), func(r lib.FHIRResource) error { return nil })
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+// TestReadNDJSON_DecodeError surfaces parse errors with the resource index.
+func TestReadNDJSON_DecodeError(t *testing.T) {
+	bad := []byte(`{"resourceType":"Patient"}` + "\n" + `{not json}`)
+
+	count, err := lib.ReadNDJSON(bytes.NewReader(bad), func(r lib.FHIRResource) error { return nil })
+	require.Error(t, err)
+	assert.Equal(t, 1, count)
+	assert.Contains(t, err.Error(), "decode at resource 2")
 }
 
 // TestCountResourcesInFile_LargeBundle verifies CountResourcesInFile works
-// with NDJSON files containing large Bundles (regression test for issue #195)
+// with NDJSON files containing large Bundles (regression for issue #335).
 func TestCountResourcesInFile_LargeBundle(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "large.ndjson")
 
-	// Write two resources: one large Bundle and one small Patient
 	largeBundle := generateLargeFHIRBundle(1500)
 	bundleJSON, err := json.Marshal(largeBundle)
 	require.NoError(t, err)
@@ -117,12 +112,12 @@ func TestCountResourcesInFile_LargeBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	count, err := lib.CountResourcesInFile(filePath)
-	require.NoError(t, err, "CountResourcesInFile should handle large bundles (issue #195)")
+	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 }
 
-// generateLargeFHIRBundle creates a FHIR Bundle with enough entries to exceed 1MB.
-// Each entry is ~2KB, so 600 entries produce a ~1.2MB JSON line.
+// generateLargeFHIRBundle creates a FHIR Bundle with the requested number of
+// Observation entries. Each entry serializes to roughly 1KB.
 func generateLargeFHIRBundle(numEntries int) map[string]any {
 	entries := make([]map[string]any, numEntries)
 	for i := 0; i < numEntries; i++ {

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -174,7 +174,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, resources)
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 		assert.Equal(t, "1", result[0]["id"])
@@ -193,7 +193,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(content), 0644)
 		require.NoError(t, err)
 
-		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 	})
@@ -210,7 +210,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		bundle := makeBundle("bundle-1", patient, condition, provPatient, provCondition)
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 
 		// Only clinical resources returned, no Provenance
@@ -242,9 +242,31 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
+	})
+
+	t.Run("skips malformed top-level resources and continues", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "mixed.ndjson")
+
+		// Mix valid resource with non-object JSON values that decode as RawMessage
+		// but fail to unmarshal into map[string]any (covers logger.Warn branch).
+		content := `{"resourceType":"Patient","id":"good-1"}
+42
+"not-an-object"
+[1,2,3]
+{"resourceType":"Patient","id":"good-2"}
+`
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "good-1", result[0]["id"])
+		assert.Equal(t, "good-2", result[1]["id"])
 	})
 
 	t.Run("handles Bundle entry without resource field", func(t *testing.T) {
@@ -262,7 +284,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -282,7 +304,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -298,18 +320,18 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
 
 	t.Run("returns error for nonexistent file", func(t *testing.T) {
-		_, _, err := pipeline.LoadResourcesFromFile("/nonexistent/path/file.ndjson", logger, lib.DefaultMaxNDJSONLineSize)
+		_, _, err := pipeline.LoadResourcesFromFile("/nonexistent/path/file.ndjson", logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open file")
 	})
 
-	t.Run("handles invalid JSON line gracefully", func(t *testing.T) {
+	t.Run("returns error on invalid JSON", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		filePath := filepath.Join(tmpDir, "invalid.ndjson")
 
@@ -320,9 +342,9 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		err := os.WriteFile(filePath, []byte(content), 0644)
 		require.NoError(t, err)
 
-		result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
-		require.NoError(t, err)
-		assert.Len(t, result, 2)
+		_, _, err = pipeline.LoadResourcesFromFile(filePath, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error reading file")
 	})
 
 	t.Run("provenance with multiple targets maps all to same group", func(t *testing.T) {
@@ -365,7 +387,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 2) // Patient + Observation, no Provenance
 		assert.Equal(t, []string{"group-x"}, index["Patient/p1"])
@@ -405,7 +427,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.Empty(t, index)
@@ -437,7 +459,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		bundle := makeBundle("b1", patient, prov)
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.Empty(t, index)
@@ -471,7 +493,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		bundle := makeBundle("b1", patient, prov)
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		// Only the valid target entry should be indexed
@@ -507,7 +529,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		bundle := makeBundle("b1", patient, prov)
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		// Only the valid reference should be indexed
@@ -530,7 +552,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		bundle := makeBundle("b1", patient, prov)
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.Empty(t, index)
@@ -556,7 +578,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		bundle := makeBundle("b1", patient, prov)
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.Empty(t, index)
@@ -596,7 +618,7 @@ func TestLoadResourcesFromFile(t *testing.T) {
 		}
 		writeTestNDJSON(t, filePath, []map[string]any{bundle})
 
-		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadResourcesFromFile(filePath, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 		assert.Empty(t, index)
@@ -623,7 +645,7 @@ func TestLoadAllResources(t *testing.T) {
 		writeTestNDJSON(t, file1, []map[string]any{bundle1})
 		writeTestNDJSON(t, file2, []map[string]any{bundle2})
 
-		result, index, err := pipeline.LoadAllResources([]string{file1, file2}, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadAllResources([]string{file1, file2}, logger)
 		require.NoError(t, err)
 		assert.Len(t, result, 2)
 		assert.Equal(t, []string{"group-a"}, index["Patient/1"])
@@ -637,13 +659,13 @@ func TestLoadAllResources(t *testing.T) {
 			{"resourceType": "Patient", "id": "1"},
 		})
 
-		_, _, err := pipeline.LoadAllResources([]string{file1, "/nonexistent/file.ndjson"}, logger, lib.DefaultMaxNDJSONLineSize)
+		_, _, err := pipeline.LoadAllResources([]string{file1, "/nonexistent/file.ndjson"}, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load")
 	})
 
 	t.Run("handles empty file list", func(t *testing.T) {
-		result, index, err := pipeline.LoadAllResources([]string{}, logger, lib.DefaultMaxNDJSONLineSize)
+		result, index, err := pipeline.LoadAllResources([]string{}, logger)
 		require.NoError(t, err)
 		assert.Empty(t, result)
 		assert.Empty(t, index)
@@ -1064,7 +1086,7 @@ func TestLoadResourcesFromFile_ScannerError(t *testing.T) {
 	}
 	writeTestNDJSON(t, filePath, resources)
 
-	result, _, err := pipeline.LoadResourcesFromFile(filePath, logger, lib.DefaultMaxNDJSONLineSize)
+	result, _, err := pipeline.LoadResourcesFromFile(filePath, logger)
 	require.NoError(t, err)
 	assert.Len(t, result, 1)
 }
@@ -1380,9 +1402,8 @@ func TestExecuteFlatteningStep_StreamingEdgeCases(t *testing.T) {
 	lookupPath := filepath.Join(tempDir, "lookup.json")
 	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
 
-	// NDJSON with many edge cases:
-	// - empty lines (skipped)
-	// - invalid JSON (skipped with warning)
+	// NDJSON with many edge cases (json.Decoder tolerates whitespace between values):
+	// - empty lines (whitespace, skipped by decoder)
 	// - standalone resources without provenance (no match - provenance routing)
 	// - Bundle with invalid entries (skipped gracefully)
 	// - Bundle with valid entries + Provenance (processed)
@@ -1393,8 +1414,7 @@ func TestExecuteFlatteningStep_StreamingEdgeCases(t *testing.T) {
 	validBundleJSON, _ := json.Marshal(validBundle)
 
 	ndjsonContent := strings.Join([]string{
-		``,               // empty line
-		`{invalid json}`, // invalid JSON
+		``, // empty line
 		`{"resourceType":"Patient","id":"no-provenance"}`,                                                                  // no provenance mapping
 		`{"resourceType":"Patient","id":"meta-string","meta":"not a map"}`,                                                 // meta not a map
 		`{"resourceType":"Bundle","type":"collection","entry":["not a map",{"fullUrl":"urn:1"},{"resource":"not a map"}]}`, // Bundle with only invalid entries


### PR DESCRIPTION
## Summary

- `bufio.Scanner` capped each NDJSON line at `pipeline.max_ndjson_line_size_mb` (default 100MB), failing with `bufio.Scanner: token too long` on legitimately large single-Bundle lines from upstream.
- Replace it with `json.Decoder` across every NDJSON read site (DIMP, flattening, validation, `FHIRClient.UploadNDJSON`, `lib.ReadNDJSON`). Memory is now bounded by the largest individual resource, not by a tokenizer buffer.
- Drop the `pipeline.max_ndjson_line_size_mb` knob and all its plumbing — no longer meaningful.

## Behavior change

Malformed JSON now aborts the stream rather than being silently skipped line-by-line. Per the issue, the input is trusted (Torch / DIMP output), so failing fast is the honest behavior. Tests that exercised lenient parsing were updated to assert strict behavior.

## Backward compatibility

Existing `aether.yaml` files containing `pipeline.max_ndjson_line_size_mb` continue to load — viper silently ignores unknown keys.

## Verification

- `go test ./...` — full suite passes (unit, integration, lib, ui).
- New regression test `TestReadNDJSON_LargeBundle` decodes a >100MB single-resource Bundle that the old scanner would reject.

## Follow-up

#336 — remove now-dead `LoadAllResources` / `LoadResourcesFromFile` exports (pre-existing, surfaced during this review).

Closes #335