### PR TITLE
ci(docs): use npm ci to avoid mutating package-lock.json

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -104,7 +104,7 @@ jobs:
           cache-dependency-path: 'docs/package-lock.json'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: docs
 
       - name: Build documentation


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci` in `.github/workflows/docs-deploy.yml`
- Prevents lockfile mutation that aborts the later `git checkout gh-pages`
- Renovate (`:maintainLockFilesWeekly`) keeps `docs/package-lock.json` in sync with `package.json`

Closes #370