### PR TITLE
feat(logging): store per-job logs in job directory

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -389,9 +390,21 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 		logLevel = lib.LogLevelDebug
 	}
 	logger := lib.NewLogger(logLevel)
+	defer func() { _ = logger.Close() }()
+
+	// Attach job.log before CreateJob so its diagnostics are captured too. The
+	// caller owns this side effect; Close runs via the defer above.
+	jobID := models.GenerateJobID()
+	jobDir := services.GetJobDir(config.JobsDir, jobID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create job directory: %w", err)
+	}
+	if err := logger.AttachJobLogFile(services.GetJobLogFilePath(config.JobsDir, jobID)); err != nil {
+		return fmt.Errorf("failed to attach job log file: %w", err)
+	}
 
 	logger.Info("Creating new pipeline job", "crtdl", crtdlPath, "input", inputSource, "localImportDir", config.Services.LocalImport.Dir)
-	job, err := pipeline.CreateJob(inputSource, crtdlPath, *config, logger)
+	job, err := pipeline.CreateJob(jobID, inputSource, crtdlPath, *config, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create job: %w", err)
 	}
@@ -543,11 +556,17 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 		logLevel = lib.LogLevelDebug
 	}
 	logger := lib.NewLogger(logLevel)
+	defer func() { _ = logger.Close() }()
 
 	fmt.Printf("Loading job %s...\n", jobID)
 	job, err := pipeline.LoadJob(config.JobsDir, jobID)
 	if err != nil {
 		return fmt.Errorf("failed to load job: %w", err)
+	}
+
+	// Append this run's logs to the job's existing job.log.
+	if err := logger.AttachJobLogFile(services.GetJobLogFilePath(config.JobsDir, jobID)); err != nil {
+		return fmt.Errorf("failed to attach job log file: %w", err)
 	}
 
 	if job.Status == models.JobStatusCompleted {

--- a/internal/lib/logging.go
+++ b/internal/lib/logging.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -18,18 +19,62 @@ const (
 	LogLevelError
 )
 
-// Logger provides structured logging for the application
+// Logger provides structured logging for the application.
+//
+// It fans out to two independent sinks: a console sink filtered by the
+// configured level, and an optional per-job file sink that always records full
+// DEBUG output so jobs/<job-id>/job.log is a complete diagnostic record
+// regardless of the console verbosity.
 type Logger struct {
-	level  LogLevel
-	logger *log.Logger
+	level      LogLevel
+	console    *log.Logger
+	fileLogger *log.Logger
+	file       *os.File
 }
 
-// NewLogger creates a new logger instance
+// NewLogger creates a new logger that writes console output to stderr.
 func NewLogger(level LogLevel) *Logger {
+	return NewLoggerWithWriter(level, os.Stderr)
+}
+
+// NewLoggerWithWriter creates a logger whose console sink writes to w. Primarily
+// used for tests that need to capture and assert on console output.
+func NewLoggerWithWriter(level LogLevel, w io.Writer) *Logger {
 	return &Logger{
-		level:  level,
-		logger: log.New(os.Stderr, "", log.LstdFlags),
+		level:   level,
+		console: log.New(w, "", log.LstdFlags),
 	}
+}
+
+// AttachJobLogFile routes a full-DEBUG copy of every log line to the file at
+// path, opened in append mode so repeated runs (e.g. pipeline continue) extend
+// one chronological record. Call Close to release the handle.
+func (l *Logger) AttachJobLogFile(path string) error {
+	// Close any previously attached file so re-attaching never leaks a handle.
+	if l.file != nil {
+		_ = l.file.Close()
+		l.file = nil
+		l.fileLogger = nil
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening job log file %s: %w", path, err)
+	}
+	l.file = f
+	l.fileLogger = log.New(f, "", log.LstdFlags)
+	return nil
+}
+
+// Close releases the attached job log file, if any. Safe to call when no file
+// is attached.
+func (l *Logger) Close() error {
+	if l.file == nil {
+		return nil
+	}
+	err := l.file.Close()
+	l.file = nil
+	l.fileLogger = nil
+	return err
 }
 
 // DefaultLogger returns a logger with INFO level
@@ -37,39 +82,39 @@ var DefaultLogger = NewLogger(LogLevelInfo)
 
 // Debug logs a debug message
 func (l *Logger) Debug(message string, fields ...any) {
-	if l.level <= LogLevelDebug {
-		l.log("DEBUG", message, fields...)
-	}
+	l.log(LogLevelDebug, "DEBUG", message, fields...)
 }
 
 // Info logs an informational message
 func (l *Logger) Info(message string, fields ...any) {
-	if l.level <= LogLevelInfo {
-		l.log("INFO", message, fields...)
-	}
+	l.log(LogLevelInfo, "INFO", message, fields...)
 }
 
 // Warn logs a warning message
 func (l *Logger) Warn(message string, fields ...any) {
-	if l.level <= LogLevelWarn {
-		l.log("WARN", message, fields...)
-	}
+	l.log(LogLevelWarn, "WARN", message, fields...)
 }
 
 // Error logs an error message
 func (l *Logger) Error(message string, fields ...any) {
-	if l.level <= LogLevelError {
-		l.log("ERROR", message, fields...)
-	}
+	l.log(LogLevelError, "ERROR", message, fields...)
 }
 
-// log formats and writes a log message with optional fields
-func (l *Logger) log(level string, message string, fields ...any) {
+// log formats a message once and fans it out: to the console only when its
+// severity meets the configured level, and to the attached job log file always.
+func (l *Logger) log(lvl LogLevel, label string, message string, fields ...any) {
 	var fieldsStr string
 	if len(fields) > 0 {
 		fieldsStr = fmt.Sprintf(" | %v", fields)
 	}
-	l.logger.Printf("[%s] %s%s", level, message, fieldsStr)
+	line := fmt.Sprintf("[%s] %s%s", label, message, fieldsStr)
+
+	if lvl >= l.level {
+		l.console.Println(line)
+	}
+	if l.fileLogger != nil {
+		l.fileLogger.Println(line)
+	}
 }
 
 // LogOperation logs the start and completion of an operation

--- a/internal/pipeline/job.go
+++ b/internal/pipeline/job.go
@@ -9,7 +9,10 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
-// CreateJob initializes a new pipeline job.
+// CreateJob initializes a new pipeline job with the given jobID.
+//
+// Callers generate jobID and attach any per-job logging before calling, so
+// CreateJob has no side effects on shared state such as the logger.
 //
 // crtdlPath is the CRTDL file attached to the job; every job carries a CRTDL
 // so it is normally non-empty (the "" case is kept only for tests that
@@ -22,11 +25,8 @@ import (
 //   - Empty string: torch_import submits the CRTDL to TORCH, or local_import
 //     falls back to config.Services.LocalImport.Dir
 //
-// Returns the created job with generated UUID and initialized steps.
-func CreateJob(inputSource string, crtdlPath string, config models.ProjectConfig, logger *lib.Logger) (*models.PipelineJob, error) {
-	// Generate unique job ID with human-readable timestamp prefix
-	jobID := models.GenerateJobID()
-
+// Returns the created job with initialized steps.
+func CreateJob(jobID string, inputSource string, crtdlPath string, config models.ProjectConfig, logger *lib.Logger) (*models.PipelineJob, error) {
 	// Determine input type based on what was provided
 	var inputType models.InputType
 	var err error

--- a/internal/services/state.go
+++ b/internal/services/state.go
@@ -13,6 +13,8 @@ import (
 
 const (
 	StateFileName = "state.json"
+	// JobLogFileName is the per-job log file stored in the job directory.
+	JobLogFileName = "job.log"
 )
 
 // StateFileOps interface for file operations in state management, allowing mocking in tests
@@ -49,6 +51,11 @@ func GetJobDir(jobsBaseDir string, jobID string) string {
 // GetStateFilePath returns the full path to a job's state file
 func GetStateFilePath(jobsBaseDir string, jobID string) string {
 	return filepath.Join(GetJobDir(jobsBaseDir, jobID), StateFileName)
+}
+
+// GetJobLogFilePath returns the full path to a job's log file.
+func GetJobLogFilePath(jobsBaseDir string, jobID string) string {
+	return filepath.Join(GetJobDir(jobsBaseDir, jobID), JobLogFileName)
 }
 
 // LoadJobState reads a job's state from disk

--- a/tests/integration/job_list_test.go
+++ b/tests/integration/job_list_test.go
@@ -226,7 +226,7 @@ func createTestJobWithState(t *testing.T, jobsDir string, status models.JobStatu
 	createTestFHIRFile(t, sourceDir)
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
-	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	// Update job to desired state

--- a/tests/integration/pipeline_crtdl_enrichment_test.go
+++ b/tests/integration/pipeline_crtdl_enrichment_test.go
@@ -80,7 +80,7 @@ func TestCRTDLEnrichmentAppliedForLocalImportPath(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// CreateJob must repoint CRTDLPath at the enriched CRTDL inside jobDir.

--- a/tests/integration/pipeline_dimp_resume_test.go
+++ b/tests/integration/pipeline_dimp_resume_test.go
@@ -54,7 +54,7 @@ func TestDIMPResumeAfterInterrupt(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
 	// Create a job
-	job, err := pipeline.CreateJob("test-input", "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "test-input", "", config, logger)
 	require.NoError(t, err)
 
 	// Manually set up import directory with test files

--- a/tests/integration/pipeline_import_error_test.go
+++ b/tests/integration/pipeline_import_error_test.go
@@ -42,7 +42,7 @@ func TestPipelineImportError_UnreachableURL(t *testing.T) {
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create job with unreachable URL
-	job, err := pipeline.CreateJob(unreachableURL, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), unreachableURL, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	assert.Equal(t, models.InputTypeHTTP, job.InputType, "Input type should be HTTP")
 
@@ -107,7 +107,7 @@ func TestPipelineImportError_HTTP404(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/missing.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/missing.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -157,7 +157,7 @@ func TestPipelineImportError_HTTP500WithRetry(t *testing.T) {
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/error.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/error.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -199,7 +199,7 @@ func TestPipelineImportError_InvalidLocalPath(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create job with invalid path
-	job, err := pipeline.CreateJob(invalidPath, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), invalidPath, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	assert.Equal(t, models.InputTypeLocal, job.InputType, "Input type should be local")
 
@@ -243,7 +243,7 @@ func TestPipelineImportError_EmptyDirectory(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(emptyDir, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), emptyDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -282,7 +282,7 @@ func TestPipelineImportError_PathIsFile(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(filePath, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), filePath, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -326,7 +326,7 @@ func TestPipelineImportError_NetworkTimeout(t *testing.T) {
 	httpClient := services.NewHTTPClient(1*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/slow.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/slow.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -369,7 +369,7 @@ func TestPipelineImportError_StatePersistence(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(server.URL+"/bad.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/bad.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -427,7 +427,7 @@ func TestPipelineImportError_PartialDownloadCleanup(t *testing.T) {
 
 	// Note: This test would ideally simulate connection drop, but for now
 	// we test the cleanup mechanism with a different error scenario
-	job, _ := pipeline.CreateJob("http://localhost:99999/unreachable.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), "http://localhost:99999/unreachable.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 

--- a/tests/integration/pipeline_import_local_test.go
+++ b/tests/integration/pipeline_import_local_test.go
@@ -57,7 +57,7 @@ func TestPipelineImportLocal_EndToEnd(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Step 1: Create new job
-	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	require.NotNil(t, job, "Job should be created")
 	assert.NotEmpty(t, job.JobID, "Job should have an ID")
@@ -146,7 +146,7 @@ func TestPipelineImportLocal_InvalidSource(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create job with invalid source
-	job, err := pipeline.CreateJob(nonexistentDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), nonexistentDir, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed even with invalid source")
 
 	// Start job
@@ -194,7 +194,7 @@ func TestPipelineImportLocal_EmptyDirectory(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create and start job
-	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	require.NoError(t, err)
 	startedJob := pipeline.StartJob(job)
 
@@ -241,7 +241,7 @@ func TestPipelineImportLocal_ResourceCounting(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import
-	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -287,8 +287,8 @@ func TestPipelineImportLocal_JobListAndStatus(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Create multiple jobs
-	job1, _ := pipeline.CreateJob(sourceDir, "", config, logger)
-	job2, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job1, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
+	job2, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 
 	// Execute import for first job
 	startedJob1 := pipeline.StartJob(job1)

--- a/tests/integration/pipeline_import_url_test.go
+++ b/tests/integration/pipeline_import_url_test.go
@@ -56,7 +56,7 @@ func TestPipelineImportURL_EndToEnd(t *testing.T) {
 
 	// Step 1: Create job with HTTP URL input
 	url := server.URL + "/Patient.ndjson"
-	job, err := pipeline.CreateJob(url, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), url, "", config, logger)
 	require.NoError(t, err, "Job creation should succeed")
 	assert.Equal(t, models.InputTypeHTTP, job.InputType, "Input type should be HTTP")
 	assert.Equal(t, url, job.InputSource, "Input source should be the URL")
@@ -138,7 +138,7 @@ func TestPipelineImportURL_WithRetry(t *testing.T) {
 	httpClient := services.NewHTTPClient(5*time.Second, config.Retry, models.TLSConfig{}, logger)
 
 	// Create and execute job
-	job, _ := pipeline.CreateJob(server.URL+"/test.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/test.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -186,7 +186,7 @@ func TestPipelineImportURL_LargeFile(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute import with progress
-	job, _ := pipeline.CreateJob(server.URL+"/large.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/large.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, true)
 
@@ -240,7 +240,7 @@ func TestPipelineImportURL_ProgressDisplay(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute with progress display enabled
-	job, _ := pipeline.CreateJob(server.URL+"/data.ndjson", "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/data.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
 
 	// This should use progress bar/spinner internally (progress indicator requirementsc, Progress indicators must update at least every 2 seconds)
@@ -289,7 +289,7 @@ func TestPipelineImportURL_MultipleURLs(t *testing.T) {
 	// Download from each URL as separate jobs
 	var jobs []*models.PipelineJob
 	for _, url := range urls {
-		job, _ := pipeline.CreateJob(url, "", config, logger)
+		job, _ := pipeline.CreateJob(models.GenerateJobID(), url, "", config, logger)
 		startedJob := pipeline.StartJob(job)
 		importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 		require.NoError(t, err, "Import should succeed for URL %s", url)
@@ -364,7 +364,7 @@ func TestPipelineImportURL_FilenameFromURL(t *testing.T) {
 
 			// Execute import
 			url := server.URL + tt.urlPath
-			job, _ := pipeline.CreateJob(url, "", config, logger)
+			job, _ := pipeline.CreateJob(models.GenerateJobID(), url, "", config, logger)
 			startedJob := pipeline.StartJob(job)
 			_, _ = pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
 
@@ -407,8 +407,8 @@ func TestPipelineImportURL_ConcurrentDownloads(t *testing.T) {
 	httpClient := services.DefaultHTTPClient()
 
 	// Execute two downloads "concurrently" (sequentially in test, but verify isolation)
-	job1, _ := pipeline.CreateJob(server.URL+"/data1.ndjson", "", config, logger)
-	job2, _ := pipeline.CreateJob(server.URL+"/data2.ndjson", "", config, logger)
+	job1, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/data1.ndjson", "", config, logger)
+	job2, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/data2.ndjson", "", config, logger)
 
 	startedJob1 := pipeline.StartJob(job1)
 	startedJob2 := pipeline.StartJob(job2)

--- a/tests/integration/pipeline_multistep_test.go
+++ b/tests/integration/pipeline_multistep_test.go
@@ -73,7 +73,7 @@ func TestPipelineMultiStep_AutomaticExecution(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create job
-	job, err := pipeline.CreateJob(importDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), importDir, "", config, logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, job.JobID)
 
@@ -190,7 +190,7 @@ func TestPipelineMultiStep_OnlyImportEnabled(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create and start job
-	job, err := pipeline.CreateJob(importDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), importDir, "", config, logger)
 	require.NoError(t, err)
 
 	startedJob := pipeline.StartJob(job)
@@ -311,7 +311,7 @@ func TestPipelineMultiStep_JobStatePersistedBetweenSteps(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create job
-	job, err := pipeline.CreateJob(importDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), importDir, "", config, logger)
 	require.NoError(t, err)
 	jobID := job.JobID
 

--- a/tests/integration/pipeline_resume_test.go
+++ b/tests/integration/pipeline_resume_test.go
@@ -55,7 +55,7 @@ func TestPipelineResume_AfterImportComplete(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Phase 1: Create and start job (SESSION 1 simulation)
-	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	require.NoError(t, err, "CreateJob should succeed")
 	require.NotNil(t, job, "Job should be created")
 
@@ -269,7 +269,7 @@ func createCompletedImportJob(t *testing.T, jobsDir string, fileCount int) *mode
 
 	logger := lib.NewLogger(lib.LogLevelInfo)
 	// Create job
-	job, err := pipeline.CreateJob(tempSourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), tempSourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	// Start job and complete import

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -153,7 +153,7 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// CRTDL is attached via the CRTDL-positional CLI contract, no external
@@ -262,7 +262,7 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -310,7 +310,7 @@ func TestPipeline_TORCHExtraction_ServerUnavailable(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -404,7 +404,7 @@ func TestPipeline_DirectTORCHURL_Download(t *testing.T) {
 
 	// Create job with TORCH result URL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(torchResultURL, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), torchResultURL, "", config, logger)
 	require.NoError(t, err)
 
 	// Verify job was created with correct input type
@@ -497,7 +497,7 @@ func TestPipeline_DirectTORCHURL_EmptyResult(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob(torchResultURL, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), torchResultURL, "", config, logger)
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
@@ -759,7 +759,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Step 1: Create job with CRTDL input
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath)
 
@@ -989,7 +989,7 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// Execute import step (triggers TORCH extraction with preprocessing)
@@ -1159,7 +1159,7 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// PHASE 1: Start extraction (simulate initial job creation)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(jobsDir, job.JobID, "crtdl.json"), job.CRTDLPath)
 
@@ -1298,7 +1298,7 @@ func TestPipeline_TORCHExtraction_PreprocessingError_InvalidEnrichmentsPath(t *t
 	// CRTDL is used by every downstream step). An invalid enrichments path
 	// must therefore be reported by CreateJob, not by the import step.
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	_, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	_, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prepare CRTDL", "Error should mention CRTDL preparation failure")
 	assert.Contains(t, err.Error(), "load enrichments", "Error should surface the underlying enrichments-loading failure")
@@ -1422,7 +1422,7 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// Execute import step - should use original CRTDL without preprocessing
@@ -1624,7 +1624,7 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 
 	// Create job with CRTDL input
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	job, err := pipeline.CreateJob("", crtdlPath, config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
 	require.NoError(t, err)
 
 	// Execute import step - should use original CRTDL content when no enrichments configured

--- a/tests/integration/pipeline_wait_test.go
+++ b/tests/integration/pipeline_wait_test.go
@@ -49,7 +49,7 @@ func TestPipelineWithWaitStep_PausesExecution(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Create and start job
-	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	startedJob := pipeline.StartJob(job)
@@ -114,7 +114,7 @@ func TestPipelineWithWaitStep_DirectoryCreated(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Create, start, and execute import
-	job, err := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	require.NoError(t, err)
 
 	startedJob := pipeline.StartJob(job)
@@ -172,7 +172,7 @@ func TestPipelineWithWaitStep_EmptyDirectory(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Run through pipeline to wait step
-	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
@@ -226,7 +226,7 @@ func TestPipelineWithWaitStep_ContinuesAfterCommand(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Run through import and wait steps
-	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
@@ -306,7 +306,7 @@ func TestWaitStep_ContinueWithFilesPresent(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Create, start, and execute import step
-	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
@@ -393,7 +393,7 @@ func TestWaitStep_ContinueWithEmptyDirectory(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelInfo)
 
 	// Run through import to wait step
-	job, _ := pipeline.CreateJob(sourceDir, "", config, logger)
+	job, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 

--- a/tests/unit/logging_test.go
+++ b/tests/unit/logging_test.go
@@ -1,0 +1,116 @@
+package unit
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// Console respects the configured level, but the attached job log file always
+// captures full DEBUG output regardless of the console level (issue #409).
+func TestLoggerDualSink_ConsoleRespectsLevelFileAlwaysDebug(t *testing.T) {
+	var console bytes.Buffer
+	logger := lib.NewLoggerWithWriter(lib.LogLevelInfo, &console)
+
+	logPath := filepath.Join(t.TempDir(), "job.log")
+	require.NoError(t, logger.AttachJobLogFile(logPath))
+
+	logger.Debug("debug-line")
+	logger.Info("info-line")
+	require.NoError(t, logger.Close())
+
+	fileContent, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	file := string(fileContent)
+
+	// Console: INFO threshold suppresses DEBUG.
+	assert.Contains(t, console.String(), "info-line")
+	assert.NotContains(t, console.String(), "debug-line")
+
+	// File: always captures everything, including DEBUG.
+	assert.Contains(t, file, "info-line")
+	assert.Contains(t, file, "debug-line")
+}
+
+// `pipeline continue` reattaches the same job.log; runs must accumulate rather
+// than overwrite, giving one chronological record per job (issue #409).
+func TestAttachJobLogFile_AppendsAcrossRuns(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "job.log")
+
+	first := lib.NewLoggerWithWriter(lib.LogLevelInfo, &bytes.Buffer{})
+	require.NoError(t, first.AttachJobLogFile(logPath))
+	first.Info("first-run")
+	require.NoError(t, first.Close())
+
+	second := lib.NewLoggerWithWriter(lib.LogLevelInfo, &bytes.Buffer{})
+	require.NoError(t, second.AttachJobLogFile(logPath))
+	second.Info("second-run")
+	require.NoError(t, second.Close())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "first-run")
+	assert.Contains(t, got, "second-run")
+	assert.Less(t, strings.Index(got, "first-run"), strings.Index(got, "second-run"))
+}
+
+// Close on a logger without an attached file must be a safe no-op.
+func TestLoggerClose_NoFileAttached(t *testing.T) {
+	logger := lib.NewLoggerWithWriter(lib.LogLevelInfo, &bytes.Buffer{})
+	assert.NoError(t, logger.Close())
+}
+
+// Re-attaching on the same logger must release the previous handle and route
+// subsequent lines to the new file, so a leaked handle never accumulates.
+func TestAttachJobLogFile_ReattachReleasesPreviousFile(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.log")
+	secondPath := filepath.Join(dir, "second.log")
+
+	logger := lib.NewLoggerWithWriter(lib.LogLevelInfo, &bytes.Buffer{})
+	require.NoError(t, logger.AttachJobLogFile(firstPath))
+	logger.Info("to-first")
+
+	// Re-attach on the SAME logger: exercises the close-previous branch.
+	require.NoError(t, logger.AttachJobLogFile(secondPath))
+	logger.Info("to-second")
+	require.NoError(t, logger.Close())
+
+	firstContent, err := os.ReadFile(firstPath)
+	require.NoError(t, err)
+	secondContent, err := os.ReadFile(secondPath)
+	require.NoError(t, err)
+
+	// First file froze at re-attach; second file received the later line only.
+	assert.Contains(t, string(firstContent), "to-first")
+	assert.NotContains(t, string(firstContent), "to-second")
+	assert.Contains(t, string(secondContent), "to-second")
+	assert.NotContains(t, string(secondContent), "to-first")
+}
+
+// A path whose parent directory does not exist cannot be opened (O_CREATE does
+// not create intermediate dirs); the error must be wrapped with the path.
+func TestAttachJobLogFile_OpenError(t *testing.T) {
+	badPath := filepath.Join(t.TempDir(), "missing-dir", "job.log")
+
+	logger := lib.NewLoggerWithWriter(lib.LogLevelInfo, &bytes.Buffer{})
+	err := logger.AttachJobLogFile(badPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening job log file")
+	assert.Contains(t, err.Error(), badPath)
+}
+
+func TestGetJobLogFilePath(t *testing.T) {
+	got := services.GetJobLogFilePath("/data/jobs", "20260101_1200_abc")
+	assert.Equal(t, filepath.Join("/data/jobs", "20260101_1200_abc", "job.log"), got)
+}

--- a/tests/unit/pipeline_job_test.go
+++ b/tests/unit/pipeline_job_test.go
@@ -282,13 +282,39 @@ func TestCreateJob_EmptyInputSource(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Create job with empty input source
-	job, err := pipeline.CreateJob("", "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", "", config, logger)
 
 	require.NoError(t, err, "CreateJob should succeed with empty input source")
 	assert.NotNil(t, job)
 	assert.Equal(t, models.InputTypeLocal, job.InputType, "Input type should be local")
 	assert.Equal(t, "", job.InputSource, "Input source should be empty")
 	assert.Equal(t, string(models.StepLocalImport), job.CurrentStep, "Current step should be local_import")
+}
+
+// TestCreateJob_DoesNotAttachJobLog pins the contract that CreateJob keeps the
+// logger side effect out: attaching per-job logging is the caller's job, so
+// CreateJob must not create job.log on its own.
+func TestCreateJob_DoesNotAttachJobLog(t *testing.T) {
+	tmpDir := t.TempDir()
+	jobsDir := filepath.Join(tmpDir, "jobs")
+
+	config := models.ProjectConfig{
+		JobsDir: jobsDir,
+		Pipeline: models.PipelineConfig{
+			EnabledSteps: []models.StepName{models.StepLocalImport},
+		},
+		Services: models.ServiceConfig{
+			LocalImport: models.LocalImportConfig{Dir: filepath.Join(tmpDir, "local_import")},
+		},
+	}
+
+	jobID := models.GenerateJobID()
+	_, err := pipeline.CreateJob(jobID, "", "", config, lib.NewLogger(lib.LogLevelDebug))
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(services.GetJobLogFilePath(jobsDir, jobID))
+	assert.True(t, os.IsNotExist(statErr),
+		"CreateJob must not create job.log; the caller owns log attachment")
 }
 
 // TestCreateJob_FailsWhenSaveStateAfterCRTDLPreparationFails covers job.go
@@ -344,7 +370,7 @@ func TestCreateJob_FailsWhenSaveStateAfterCRTDLPreparationFails(t *testing.T) {
 	}
 	services.StateFileOpsProvider = ops
 
-	job, err := pipeline.CreateJob(crtdlPath, "", config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob(models.GenerateJobID(), crtdlPath, "", config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.Error(t, err, "CreateJob must surface the second SaveJobState failure")
 	assert.Nil(t, job)
@@ -369,7 +395,7 @@ func TestCreateJob_NoImportStepEnabled(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Create job - should fail because no import step is enabled
-	job, err := pipeline.CreateJob("/some/path", "", config, logger)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "/some/path", "", config, logger)
 
 	require.Error(t, err, "CreateJob should fail when no import step is enabled")
 	assert.Nil(t, job)
@@ -401,7 +427,7 @@ func TestCreateJob_CRTDLFlagWithHTTPInput(t *testing.T) {
 		},
 	}
 
-	job, err := pipeline.CreateJob("https://example.com/data.ndjson", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "https://example.com/data.ndjson", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.NoError(t, err)
 	require.NotNil(t, job)
@@ -429,7 +455,7 @@ func TestCreateJob_TorchCRTDLOnly(t *testing.T) {
 		},
 	}
 
-	job, err := pipeline.CreateJob("", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.NoError(t, err)
 	require.NotNil(t, job)
@@ -453,7 +479,7 @@ func TestCreateJob_InvalidCRTDL(t *testing.T) {
 		},
 	}
 
-	job, err := pipeline.CreateJob("https://example.com/data.ndjson", missingCRTDL, config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "https://example.com/data.ndjson", missingCRTDL, config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.Error(t, err, "CreateJob must fail when CRTDL file is unreadable")
 	assert.Nil(t, job)
@@ -478,7 +504,7 @@ func TestCreateJob_CRTDLFlagOnlyNoPositional(t *testing.T) {
 		},
 	}
 
-	job, err := pipeline.CreateJob("", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, lib.NewLogger(lib.LogLevelDebug))
 
 	require.NoError(t, err)
 	require.NotNil(t, job)


### PR DESCRIPTION
## Summary

Persists each job's logs to `jobs/<job-id>/job.log` so a job's diagnostics live alongside its state and data (issue #409).

The `lib.Logger` now fans out to two independent sinks:
- **Console sink** — keeps respecting `--verbose` (INFO default, DEBUG with `-v`).
- **File sink** — always records full **DEBUG**, so `job.log` is a complete diagnostic record regardless of console verbosity.

The file is opened in **append mode**, so `pipeline continue` extends one chronological record per job rather than overwriting it. The feature is always on (no config knob).

## Changes
- `internal/lib/logging.go` — dual-sink `Logger` with `AttachJobLogFile` / `Close`; `NewLoggerWithWriter` for testable console capture.
- `internal/services/state.go` — `JobLogFileName` + `GetJobLogFilePath` helper, alongside `GetStateFilePath`.
- `internal/pipeline/job.go` — `CreateJob` creates the job dir and attaches the log file up front, capturing all creation-time diagnostics.
- `cmd/pipeline.go` — `runPipelineStart`/`runPipelineContinue` close the logger on exit; `continue` re-attaches in append mode.
- `tests/unit/logging_test.go` — dual-sink level filtering, append-across-runs, `Close` no-op, path helper.

Closes #409