### PR TITLE
fix(crtdl): preserve unknown fields during enrichment

### DIFF
--- a/internal/models/flattening.go
+++ b/internal/models/flattening.go
@@ -131,32 +131,194 @@ type ColumnDefinition struct {
 }
 
 // CRTDLDocument represents the CRTDL file structure
-// Includes all top-level fields to preserve the full document during preprocessing
+// Includes all top-level fields to preserve the full document during preprocessing.
+// Extra captures any unknown top-level fields so they survive JSON round-trips
+// (see issue #356).
 type CRTDLDocument struct {
-	Display          string          `json:"display,omitempty"`
-	Version          string          `json:"version,omitempty"`
-	CohortDefinition json.RawMessage `json:"cohortDefinition,omitempty"` // Preserved as-is, not processed
-	DataExtraction   DataExtraction  `json:"dataExtraction"`
+	Display          string                     `json:"-"`
+	Version          string                     `json:"-"`
+	CohortDefinition json.RawMessage            `json:"-"`
+	DataExtraction   DataExtraction             `json:"-"`
+	Extra            map[string]json.RawMessage `json:"-"`
 }
 
-// DataExtraction represents the dataExtraction section of a CRTDL document
+// DataExtraction represents the dataExtraction section of a CRTDL document.
+// Extra preserves unknown sibling fields.
 type DataExtraction struct {
-	AttributeGroups []AttributeGroup `json:"attributeGroups"`
+	AttributeGroups []AttributeGroup           `json:"-"`
+	Extra           map[string]json.RawMessage `json:"-"`
 }
 
-// AttributeGroup represents an attributeGroup in the CRTDL dataExtraction
+// AttributeGroup represents an attributeGroup in the CRTDL dataExtraction.
+// Extra preserves unknown fields such as `includeReferenceOnly`.
 type AttributeGroup struct {
-	ID             string      `json:"id"`             // Required: used for provenance-based resource routing
-	Name           string      `json:"name"`           // Group name (used for CSV filename)
-	GroupReference string      `json:"groupReference"` // Profile URL for resource matching
-	Attributes     []Attribute `json:"attributes"`     // List of attributes to extract
+	ID             string                     `json:"-"` // Required: used for provenance-based resource routing
+	Name           string                     `json:"-"` // Group name (used for CSV filename)
+	GroupReference string                     `json:"-"` // Profile URL for resource matching
+	Attributes     []Attribute                `json:"-"` // List of attributes to extract
+	Extra          map[string]json.RawMessage `json:"-"`
 }
 
-// Attribute represents a single attribute within an attributeGroup
+// Attribute represents a single attribute within an attributeGroup.
+// Extra preserves unknown fields.
 type Attribute struct {
-	AttributeRef string   `json:"attributeRef"`           // Element ID reference to lookup
-	MustHave     bool     `json:"mustHave"`               // Whether this attribute is required
-	LinkedGroups []string `json:"linkedGroups,omitempty"` // Profile URLs for linked groups (resolved to IDs during preprocessing)
+	AttributeRef string                     `json:"-"` // Element ID reference to lookup
+	MustHave     bool                       `json:"-"` // Whether this attribute is required
+	LinkedGroups []string                   `json:"-"` // Profile URLs for linked groups (resolved to IDs during preprocessing)
+	Extra        map[string]json.RawMessage `json:"-"`
+}
+
+// --- Custom JSON marshaling preserves unknown fields (issue #356) ---
+
+func unmarshalKnown(raw map[string]json.RawMessage, key string, target any) error {
+	v, ok := raw[key]
+	if !ok {
+		return nil
+	}
+	delete(raw, key)
+	if len(v) == 0 || string(v) == "null" {
+		return nil
+	}
+	return json.Unmarshal(v, target)
+}
+
+func mustMarshal(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("CRTDL marshal failed for %T: %v", v, err))
+	}
+	return b
+}
+
+func mergeExtra(out map[string]json.RawMessage, extra map[string]json.RawMessage) {
+	for k, v := range extra {
+		out[k] = v
+	}
+}
+
+func (a *Attribute) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "attributeRef", &a.AttributeRef); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "mustHave", &a.MustHave); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "linkedGroups", &a.LinkedGroups); err != nil {
+		return err
+	}
+	if len(raw) > 0 {
+		a.Extra = raw
+	}
+	return nil
+}
+
+func (a Attribute) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	mergeExtra(out, a.Extra)
+	out["attributeRef"] = mustMarshal(a.AttributeRef)
+	out["mustHave"] = mustMarshal(a.MustHave)
+	if len(a.LinkedGroups) > 0 {
+		out["linkedGroups"] = mustMarshal(a.LinkedGroups)
+	}
+	return json.Marshal(out)
+}
+
+func (g *AttributeGroup) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "id", &g.ID); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "name", &g.Name); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "groupReference", &g.GroupReference); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "attributes", &g.Attributes); err != nil {
+		return err
+	}
+	if len(raw) > 0 {
+		g.Extra = raw
+	}
+	return nil
+}
+
+func (g AttributeGroup) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	mergeExtra(out, g.Extra)
+	out["id"] = mustMarshal(g.ID)
+	out["name"] = mustMarshal(g.Name)
+	out["groupReference"] = mustMarshal(g.GroupReference)
+	out["attributes"] = mustMarshal(g.Attributes)
+	return json.Marshal(out)
+}
+
+func (d *DataExtraction) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "attributeGroups", &d.AttributeGroups); err != nil {
+		return err
+	}
+	if len(raw) > 0 {
+		d.Extra = raw
+	}
+	return nil
+}
+
+func (d DataExtraction) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	mergeExtra(out, d.Extra)
+	out["attributeGroups"] = mustMarshal(d.AttributeGroups)
+	return json.Marshal(out)
+}
+
+func (c *CRTDLDocument) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "display", &c.Display); err != nil {
+		return err
+	}
+	if err := unmarshalKnown(raw, "version", &c.Version); err != nil {
+		return err
+	}
+	if v, ok := raw["cohortDefinition"]; ok {
+		c.CohortDefinition = append(c.CohortDefinition[:0], v...)
+		delete(raw, "cohortDefinition")
+	}
+	if err := unmarshalKnown(raw, "dataExtraction", &c.DataExtraction); err != nil {
+		return err
+	}
+	if len(raw) > 0 {
+		c.Extra = raw
+	}
+	return nil
+}
+
+func (c CRTDLDocument) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	mergeExtra(out, c.Extra)
+	if c.Display != "" {
+		out["display"] = mustMarshal(c.Display)
+	}
+	if c.Version != "" {
+		out["version"] = mustMarshal(c.Version)
+	}
+	if len(c.CohortDefinition) > 0 {
+		out["cohortDefinition"] = append(json.RawMessage(nil), c.CohortDefinition...)
+	}
+	out["dataExtraction"] = mustMarshal(c.DataExtraction)
+	return json.Marshal(out)
 }
 
 // FlatteningRequest represents the FHIR Parameters request body sent to fhir-flattener

--- a/internal/services/crtdl_preprocessor.go
+++ b/internal/services/crtdl_preprocessor.go
@@ -236,6 +236,20 @@ func loadEnrichmentsFromFile(path string) ([]models.GroupEnrichment, error) {
 
 // --- Internal Helper Functions ---
 
+// cloneExtra deep-copies a map of preserved unknown JSON fields.
+func cloneExtra(in map[string]json.RawMessage) map[string]json.RawMessage {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]json.RawMessage, len(in))
+	for k, v := range in {
+		b := make(json.RawMessage, len(v))
+		copy(b, v)
+		out[k] = b
+	}
+	return out
+}
+
 // deepCopyCRTDL creates a deep copy of a CRTDL document.
 func deepCopyCRTDL(doc models.CRTDLDocument) models.CRTDLDocument {
 	result := models.CRTDLDocument{
@@ -243,7 +257,9 @@ func deepCopyCRTDL(doc models.CRTDLDocument) models.CRTDLDocument {
 		Version: doc.Version,
 		DataExtraction: models.DataExtraction{
 			AttributeGroups: make([]models.AttributeGroup, len(doc.DataExtraction.AttributeGroups)),
+			Extra:           cloneExtra(doc.DataExtraction.Extra),
 		},
+		Extra: cloneExtra(doc.Extra),
 	}
 
 	// Deep copy CohortDefinition (json.RawMessage is a []byte)
@@ -266,6 +282,7 @@ func deepCopyGroup(group models.AttributeGroup) models.AttributeGroup {
 		Name:           group.Name,
 		GroupReference: group.GroupReference,
 		Attributes:     make([]models.Attribute, len(group.Attributes)),
+		Extra:          cloneExtra(group.Extra),
 	}
 
 	for i, attr := range group.Attributes {
@@ -280,6 +297,7 @@ func deepCopyAttribute(attr models.Attribute) models.Attribute {
 	result := models.Attribute{
 		AttributeRef: attr.AttributeRef,
 		MustHave:     attr.MustHave,
+		Extra:        cloneExtra(attr.Extra),
 	}
 
 	if len(attr.LinkedGroups) > 0 {

--- a/tests/unit/crtdl_preprocessor_test.go
+++ b/tests/unit/crtdl_preprocessor_test.go
@@ -1070,3 +1070,158 @@ func TestLoadEnrichments_FromFile_SnakeCaseRejected(t *testing.T) {
 	require.Error(t, err, "snake_case fields in JSON file should be rejected")
 	assert.Contains(t, err.Error(), "snake_case", "error should mention snake_case")
 }
+
+// --- Unknown Field Preservation (Issue #356) ---
+
+// TestEnrichCRTDL_PreservesUnknownAttributeGroupField verifies that fields
+// not modeled by the AttributeGroup struct (e.g. includeReferenceOnly) survive
+// the unmarshal → enrich → marshal round-trip.
+func TestEnrichCRTDL_PreservesUnknownAttributeGroupField(t *testing.T) {
+	rawCRTDL := `{
+		"version": "http://json-schema.org/to-be-done/schema#",
+		"display": "",
+		"dataExtraction": {
+			"attributeGroups": [
+				{
+					"id": "med-group",
+					"name": "Medication",
+					"groupReference": "https://example.org/Medication",
+					"includeReferenceOnly": true,
+					"attributes": [
+						{"attributeRef": "Medication.code", "mustHave": false}
+					]
+				}
+			]
+		}
+	}`
+
+	var doc models.CRTDLDocument
+	require.NoError(t, json.Unmarshal([]byte(rawCRTDL), &doc))
+
+	enrichments := []models.GroupEnrichment{
+		{
+			GroupReference: "https://example.org/Medication",
+			AttributesToAdd: []models.EnrichmentAttribute{
+				{AttributeRef: "Medication.ingredient", MustHave: false},
+			},
+		},
+	}
+
+	enriched, err := services.EnrichCRTDL(doc, enrichments)
+	require.NoError(t, err)
+
+	out, err := json.Marshal(enriched)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	groups := got["dataExtraction"].(map[string]any)["attributeGroups"].([]any)
+	require.Len(t, groups, 1)
+	medGroup := groups[0].(map[string]any)
+	assert.Equal(t, true, medGroup["includeReferenceOnly"],
+		"includeReferenceOnly must be preserved through enrichment")
+
+	attrs := medGroup["attributes"].([]any)
+	assert.Len(t, attrs, 2, "enrichment should still have added attribute")
+}
+
+// TestEnrichCRTDL_PreservesUnknownAttributeField verifies that unknown fields
+// at the Attribute level survive enrichment.
+func TestEnrichCRTDL_PreservesUnknownAttributeField(t *testing.T) {
+	rawCRTDL := `{
+		"dataExtraction": {
+			"attributeGroups": [
+				{
+					"id": "p",
+					"name": "Patient",
+					"groupReference": "https://example.org/Patient",
+					"attributes": [
+						{
+							"attributeRef": "Patient.id",
+							"mustHave": true,
+							"customExtension": "preserveMe"
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	var doc models.CRTDLDocument
+	require.NoError(t, json.Unmarshal([]byte(rawCRTDL), &doc))
+
+	enriched, err := services.EnrichCRTDL(doc, []models.GroupEnrichment{
+		{
+			GroupReference: "https://example.org/Patient",
+			AttributesToAdd: []models.EnrichmentAttribute{
+				{AttributeRef: "Patient.gender", MustHave: false},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := json.Marshal(enriched)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	attrs := got["dataExtraction"].(map[string]any)["attributeGroups"].([]any)[0].(map[string]any)["attributes"].([]any)
+	var patientID map[string]any
+	for _, a := range attrs {
+		m := a.(map[string]any)
+		if m["attributeRef"] == "Patient.id" {
+			patientID = m
+			break
+		}
+	}
+	require.NotNil(t, patientID, "Patient.id attribute should exist")
+	assert.Equal(t, "preserveMe", patientID["customExtension"],
+		"unknown attribute-level field must be preserved")
+}
+
+// TestCRTDLDocument_RoundTripPreservesUnknownFieldsAllLevels verifies a plain
+// JSON round-trip preserves unknown fields at all four document levels.
+func TestCRTDLDocument_RoundTripPreservesUnknownFieldsAllLevels(t *testing.T) {
+	raw := `{
+		"display": "x",
+		"version": "v1",
+		"topLevelExtra": "doc-level",
+		"dataExtraction": {
+			"sectionExtra": "section-level",
+			"attributeGroups": [
+				{
+					"id": "g",
+					"name": "G",
+					"groupReference": "https://example.org/G",
+					"groupExtra": "group-level",
+					"includeReferenceOnly": true,
+					"attributes": [
+						{
+							"attributeRef": "G.id",
+							"mustHave": true,
+							"attrExtra": "attr-level"
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	var doc models.CRTDLDocument
+	require.NoError(t, json.Unmarshal([]byte(raw), &doc))
+
+	out, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+
+	assert.Equal(t, "doc-level", got["topLevelExtra"], "doc-level unknown field preserved")
+	de := got["dataExtraction"].(map[string]any)
+	assert.Equal(t, "section-level", de["sectionExtra"], "dataExtraction-level unknown field preserved")
+	group := de["attributeGroups"].([]any)[0].(map[string]any)
+	assert.Equal(t, "group-level", group["groupExtra"], "group-level unknown field preserved")
+	assert.Equal(t, true, group["includeReferenceOnly"], "includeReferenceOnly preserved")
+	attr := group["attributes"].([]any)[0].(map[string]any)
+	assert.Equal(t, "attr-level", attr["attrExtra"], "attribute-level unknown field preserved")
+}


### PR DESCRIPTION
## Summary
- CRTDL enrichment dropped any field not modeled by aether's structs (e.g. `includeReferenceOnly: true` on an `attributeGroup`), corrupting the file sent on to TORCH.
- Added a generic `Extra map[string]json.RawMessage` with custom `(Un)MarshalJSON` on `CRTDLDocument`, `DataExtraction`, `AttributeGroup`, and `Attribute` so any unknown field at any level is preserved through parse → enrich → marshal.
- Extended the deep-copy helpers used by `EnrichCRTDL` to clone `Extra`, keeping the existing immutability guarantee.

Closes #356