### PR TITLE
ci(docs): declare esbuild so npm ci works, restoring pinned deps (#413)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -104,7 +104,7 @@ jobs:
           cache-dependency-path: 'docs/package-lock.json'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: docs
 
       - name: Build documentation
@@ -118,9 +118,6 @@ jobs:
 
       - name: Checkout gh-pages branch
         run: |
-          # `npm install` may refresh docs/package-lock.json (integrity hashes,
-          # metadata). Discard that mutation so the branch switch doesn't abort.
-          git checkout -- docs/package-lock.json
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
           if git rev-parse --verify gh-pages >/dev/null 2>&1; then
             git checkout gh-pages

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,6 +12,7 @@
         "vue": "^3.5.0"
       },
       "devDependencies": {
+        "esbuild": "^0.28.0",
         "vite": "8.0.14"
       }
     },
@@ -390,8 +391,9 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "aix"
       ],
@@ -406,8 +408,9 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -422,8 +425,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -438,8 +442,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "android"
       ],
@@ -454,8 +459,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -470,8 +476,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -486,8 +493,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -502,8 +510,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "freebsd"
       ],
@@ -518,8 +527,9 @@
       "cpu": [
         "arm"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -534,8 +544,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -550,8 +561,9 @@
       "cpu": [
         "ia32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -566,8 +578,9 @@
       "cpu": [
         "loong64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -582,8 +595,9 @@
       "cpu": [
         "mips64el"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -598,8 +612,9 @@
       "cpu": [
         "ppc64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -614,8 +629,9 @@
       "cpu": [
         "riscv64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -630,8 +646,9 @@
       "cpu": [
         "s390x"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -646,8 +663,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -662,8 +680,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -678,8 +697,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "netbsd"
       ],
@@ -694,8 +714,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -710,8 +731,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openbsd"
       ],
@@ -726,8 +748,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "openharmony"
       ],
@@ -742,8 +765,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "sunos"
       ],
@@ -758,8 +782,9 @@
       "cpu": [
         "arm64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -774,8 +799,9 @@
       "cpu": [
         "ia32"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -790,8 +816,9 @@
       "cpu": [
         "x64"
       ],
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ],
@@ -2033,7 +2060,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "extraneous": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "vue": "^3.5.0"
   },
   "devDependencies": {
+    "esbuild": "^0.28.0",
     "vite": "8.0.14"
   }
 }


### PR DESCRIPTION
Addresses OpenSSF Scorecard findings from #413.

## Alert 21 — Pinned-Dependencies (code fix, this PR)
`docs-deploy.yml` used `npm install`, which Scorecard flags as unpinned. The earlier switch to `npm ci` (#371) was reverted (#373) because `npm ci` died in CI with `EBADPLATFORM` on `@esbuild/aix-ppc64`.

**Root cause:** vite@8 declares `esbuild` only as an *optional peer dependency*, so esbuild landed in the lockfile as `extraneous` with its full platform `optionalDependencies`. npm 11.x in CI refused the wrong-platform entry instead of skipping it.

**Fix:** declare `esbuild ^0.28.0` (within vite's `^0.27.0 || ^0.28.0` range) as a direct devDependency. Its platform binaries become real `dev+optional` deps (no longer extraneous), so `npm ci` skips non-matching OS/CPU correctly. Switched back to `npm ci` and dropped the now-obsolete lockfile-discard workaround (`npm ci` never mutates the lockfile).

Verified locally: `npm ci` and `npm run docs:build` both succeed; lockfile diff is only the esbuild declaration plus `extraneous`→`dev/optional` flag flips (no version bumps).

> Note: the `EBADPLATFORM` bug reproduces only in CI, not locally. `docs-deploy` runs on push-to-main / `workflow_dispatch` (not on PR), so the runtime `npm ci` path is exercised after merge.

## Alert 31 — Token-Permissions (handled outside this PR)
`contents: write` on the release `publish` job is required by `softprops/action-gh-release` to create the GitHub Release; it is scoped to that single job and the workflow top-level is `permissions: {}`. The code-scanning alert was dismissed ("won't fix") with that justification — no code change possible.

## Alert 4 — Code-Review (not addressed)
`main` is protected via rulesets (PR required, 1 approving review). The score is dragged down because some PRs are merged **without review** — Renovate auto-merges its dependency-update PRs, bypassing the approval requirement, so they land on `main` as unreviewed changesets. Raising the score requires repo-admin changes (stop Renovate auto-merging without review and/or tighten the ruleset bypass actors), not a code change.

Closes #413