### PR TITLE
ci(renovate): track torch beta pre-releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,12 +31,12 @@
       "ignoreUnstable": false
     },
     {
-      "description": "Only allow stable releases and alpha pre-releases for torch (exclude test/dev tags)",
+      "description": "Only allow stable releases and alpha/beta pre-releases for torch (exclude test/dev tags)",
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "ghcr.io/medizininformatik-initiative/torch"
       ],
-      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-alpha\\.\\d+)?$/"
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-(alpha|beta)\\.\\d+)?$/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Extend `allowedVersions` regex for `ghcr.io/medizininformatik-initiative/torch` to include `-beta.N` alongside `-alpha.N`.
- Without this, Renovate filters out releases like `1.0.0-beta.1` and never opens an update PR.

Closes #377