### PR TITLE
fix(ci): use Scorecard-recognized extensions for release artifacts

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -64,7 +64,7 @@ jobs:
           for file in release/*; do
             if [ -f "$file" ]; then
               echo "Signing $file..."
-              cosign sign-blob --yes "$file" --bundle "${file}.bundle"
+              cosign sign-blob --yes "$file" --bundle "${file}.sigstore"
             fi
           done
 
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd release
           for file in *; do
-            if [ -f "$file" ] && [ "${file##*.}" != "bundle" ]; then
+            if [ -f "$file" ] && [ "${file##*.}" != "sigstore" ]; then
               sha256sum "$file" > "${file}.sha256"
             fi
           done
@@ -80,13 +80,13 @@ jobs:
       - name: Generate in-toto attestations
         run: |
           for file in release/*; do
-            if [ -f "$file" ] && [ "${file##*.}" != "bundle" ] && [ "${file##*.}" != "sha256" ]; then
+            if [ -f "$file" ] && [ "${file##*.}" != "sigstore" ] && [ "${file##*.}" != "sha256" ]; then
               filename=$(basename "$file")
               echo "Creating attestation for $filename..."
               cosign attest-blob --yes \
                 --predicate <(echo "{\"name\": \"$filename\"}") \
                 --type intoto \
-                "$file" --bundle "${file}.att.bundle"
+                "$file" --bundle "${file}.intoto.jsonl"
             fi
           done
 
@@ -95,8 +95,8 @@ jobs:
         with:
           name: signatures-checksums
           path: |
-            release/*.bundle
-            release/*.att.bundle
+            release/*.sigstore
+            release/*.intoto.jsonl
             release/*.sha256
           retention-days: 1
 


### PR DESCRIPTION
## Summary

- Rename cosign signature output `.bundle` → `.sigstore`
- Rename cosign attestation output `.att.bundle` → `.intoto.jsonl`
- Update upload glob patterns and in-loop extension filters

## Why

OpenSSF Scorecard's `signed-releases` check only recognizes `.sig`, `.asc`, `.minisig`, `.sigstore`, `.intoto.jsonl`. The previous `.bundle` / `.att.bundle` outputs (cosign sigstore bundles + in-toto attestation bundles) are valid signatures but Scorecard's filename-based check ignored them, so v0.4.0–v0.8.0 were flagged as unsigned with no provenance.

Cosign writes the same JSON bundle format regardless of `--bundle` filename — only the extension changes, so existing tooling that verifies via `cosign verify-blob --bundle` keeps working.

Closes #375