### PR TITLE
Rename DIMP step output directory from pseudonymized to dimp

### DIFF
--- a/.github/scripts/run-flattening-e2e-test.sh
+++ b/.github/scripts/run-flattening-e2e-test.sh
@@ -33,13 +33,13 @@ echo "Creating job: $JOB_ID"
 echo "Setting up pre-staged job state..."
 docker compose exec -T aether-runner sh -c "
     mkdir -p /app/jobs/$JOB_ID/import
-    mkdir -p /app/jobs/$JOB_ID/pseudonymized
+    mkdir -p /app/jobs/$JOB_ID/dimp
 
     # Copy NDJSON files to import directory (original data with Provenance)
     cp /app/example-flattening/testdata/fhir-data.ndjson /app/jobs/$JOB_ID/import/
 
-    # Copy NDJSON files to pseudonymized directory (simulating completed DIMP step)
-    cp /app/example-flattening/testdata/fhir-data.ndjson /app/jobs/$JOB_ID/pseudonymized/
+    # Copy NDJSON files to dimp directory (simulating completed DIMP step)
+    cp /app/example-flattening/testdata/fhir-data.ndjson /app/jobs/$JOB_ID/dimp/
 "
 
 # Create state.json with proper variable expansion

--- a/.github/scripts/verify-e2e-output.sh
+++ b/.github/scripts/verify-e2e-output.sh
@@ -145,15 +145,15 @@ verify_job() {
         success "Job ${job_id}: ${valid_files} valid NDJSON file(s) verified"
     fi
 
-    # Check for pseudonymized directory (if DIMP step was enabled)
-    local pseudo_dir="${job_dir}/pseudonymized"
-    if [[ -d "${pseudo_dir}" ]]; then
-        info "Job ${job_id}: pseudonymized directory exists"
-        local pseudo_count=$(find "${pseudo_dir}" \( -name "*.ndjson" -o -name "*.ndjson.zst" \) -type f | wc -l)
-        if [[ ${pseudo_count} -gt 0 ]]; then
-            success "Job ${job_id}: Found ${pseudo_count} pseudonymized file(s)"
+    # Check for dimp directory (if DIMP step was enabled)
+    local dimp_dir="${job_dir}/dimp"
+    if [[ -d "${dimp_dir}" ]]; then
+        info "Job ${job_id}: dimp directory exists"
+        local dimp_count=$(find "${dimp_dir}" \( -name "*.ndjson" -o -name "*.ndjson.zst" \) -type f | wc -l)
+        if [[ ${dimp_count} -gt 0 ]]; then
+            success "Job ${job_id}: Found ${dimp_count} pseudonymized file(s)"
         else
-            warn "Job ${job_id}: pseudonymized directory exists but contains no NDJSON files"
+            warn "Job ${job_id}: dimp directory exists but contains no NDJSON files"
         fi
     fi
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -161,7 +161,7 @@ ls -la jobs/<job-id>/
 jobs/<job-id>/
 ├── state.json          # Job state (status, steps, retry counts)
 ├── import/             # Imported FHIR files (13 files)
-├── pseudonymized/      # DIMP output (when implemented)
+├── dimp/              # DIMP output (when implemented)
 ├── csv/                # CSV output (when implemented)
 └── parquet/            # Parquet output (when implemented)
 ```

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -143,7 +143,7 @@ aether/
 jobs/{job-uuid}/
 ├── state.json              ✓ Job state (atomic writes)
 ├── import/                 ✓ Imported FHIR files (13 files)
-├── pseudonymized/          ✓ DIMP output (Phase 5)
+├── dimp/                  ✓ DIMP output (Phase 5)
 ├── csv/                    ✓ CSV conversion (Phase 6)
 └── parquet/                ✓ Parquet conversion (Phase 6)
 ```

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -181,7 +181,7 @@ jobs/
     ├── validation/
     │   ├── Patient.validation.ndjson     # OperationOutcome reports
     │   └── Observation.validation.ndjson
-    ├── pseudonymized/
+    ├── dimp/
     │   ├── Patient.ndjson.zst    # De-identified data (zstd)
     │   └── Observation.ndjson.zst
     └── logs.txt                  # Execution logs

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -38,7 +38,7 @@ Aether will:
 2. Wait for extraction to complete
 3. Download the FHIR data
 4. Pseudonymize it via DIMP
-5. Save results in `jobs/<job-id>/pseudonymized/`
+5. Save results in `jobs/<job-id>/dimp/`
 
 Output files use `.ndjson.zst` extension (zstd compressed).
 

--- a/docs/guides/steps/dimp.md
+++ b/docs/guides/steps/dimp.md
@@ -40,4 +40,4 @@ Large FHIR Bundles are automatically split to prevent HTTP 413 errors:
 
 ## Output
 
-Pseudonymized files are saved to `jobs/<job-id>/pseudonymized/`
+Pseudonymized files are saved to `jobs/<job-id>/dimp/`

--- a/docs/guides/steps/wait.md
+++ b/docs/guides/steps/wait.md
@@ -46,6 +46,6 @@ aether pipeline continue aether.yaml <job-id>
 The wait directory is created empty. You must place your data files there before continuing:
 
 - After import step: `jobs/<job-id>/import_wait/`
-- After DIMP step: `jobs/<job-id>/pseudonymized_wait/`
+- After DIMP step: `jobs/<job-id>/dimp_wait/`
 
 The pipeline will only continue when files are present in the wait directory.

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ExecuteDIMPStep processes FHIR resources through the DIMP pseudonymization service
-// Reads from import/ directory, writes to pseudonymized/ directory
+// Reads from import/ directory, writes to dimp/ directory
 // Orchestrates Bundle splitting and oversized resource detection before pseudonymization
 func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
 	stepName := models.StepDIMP
@@ -48,7 +48,7 @@ func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger)
 	jobID := filepath.Base(jobDir)
 	stepIndex := getStepIndexInEnabledSteps(job.Config.Pipeline.EnabledSteps, stepName)
 	importDir := services.GetStepInputDir(jobsBaseDir, jobID, job.Config.Pipeline.EnabledSteps, stepIndex)
-	outputDir := filepath.Join(jobDir, "pseudonymized")
+	outputDir := filepath.Join(jobDir, "dimp")
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -23,7 +23,7 @@ type groupBatch struct {
 }
 
 // ExecuteFlatteningStep transforms FHIR NDJSON data into CSV files using the fhir-flattener API
-// Reads from pseudonymized/ (if DIMP enabled) or import/ directory
+// Reads from dimp/ (if DIMP enabled) or import/ directory
 // Outputs to csv/ directory
 func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
 	stepName := models.StepFlattening

--- a/internal/services/state.go
+++ b/internal/services/state.go
@@ -165,7 +165,7 @@ func EnsureJobDirs(jobsBaseDir string, jobID string) (map[models.StepName]string
 		models.StepTorchImport: filepath.Join(jobDir, "import"),
 		models.StepLocalImport: filepath.Join(jobDir, "import"),
 		models.StepHttpImport:  filepath.Join(jobDir, "import"),
-		models.StepDIMP:        filepath.Join(jobDir, "pseudonymized"),
+		models.StepDIMP:        filepath.Join(jobDir, "dimp"),
 		models.StepValidation:  filepath.Join(jobDir, "validation"),
 		models.StepFlattening:  filepath.Join(jobDir, "csv"),
 		models.StepSend:        filepath.Join(jobDir, "send"),
@@ -188,7 +188,7 @@ func GetJobOutputDir(jobsBaseDir string, jobID string, step models.StepName) str
 	case models.StepTorchImport, models.StepLocalImport, models.StepHttpImport:
 		return filepath.Join(jobDir, "import")
 	case models.StepDIMP:
-		return filepath.Join(jobDir, "pseudonymized")
+		return filepath.Join(jobDir, "dimp")
 	case models.StepValidation:
 		return filepath.Join(jobDir, "validation")
 	case models.StepFlattening:

--- a/tests/integration/pipeline_dimp_consistency_test.go
+++ b/tests/integration/pipeline_dimp_consistency_test.go
@@ -36,7 +36,7 @@ func TestDIMPConsistency_SplitVsUnsplit(t *testing.T) {
 		jobID := "test-unsplit"
 		jobDir := filepath.Join(tmpDir, "jobs", jobID)
 		importDir := filepath.Join(jobDir, "import")
-		pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+		pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 		require.NoError(t, os.MkdirAll(importDir, 0755))
 		require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
@@ -99,7 +99,7 @@ func TestDIMPConsistency_SplitVsUnsplit(t *testing.T) {
 		jobID := "test-split"
 		jobDir := filepath.Join(tmpDir, "jobs", jobID)
 		importDir := filepath.Join(jobDir, "import")
-		pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+		pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 		require.NoError(t, os.MkdirAll(importDir, 0755))
 		require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))

--- a/tests/integration/pipeline_dimp_resume_test.go
+++ b/tests/integration/pipeline_dimp_resume_test.go
@@ -84,7 +84,7 @@ func TestDIMPResumeAfterInterrupt(t *testing.T) {
 	require.NoError(t, pipeline.UpdateJob(jobsDir, advancedJob))
 
 	// Create output directory (simulating partial processing)
-	outputDir := filepath.Join(jobsDir, job.JobID, "pseudonymized")
+	outputDir := filepath.Join(jobsDir, job.JobID, "dimp")
 	require.NoError(t, os.MkdirAll(outputDir, 0755))
 
 	// SIMULATE INTERRUPTION: Process only the first file manually

--- a/tests/integration/pipeline_dimp_split_test.go
+++ b/tests/integration/pipeline_dimp_split_test.go
@@ -33,7 +33,7 @@ func TestDIMPStepWithLargeBundle(t *testing.T) {
 	jobID := "test-large-bundle-split"
 	jobDir := filepath.Join(tmpDir, "jobs", jobID)
 	importDir := filepath.Join(jobDir, "import")
-	pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 	require.NoError(t, os.MkdirAll(importDir, 0755), "Failed to create import directory")
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755), "Failed to create pseudonymized directory")
@@ -142,7 +142,7 @@ func TestDIMPStepWithLargeBundleAndChunks(t *testing.T) {
 	jobID := "test-bundle-chunks"
 	jobDir := filepath.Join(tmpDir, "jobs", jobID)
 	importDir := filepath.Join(jobDir, "import")
-	pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
@@ -221,7 +221,7 @@ func TestDIMPStepWithSmallBundleNoSplit(t *testing.T) {
 	jobID := "test-small-bundle-nosplit"
 	jobDir := filepath.Join(tmpDir, "jobs", jobID)
 	importDir := filepath.Join(jobDir, "import")
-	pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
@@ -443,7 +443,7 @@ func TestDIMPStepWithOversizedResource(t *testing.T) {
 	jobID := "test-oversized-resource"
 	jobDir := filepath.Join(tmpDir, "jobs", jobID)
 	importDir := filepath.Join(jobDir, "import")
-	pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 	require.NoError(t, os.MkdirAll(importDir, 0755), "Failed to create import directory")
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755), "Failed to create pseudonymized directory")
@@ -528,7 +528,7 @@ func TestDIMPStepWithCustomThreshold(t *testing.T) {
 		jobID := "test-threshold-5mb"
 		jobDir := filepath.Join(tmpDir, "jobs", jobID)
 		importDir := filepath.Join(jobDir, "import")
-		pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+		pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 		require.NoError(t, os.MkdirAll(importDir, 0755))
 		require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
@@ -579,7 +579,7 @@ func TestDIMPStepWithCustomThreshold(t *testing.T) {
 		jobID := "test-threshold-20mb"
 		jobDir := filepath.Join(tmpDir, "jobs", jobID)
 		importDir := filepath.Join(jobDir, "import")
-		pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+		pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 		require.NoError(t, os.MkdirAll(importDir, 0755))
 		require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
@@ -630,7 +630,7 @@ func TestDIMPStepWithCustomThreshold(t *testing.T) {
 		jobID := "test-threshold-1mb"
 		jobDir := filepath.Join(tmpDir, "jobs", jobID)
 		importDir := filepath.Join(jobDir, "import")
-		pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+		pseudonymizedDir := filepath.Join(jobDir, "dimp")
 
 		require.NoError(t, os.MkdirAll(importDir, 0755))
 		require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))

--- a/tests/integration/pipeline_multistep_test.go
+++ b/tests/integration/pipeline_multistep_test.go
@@ -118,7 +118,7 @@ func TestPipelineMultiStep_AutomaticExecution(t *testing.T) {
 	assert.Equal(t, models.StepStatusCompleted, dimpStep.Status, "DIMP step should be completed")
 
 	// Verify pseudonymized files were created
-	pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobDir, "dimp")
 	entries, err := os.ReadDir(pseudonymizedDir)
 	require.NoError(t, err)
 	assert.NotEmpty(t, entries, "Pseudonymized directory should contain files")

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -824,7 +824,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Step 7: Verify DIMP output contains the MODIFIED data (not the original)
-	pseudonymizedDir := filepath.Join(jobsDir, dimpReadyJob.JobID, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobsDir, dimpReadyJob.JobID, "dimp")
 	dimpFiles, err := os.ReadDir(pseudonymizedDir)
 	require.NoError(t, err)
 	require.NotEmpty(t, dimpFiles, "Should have pseudonymized output files")

--- a/tests/unit/pipeline_dimp_test.go
+++ b/tests/unit/pipeline_dimp_test.go
@@ -141,7 +141,7 @@ func TestExecuteDIMPStep_FailedToCreateOutputDir(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	// Create a file where we need a directory
-	pseudonymizedPath := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedPath := filepath.Join(tmpDir, "dimp")
 	f, cerr := os.Create(pseudonymizedPath)
 	require.NoError(t, cerr)
 	require.NoError(t, f.Close())
@@ -193,7 +193,7 @@ func TestExecuteDIMPStep_ProcessSimpleResources(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file was created
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_patients.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson")
 	assert.FileExists(t, outputFile)
 
 	// Verify pseudonymized content
@@ -214,7 +214,7 @@ func TestExecuteDIMPStep_ResumeProcessing(t *testing.T) {
 
 	// Create import and pseudonymized directories
 	importDir := filepath.Join(tmpDir, "import")
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
@@ -299,7 +299,7 @@ func TestExecuteDIMPStep_ProcessBundleWithoutSplit(t *testing.T) {
 	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
 	assert.NoError(t, err)
 
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_bundles.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
 	assert.FileExists(t, outputFile)
 }
 
@@ -324,7 +324,7 @@ func TestExecuteDIMPStep_ProcessBundleWithSplit(t *testing.T) {
 	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
 	assert.NoError(t, err)
 
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_bundles.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
 	assert.FileExists(t, outputFile)
 }
 
@@ -377,7 +377,7 @@ func TestExecuteDIMPStep_MultipleFiles(t *testing.T) {
 
 	// Verify all output files were created
 	for _, filename := range files {
-		outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_"+filename)
+		outputFile := filepath.Join(tmpDir, "dimp", "dimped_"+filename)
 		assert.FileExists(t, outputFile)
 	}
 }
@@ -438,7 +438,7 @@ func TestExecuteDIMPStep_EmptyLines(t *testing.T) {
 	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
 	assert.NoError(t, err)
 
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_sparse.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_sparse.ndjson")
 	resources := readDIMPNDJSON(t, outputFile)
 	assert.Len(t, resources, 2) // Should have 2 resources, skipping empty line
 }
@@ -537,7 +537,7 @@ func TestExecuteDIMPStep_DefaultBundleThreshold(t *testing.T) {
 	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
 	assert.NoError(t, err)
 
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_bundles.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
 	assert.FileExists(t, outputFile)
 }
 
@@ -613,7 +613,7 @@ func TestExecuteDIMPStep_AlreadyProcessedFileCountError(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	importDir := filepath.Join(tmpDir, "import")
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
@@ -705,7 +705,7 @@ func TestExecuteDIMPStep_VeryLargeBundle(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file was created
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_large_bundle.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_large_bundle.ndjson")
 	assert.FileExists(t, outputFile)
 }
 
@@ -734,7 +734,7 @@ func TestExecuteDIMPStep_MixedResourceTypes(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file exists and has all resources
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_mixed.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_mixed.ndjson")
 	assert.FileExists(t, outputFile)
 
 	outputResources := readDIMPNDJSON(t, outputFile)
@@ -780,7 +780,7 @@ func TestExecuteDIMPStep_BundleWithError(t *testing.T) {
 	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
 	assert.NoError(t, err)
 
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_bundles.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
 	assert.FileExists(t, outputFile)
 
 	// Verify the output is a valid Bundle
@@ -814,7 +814,7 @@ func TestExecuteDIMPStep_LargeNumberOfFiles(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify all files were processed
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	files, err := filepath.Glob(filepath.Join(pseudonymizedDir, "dimped_*.ndjson"))
 	require.NoError(t, err)
 	assert.Len(t, files, fileCount)
@@ -842,7 +842,7 @@ func TestExecuteDIMPStep_SpecialCharactersInFilenames(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file exists
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_test_data-2025-01-01.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_test_data-2025-01-01.ndjson")
 	assert.FileExists(t, outputFile)
 }
 
@@ -877,7 +877,7 @@ func TestExecuteDIMPStep_WithCompression(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file was created with compression extension
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_patients.ndjson.zst")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson.zst")
 	assert.FileExists(t, outputFile)
 
 	// Verify content is readable as compressed
@@ -925,7 +925,7 @@ func TestExecuteDIMPStep_CompressedInput(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file was created (uncompressed)
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_patients.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson")
 	assert.FileExists(t, outputFile)
 
 	resources := readDIMPNDJSON(t, outputFile)
@@ -968,7 +968,7 @@ func TestExecuteDIMPStep_CompressedInputToCompressedOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file was created with compression extension
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_patients.ndjson.zst")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson.zst")
 	assert.FileExists(t, outputFile)
 
 	// Verify content
@@ -1011,7 +1011,7 @@ func TestExecuteDIMPStep_MixedInputFiles(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify both output files were created with compression
-	outputDir := filepath.Join(tmpDir, "pseudonymized")
+	outputDir := filepath.Join(tmpDir, "dimp")
 	assert.FileExists(t, filepath.Join(outputDir, "dimped_patients.ndjson.zst"))
 	assert.FileExists(t, filepath.Join(outputDir, "dimped_observations.ndjson.zst"))
 }
@@ -1041,7 +1041,7 @@ func TestExecuteDIMPStep_CompressionAllLevels(t *testing.T) {
 			err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
 			assert.NoError(t, err, "DIMP should succeed with compression level: %s", level)
 
-			outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_patients.ndjson.zst")
+			outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson.zst")
 			assert.FileExists(t, outputFile)
 		})
 	}
@@ -1088,7 +1088,7 @@ func TestExecuteDIMPStep_ResumeWithCompressedOutput(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	importDir := filepath.Join(tmpDir, "import")
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
@@ -1138,7 +1138,7 @@ func TestExecuteDIMPStep_StalePartFileRemovalError(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	importDir := filepath.Join(tmpDir, "import")
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
@@ -1178,7 +1178,7 @@ func TestExecuteDIMPStep_CountResourcesError(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	importDir := filepath.Join(tmpDir, "import")
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
@@ -1269,7 +1269,7 @@ func TestExecuteDIMPStep_LongLine(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify output file was created
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_long.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_long.ndjson")
 	assert.FileExists(t, outputFile)
 }
 
@@ -1283,7 +1283,7 @@ func TestExecuteDIMPStep_StalePartFileRemoval(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	importDir := filepath.Join(tmpDir, "import")
-	pseudonymizedDir := filepath.Join(tmpDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(tmpDir, "dimp")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
@@ -1304,7 +1304,7 @@ func TestExecuteDIMPStep_StalePartFileRemoval(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), ".part file should be removed")
 
 	// Verify output file exists
-	outputFile := filepath.Join(tmpDir, "pseudonymized", "dimped_patients.ndjson")
+	outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson")
 	assert.FileExists(t, outputFile)
 }
 

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -1220,7 +1220,7 @@ func TestExecuteFlatteningStep_ProvenanceInPseudonymizedDir(t *testing.T) {
 	tempDir := t.TempDir()
 	jobID := "test-provenance-pseudonymized"
 	jobDir := filepath.Join(tempDir, "jobs", jobID)
-	pseudonymizedDir := filepath.Join(jobDir, "pseudonymized")
+	pseudonymizedDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(pseudonymizedDir, 0755))
 
 	groupID := "group-patient"

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -1257,7 +1257,7 @@ func TestExecuteSendStep_FHIR_Success(t *testing.T) {
 	jobDir := filepath.Join(tmpDir, jobID)
 
 	// Create input directory with NDJSON file
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Write test NDJSON file with multiple resources
@@ -1328,7 +1328,7 @@ func TestExecuteSendStep_FHIR_CoreFilesFirst(t *testing.T) {
 	jobID := "test-fhir-core-order"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Write files in alphabetical order, but core.ndjson should be processed first
@@ -1368,7 +1368,7 @@ func TestExecuteSendStep_FHIR_CompressedFiles(t *testing.T) {
 	jobID := "test-fhir-compressed"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Write compressed NDJSON file
@@ -1403,7 +1403,7 @@ func TestExecuteSendStep_FHIR_NoFiles(t *testing.T) {
 	jobDir := filepath.Join(tmpDir, jobID)
 
 	// Create input directory but don't add any NDJSON files
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	// Add a non-NDJSON file
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "data.csv"), []byte("data"), 0644))
@@ -1427,7 +1427,7 @@ func TestExecuteSendStep_FHIR_ServerError(t *testing.T) {
 	jobID := "test-fhir-server-error"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"), []byte(`{"resourceType":"Patient","id":"1"}`+"\n"), 0644))
 
@@ -1464,7 +1464,7 @@ func TestExecuteSendStep_FHIR_BadRequest(t *testing.T) {
 	jobID := "test-fhir-bad-request"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"), []byte(`{"resourceType":"Patient","id":"1"}`+"\n"), 0644))
 
@@ -1500,7 +1500,7 @@ func TestExecuteSendStep_FHIR_WithAuth(t *testing.T) {
 	jobID := "test-fhir-auth"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"), []byte(`{"resourceType":"Patient","id":"1"}`+"\n"), 0644))
 
@@ -1599,7 +1599,7 @@ func TestExecuteSendStep_FHIR_CoreAndCompressed(t *testing.T) {
 	jobID := "test-fhir-core-compressed"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Write core.ndjson.zst (compressed core file)
@@ -1636,7 +1636,7 @@ func TestExecuteSendStep_S3_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-success"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"), []byte(`{"resourceType":"Patient","id":"1"}`+"\n"), 0644))
@@ -1686,7 +1686,7 @@ func TestExecuteSendStep_S3_NoFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-empty"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	// No files in directory
 
@@ -1710,7 +1710,7 @@ func TestExecuteSendStep_S3_UploadError(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-upload-error"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte("data\n"), 0644))
 
@@ -1745,7 +1745,7 @@ func TestExecuteSendStep_S3_ManifestRetry(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-manifest-retry"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	file1 := filepath.Join(inputDir, "Patient.ndjson")
@@ -1791,7 +1791,7 @@ func TestExecuteSendStep_S3_SubdirectoryFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-subdirs"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	subDir := filepath.Join(inputDir, "nested")
 	require.NoError(t, os.MkdirAll(subDir, 0755))
 
@@ -1863,7 +1863,7 @@ func TestExecuteSendStep_S3_TransientError(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-transient"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte("data\n"), 0644))
 
@@ -2051,7 +2051,7 @@ func TestExecuteSendStep_FHIR_FileOpenError(t *testing.T) {
 	jobID := "test-fhir-file-open-error"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Create a file and make it unreadable
@@ -2102,7 +2102,7 @@ func TestExecuteSendStep_FHIR_CloseWarning(t *testing.T) {
 	jobID := "test-fhir-close-warning"
 	jobDir := filepath.Join(tmpDir, jobID)
 
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 
 	// Write a normal file - the close should work fine
@@ -2149,7 +2149,7 @@ func TestExecuteSendStep_S3_UploaderFactoryError(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-factory-error"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte("data\n"), 0644))
 
@@ -2171,7 +2171,7 @@ func TestExecuteSendStep_S3_CorruptedManifest(t *testing.T) {
 	tmpDir := t.TempDir()
 	jobID := "test-s3-corrupted-manifest"
 	jobDir := filepath.Join(tmpDir, jobID)
-	inputDir := filepath.Join(jobDir, "pseudonymized")
+	inputDir := filepath.Join(jobDir, "dimp")
 	require.NoError(t, os.MkdirAll(inputDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte("data\n"), 0644))
 

--- a/tests/unit/state_persistence_test.go
+++ b/tests/unit/state_persistence_test.go
@@ -27,7 +27,7 @@ func TestGetJobOutputDir(t *testing.T) {
 		{models.StepLocalImport, "/tmp/jobs/test-job-123/import"},
 		{models.StepTorchImport, "/tmp/jobs/test-job-123/import"},
 		{models.StepHttpImport, "/tmp/jobs/test-job-123/import"},
-		{models.StepDIMP, "/tmp/jobs/test-job-123/pseudonymized"},
+		{models.StepDIMP, "/tmp/jobs/test-job-123/dimp"},
 		{models.StepFlattening, "/tmp/jobs/test-job-123/csv"},
 		{models.StepSend, "/tmp/jobs/test-job-123/send"},
 		{models.StepWait, "/tmp/jobs/test-job-123"},

--- a/tests/unit/wait_step_test.go
+++ b/tests/unit/wait_step_test.go
@@ -95,7 +95,7 @@ func TestGetWaitStepDir(t *testing.T) {
 		{
 			name:        "After DIMP",
 			prevStep:    models.StepDIMP,
-			expectedDir: "/tmp/jobs/test-job-123/pseudonymized_wait",
+			expectedDir: "/tmp/jobs/test-job-123/dimp_wait",
 		},
 	}
 
@@ -665,10 +665,10 @@ func TestGetStepInputDir_AfterValidation(t *testing.T) {
 			expectedDir: "/tmp/jobs/test-job/import",
 		},
 		{
-			name:        "Step after validation reads from pseudonymized",
+			name:        "Step after validation reads from dimp",
 			steps:       []models.StepName{models.StepLocalImport, models.StepDIMP, models.StepValidation, models.StepFlattening},
 			stepIndex:   3,
-			expectedDir: "/tmp/jobs/test-job/pseudonymized",
+			expectedDir: "/tmp/jobs/test-job/dimp",
 		},
 		{
 			name:        "Validation itself reads from import",
@@ -677,10 +677,10 @@ func TestGetStepInputDir_AfterValidation(t *testing.T) {
 			expectedDir: "/tmp/jobs/test-job/import",
 		},
 		{
-			name:        "Validation reads from pseudonymized after DIMP",
+			name:        "Validation reads from dimp after DIMP",
 			steps:       []models.StepName{models.StepLocalImport, models.StepDIMP, models.StepValidation},
 			stepIndex:   2,
-			expectedDir: "/tmp/jobs/test-job/pseudonymized",
+			expectedDir: "/tmp/jobs/test-job/dimp",
 		},
 	}
 


### PR DESCRIPTION
## Summary
The DIMP step wrote its output to `jobs/<job-id>/pseudonymized/`. This renames the directory to `jobs/<job-id>/dimp/` so it matches the step name (`StepDIMP = "dimp"`) and aligns with the other per-step output directories.

## Changes
- `internal/services/state.go` — directory string in `EnsureJobDirs` and `GetJobOutputDir`
- `internal/pipeline/dimp.go` — output directory + doc comment
- `internal/pipeline/flattening.go` — doc comment
- Wait directory derivation now yields `dimp_wait/` (no code change needed; derived from step output dir)
- All unit/integration tests asserting these paths
- Docs describing the job directory layout

## Notes
- Variable names referring to the pseudonymized *data* (`pseudonymized`, `pseudonymizedChunks`, etc.) are intentionally left unchanged — only the output **directory** name changes.
- Kept the literal `"dimp"` rather than `string(models.StepDIMP)`: the dir→step mapping is not 1:1 (e.g. import/csv differ), so coupling only this dir to the constant would be misleading.
- **No backward-compatibility fallback** (per decision): in-flight jobs created before this change must be restarted, since resume now looks for `dimp/`.

Closes #408