### PR TITLE
chore(go): track Go toolchain via go.mod for Renovate

### DIFF
--- a/.github/workflows/_codeql.yaml
+++ b/.github/workflows/_codeql.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run golangci-lint

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build release binaries

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Run tests with coverage
@@ -244,7 +244,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build aether
@@ -313,7 +313,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build aether
@@ -386,7 +386,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build aether

--- a/.github/workflows/_vuln.yaml
+++ b/.github/workflows/_vuln.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.26.2'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Install govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/medizininformatik-initiative/aether
 
-go 1.25
+go 1.26
+
+toolchain go1.26.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
## Summary
- Bump `go 1.25` → `go 1.26` and add `toolchain go1.26.3` in `go.mod`
- Switch all 5 CI workflows from hardcoded `go-version: '1.26.2'` to `go-version-file: 'go.mod'`
- `go.mod` becomes the single source of truth; Renovate's `gomod` manager auto-bumps the toolchain on each Go release

Closes #354