### PR TITLE
ci(docs): revert to npm install, discard lockfile mutation before gh-pages checkout

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -104,7 +104,7 @@ jobs:
           cache-dependency-path: 'docs/package-lock.json'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: docs
 
       - name: Build documentation
@@ -118,6 +118,9 @@ jobs:
 
       - name: Checkout gh-pages branch
         run: |
+          # `npm install` may refresh docs/package-lock.json (integrity hashes,
+          # metadata). Discard that mutation so the branch switch doesn't abort.
+          git checkout -- docs/package-lock.json
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
           if git rev-parse --verify gh-pages >/dev/null 2>&1; then
             git checkout gh-pages


### PR DESCRIPTION
## Summary
- Revert `npm ci` (from #371) back to `npm install` in `docs-deploy.yml` — `npm ci` triggers `EBADPLATFORM` on `@esbuild/aix-ppc64@0.28.0` due to an npm runtime bug handling transitive optional platform binaries.
- Re-address the original gh-pages checkout failure (#370) by discarding the lockfile mutation immediately before the branch switch.

Why not just regenerate the lockfile: `rm -rf node_modules package-lock.json && npm install` produces an identical lockfile, and `npm ci` succeeds locally — this is CI npm behavior, not lockfile content.

Closes #373