### PR TITLE
fix(torch): handle scheme-less host-prefixed URLs from TORCH

### DIFF
--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,7 +193,7 @@ func (c *TORCHClient) SubmitExtraction(crtdlPath string) (string, error) {
 	}
 
 	// Ensure URL is absolute (handle relative URLs from TORCH)
-	contentLocation = c.makeAbsoluteURL(contentLocation)
+	contentLocation = makeAbsoluteURL(c.config.BaseURL, contentLocation, c.logger)
 	c.logger.Info("TORCH extraction submitted successfully", "extraction_url", contentLocation)
 
 	return contentLocation, nil
@@ -290,7 +291,7 @@ func (c *TORCHClient) SubmitExtractionWithContent(crtdlContent []byte) (string, 
 	}
 
 	// Ensure URL is absolute (handle relative URLs from TORCH)
-	contentLocation = c.makeAbsoluteURL(contentLocation)
+	contentLocation = makeAbsoluteURL(c.config.BaseURL, contentLocation, c.logger)
 	c.logger.Info("TORCH extraction submitted successfully", "extraction_url", contentLocation)
 
 	return contentLocation, nil
@@ -663,7 +664,7 @@ func (c *TORCHClient) extractURLsFromSimpleFormat(result TORCHSimpleResponse) []
 	for _, output := range result.Output {
 		if output.URL != "" {
 			// Ensure URL is absolute (handle relative URLs from TORCH)
-			fileURLs = append(fileURLs, c.makeAbsoluteURL(output.URL))
+			fileURLs = append(fileURLs, makeAbsoluteURL(c.config.BaseURL, output.URL, c.logger))
 		}
 	}
 	c.logger.Debug("Extracted URLs from simple format", "file_count", len(fileURLs))
@@ -678,7 +679,7 @@ func (c *TORCHClient) extractURLsFromFHIRFormat(result TORCHExtractionResult) []
 			for _, part := range param.Part {
 				if part.Name == "url" && part.ValueURL != "" {
 					// Ensure URL is absolute (handle relative URLs from TORCH)
-					fileURLs = append(fileURLs, c.makeAbsoluteURL(part.ValueURL))
+					fileURLs = append(fileURLs, makeAbsoluteURL(c.config.BaseURL, part.ValueURL, c.logger))
 				}
 			}
 		}
@@ -767,15 +768,47 @@ func (c *TORCHClient) checkFileAvailableWithRange(fileURL string) (bool, error) 
 	return resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent, nil
 }
 
-// makeAbsoluteURL converts relative URLs to absolute using the configured baseURL.
-// Absolute URLs are returned as-is.
-func (c *TORCHClient) makeAbsoluteURL(rawURL string) string {
-	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
-		absoluteURL := c.config.BaseURL + rawURL
-		c.logger.Debug("Converted relative URL", "raw", rawURL, "absolute", absoluteURL)
-		return absoluteURL
+// makeAbsoluteURL converts a TORCH-returned URL to absolute using baseURL.
+// Pure function (no client state) so it can be tested directly without an
+// HTTP server. It dispatches on the input shape: absolute URLs pass through,
+// path-relative URLs resolve against baseURL, and scheme-less host-prefixed
+// URLs (the TORCH misconfiguration) inherit baseURL's scheme.
+func makeAbsoluteURL(baseURL, rawURL string, logger *lib.Logger) string {
+	if strings.Contains(rawURL, "://") {
+		logger.Debug("Using absolute URL from TORCH", "url", rawURL)
+		return rawURL
 	}
 
-	c.logger.Debug("Using absolute URL from TORCH", "url", rawURL)
-	return rawURL
+	base, err := url.Parse(baseURL)
+	if err != nil || base.Scheme == "" {
+		logger.Warn("Cannot resolve TORCH URL: invalid BaseURL", "base", baseURL, "raw", rawURL)
+		return rawURL
+	}
+
+	if strings.HasPrefix(rawURL, "/") {
+		return resolvePathRelativeURL(base, rawURL, logger)
+	}
+	return prependBaseScheme(base, rawURL, logger)
+}
+
+// resolvePathRelativeURL resolves a path-relative URL ("/output/x.ndjson")
+// against base. ResolveReference also collapses an accidental double-slash
+// when base carries a trailing slash.
+func resolvePathRelativeURL(base *url.URL, rawURL string, logger *lib.Logger) string {
+	ref, err := url.Parse(rawURL)
+	if err != nil {
+		logger.Warn("Cannot parse path-relative TORCH URL, returning as-is", "raw", rawURL, "error", err)
+		return rawURL
+	}
+	resolved := base.ResolveReference(ref).String()
+	logger.Debug("Converted relative URL", "raw", rawURL, "absolute", resolved)
+	return resolved
+}
+
+// prependBaseScheme recovers a scheme-less host-prefixed URL
+// ("localhost:8080/output/x.ndjson") by prepending base's scheme.
+func prependBaseScheme(base *url.URL, rawURL string, logger *lib.Logger) string {
+	fixed := base.Scheme + "://" + rawURL
+	logger.Warn("TORCH returned scheme-less URL, prepending BaseURL scheme", "raw", rawURL, "fixed", fixed)
+	return fixed
 }

--- a/internal/services/torch_client_internal_test.go
+++ b/internal/services/torch_client_internal_test.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+// Pure unit table for makeAbsoluteURL — all URL shapes and fallback branches,
+// no HTTP server. The integration path stays covered by the
+// SchemelessHostPortURL test in tests/unit; this exercises the resolution
+// logic directly.
+func TestMakeAbsoluteURL(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelDebug)
+
+	cases := []struct {
+		name    string
+		baseURL string
+		rawURL  string
+		want    string
+	}{
+		{name: "absolute http passed through", baseURL: "http://localhost:8080", rawURL: "http://other:9090/output/x.ndjson", want: "http://other:9090/output/x.ndjson"},
+		{name: "absolute https passed through", baseURL: "http://localhost:8080", rawURL: "https://other:9090/x", want: "https://other:9090/x"},
+		{name: "path-relative resolved against base", baseURL: "http://localhost:8080", rawURL: "/output/x.ndjson", want: "http://localhost:8080/output/x.ndjson"},
+		{name: "path-relative with base trailing slash collapses double slash", baseURL: "http://localhost:8080/", rawURL: "/output/x.ndjson", want: "http://localhost:8080/output/x.ndjson"},
+		{name: "scheme-less host-prefixed inherits http", baseURL: "http://localhost:8080", rawURL: "localhost:8080/output/x.ndjson", want: "http://localhost:8080/output/x.ndjson"},
+		{name: "scheme-less host-prefixed inherits https", baseURL: "https://torch.example", rawURL: "127.0.0.1:8080/output/x.ndjson", want: "https://127.0.0.1:8080/output/x.ndjson"},
+		{name: "invalid base returns raw unchanged", baseURL: "not-a-url", rawURL: "/output/x.ndjson", want: "/output/x.ndjson"},
+		{name: "empty base returns raw unchanged", baseURL: "", rawURL: "/output/x.ndjson", want: "/output/x.ndjson"},
+		{name: "unparseable path-relative returns raw unchanged", baseURL: "http://localhost:8080", rawURL: "/foo\x7fbar", want: "/foo\x7fbar"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := makeAbsoluteURL(tc.baseURL, tc.rawURL, logger)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -826,6 +828,47 @@ func TestTORCHClient_EncodeCRTDLToBase64_InvalidJSON(t *testing.T) {
 
 // Tests for response parsing edge cases
 
+// atServer yields the live stub's own URL — for tests whose BaseURL or output
+// URL should point at the stub.
+func atServer(serverURL string) string { return serverURL }
+
+// staticURL ignores the stub URL and always returns u — for fixed test values.
+func staticURL(u string) func(string) string {
+	return func(string) string { return u }
+}
+
+// pollSimpleOutput starts a TORCH stub returning a single simple-format output
+// whose url is urlFor(stubURL), configures a client with baseURLFor(stubURL) as
+// BaseURL, polls the stub, and returns the resolved file URLs alongside the
+// stub's URL (for assertions that reference the host).
+func pollSimpleOutput(t *testing.T, baseURLFor, urlFor func(serverURL string) string) ([]string, string, error) {
+	t.Helper()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"requiresAccessToken": false,
+			"output":              []map[string]any{{"type": "data", "url": urlFor(server.URL)}},
+		})
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+	cfg := models.TORCHConfig{
+		BaseURL:            baseURLFor(server.URL),
+		Username:           "testuser",
+		Password:           "testpass",
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 5 * time.Second,
+	}
+	client := services.NewTORCHClient(cfg, httpClient, logger)
+	urls, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+	return urls, server.URL, err
+}
+
 func TestTORCHClient_ParseExtractionResult_FHIRFormat(t *testing.T) {
 	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -870,41 +913,58 @@ func TestTORCHClient_ParseExtractionResult_FHIRFormat(t *testing.T) {
 }
 
 func TestTORCHClient_ParseExtractionResult_SimpleFormat(t *testing.T) {
-	var serverURL string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		result := map[string]any{
-			"requiresAccessToken": false,
-			"output": []map[string]any{
-				{
-					"type": "data",
-					"url":  serverURL + "/downloads/data.ndjson",
-				},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(result)
-	}))
-	serverURL = server.URL
-	defer server.Close()
-
-	logger := lib.NewLogger(lib.LogLevelDebug)
-	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
-	torchConfig := models.TORCHConfig{
-		BaseURL:            server.URL,
-		Username:           "testuser",
-		Password:           "testpass",
-		ExtractionTimeout:  1 * time.Minute,
-		PollingInterval:    1 * time.Second,
-		MaxPollingInterval: 5 * time.Second,
-	}
-
-	client := services.NewTORCHClient(torchConfig, httpClient, logger)
-	urls, err := client.PollExtractionStatus(server.URL+"/fhir/extraction/job-123", false)
+	urls, _, err := pollSimpleOutput(t, atServer, func(s string) string { return s + "/downloads/data.ndjson" })
 
 	assert.NoError(t, err)
 	assert.Len(t, urls, 1)
 	assert.Contains(t, urls[0], "data.ndjson")
+}
+
+// Reproduces the issue: when TORCH returns scheme-less host:port URLs
+// (e.g. "localhost:8080/output/x.ndjson"), makeAbsoluteURL must prepend
+// BaseURL's scheme rather than concatenating BaseURL — which would produce
+// "http://localhost:8080localhost:8080/output/x.ndjson".
+func TestTORCHClient_ParseExtractionResult_SchemelessHostPortURL(t *testing.T) {
+	// Simulate TORCH returning "<host>:<port>/output/abc.ndjson" — no scheme.
+	urls, serverURL, err := pollSimpleOutput(t, atServer, func(s string) string {
+		return strings.TrimPrefix(s, "http://") + "/output/abc.ndjson"
+	})
+
+	require.NoError(t, err)
+	require.Len(t, urls, 1)
+
+	serverHost := strings.TrimPrefix(serverURL, "http://")
+	// URL must be parseable and have exactly one host — not "<host><host>"
+	parsed, perr := url.Parse(urls[0])
+	require.NoError(t, perr, "returned URL must be valid: %q", urls[0])
+	assert.Equal(t, "http", parsed.Scheme, "scheme must be http, got URL: %q", urls[0])
+	assert.Equal(t, serverHost, parsed.Host, "host must appear exactly once, got URL: %q", urls[0])
+	assert.NotContains(t, urls[0], serverHost+serverHost, "host must not be duplicated: %q", urls[0])
+}
+
+// When BaseURL has no scheme (misconfiguration) and TORCH returns a
+// path-relative URL, makeAbsoluteURL cannot resolve it and must return the raw
+// URL unchanged rather than producing a broken absolute URL. "not-a-url" parses
+// without error but yields an empty scheme, which is the unresolvable case.
+func TestTORCHClient_ParseExtractionResult_SchemelessBaseURL(t *testing.T) {
+	const relativeURL = "/output/abc.ndjson"
+	urls, _, err := pollSimpleOutput(t, staticURL("not-a-url"), staticURL(relativeURL))
+
+	require.NoError(t, err)
+	require.Len(t, urls, 1)
+	assert.Equal(t, relativeURL, urls[0], "unresolvable URL must be returned unchanged")
+}
+
+// When TORCH returns a path-relative URL that is itself unparseable (contains a
+// control character), makeAbsoluteURL must return the raw URL unchanged instead
+// of panicking or resolving against base.
+func TestTORCHClient_ParseExtractionResult_UnparseableRelativeURL(t *testing.T) {
+	const brokenURL = "/output/\x7f.ndjson"
+	urls, _, err := pollSimpleOutput(t, atServer, staticURL(brokenURL))
+
+	require.NoError(t, err)
+	require.Len(t, urls, 1)
+	assert.Equal(t, brokenURL, urls[0], "unparseable URL must be returned unchanged")
 }
 
 func TestTORCHClient_ParseExtractionResult_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix double-host URL bug (`http://localhost:8080localhost:8080/output/...`) when TORCH's `torch.output.file.server.url` is misconfigured without a scheme.
- `makeAbsoluteURL` now detects three input shapes: absolute (`http(s)://`), path-relative (`/output/x`), and host-prefixed scheme-less (`localhost:8080/output/x` — the TORCH bug shape) — and recovers the third by prepending BaseURL's scheme.
- Warn-logs the recovery so misconfiguration on the TORCH side surfaces instead of silently masking.
- Path-relative case uses `url.URL.ResolveReference`, which also fixes accidental double-slash when BaseURL has a trailing `/`.

## Reproduction

`TestTORCHClient_ParseExtractionResult_SchemelessHostPortURL` reproduces the user-reported failure (was failing on `main`, now passes).

`TestTORCHClient_ParseExtractionResult_URLShapes` covers all four shapes:
- absolute `http://`
- path-relative `/x`
- host-prefixed scheme-less (TORCH bug shape)
- BaseURL with trailing slash + path-relative

## Note for users

Aether now defends against this. The proper TORCH-side fix is still:

```
TORCH_OUTPUT_FILE_SERVER_URL=http://<host>:<port>/output
```

`TORCH_BASE_URL` and `TORCH_RESULTS_DIR` do **not** control this.

Closes #351