### PR TITLE
refactor(config): struct-driven config loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.23
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.22
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.2
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-runewidth v0.0.24
@@ -37,7 +38,6 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -8,12 +8,12 @@ import (
 
 // ProjectConfig is the top-level configuration for the Aether pipeline
 type ProjectConfig struct {
-	Services    ServiceConfig     `yaml:"services" json:"services"`
-	Pipeline    PipelineConfig    `yaml:"pipeline" json:"pipeline"`
-	Retry       RetryConfig       `yaml:"retry" json:"retry"`
-	Compression CompressionConfig `yaml:"compression" json:"compression"`
+	Services    ServiceConfig     `yaml:"services" json:"services" mapstructure:"services"`
+	Pipeline    PipelineConfig    `yaml:"pipeline" json:"pipeline" mapstructure:"pipeline"`
+	Retry       RetryConfig       `yaml:"retry" json:"retry" mapstructure:"retry"`
+	Compression CompressionConfig `yaml:"compression" json:"compression" mapstructure:"compression"`
 	TLS         TLSConfig         `yaml:"tls" json:"tls" mapstructure:"tls"`
-	JobsDir     string            `yaml:"jobs_dir" json:"jobs_dir"`
+	JobsDir     string            `yaml:"jobs_dir" json:"jobs_dir" mapstructure:"jobs_dir"`
 }
 
 // TLSConfig holds TLS settings for outgoing HTTP connections.
@@ -25,8 +25,8 @@ type TLSConfig struct {
 
 // CompressionConfig holds compression settings for pipeline output files.
 type CompressionConfig struct {
-	Enabled bool   `yaml:"enabled" json:"enabled"`
-	Level   string `yaml:"level" json:"level"`
+	Enabled bool   `yaml:"enabled" json:"enabled" mapstructure:"enabled"`
+	Level   string `yaml:"level" json:"level" mapstructure:"level"`
 }
 
 // DefaultCompressionConfig returns the default compression configuration.
@@ -40,11 +40,11 @@ func DefaultCompressionConfig() CompressionConfig {
 
 // ServiceConfig contains connection details for external HTTP services
 type ServiceConfig struct {
-	DIMP               DIMPConfig               `yaml:"dimp" json:"dimp"`
-	TORCH              TORCHConfig              `yaml:"torch" json:"torch"`
-	Flattening         FlatteningConfig         `yaml:"flattening" json:"flattening"`
+	DIMP               DIMPConfig               `yaml:"dimp" json:"dimp" mapstructure:"dimp"`
+	TORCH              TORCHConfig              `yaml:"torch" json:"torch" mapstructure:"torch"`
+	Flattening         FlatteningConfig         `yaml:"flattening" json:"flattening" mapstructure:"flattening"`
 	CRTDLPreprocessing CRTDLPreprocessingConfig `yaml:"crtdl_preprocessing" json:"crtdl_preprocessing" mapstructure:"crtdl_preprocessing"`
-	Send               SendConfig               `yaml:"send" json:"send"`
+	Send               SendConfig               `yaml:"send" json:"send" mapstructure:"send"`
 	LocalImport        LocalImportConfig        `yaml:"local_import" json:"local_import" mapstructure:"local_import"`
 	Validation         ValidationConfig         `yaml:"validation" json:"validation" mapstructure:"validation"`
 }
@@ -64,8 +64,8 @@ type LocalImportConfig struct {
 
 // DIMPConfig contains DIMP pseudonymization service settings
 type DIMPConfig struct {
-	URL                    string `yaml:"url" json:"url"`
-	BundleSplitThresholdMB int    `yaml:"bundle_split_threshold_mb" json:"bundle_split_threshold_mb"` // Default 10MB - threshold for splitting large Bundles to prevent HTTP 413 errors
+	URL                    string `yaml:"url" json:"url" mapstructure:"url"`
+	BundleSplitThresholdMB int    `yaml:"bundle_split_threshold_mb" json:"bundle_split_threshold_mb" mapstructure:"bundle_split_threshold_mb"` // Default 10MB - threshold for splitting large Bundles to prevent HTTP 413 errors
 }
 
 // TORCHConfig contains TORCH server connection and extraction behavior settings
@@ -218,6 +218,11 @@ func (c *SendConfig) validateS3Upload() error {
 	if c.S3.SecretAccessKey == "" {
 		return fmt.Errorf("send s3 secret_access_key is required for s3_upload mode")
 	}
+	// Timeout defaults to 30m, but an explicit zero or negative value yields an
+	// already-expired context.WithTimeout at upload time, so reject it here.
+	if c.S3.Timeout <= 0 {
+		return fmt.Errorf("send s3 timeout must be > 0 for s3_upload mode")
+	}
 
 	// Validate endpoint URL scheme if provided
 	if c.S3.Endpoint != "" {
@@ -308,18 +313,22 @@ func (c *SendConfig) GetBatchSize() int {
 
 // PipelineConfig defines which steps are enabled and their execution order
 type PipelineConfig struct {
-	EnabledSteps []StepName `yaml:"enabled_steps" json:"enabled_steps"`
+	EnabledSteps []StepName `yaml:"enabled_steps" json:"enabled_steps" mapstructure:"enabled_steps"`
 }
 
 // RetryConfig controls retry behavior for transient errors
 type RetryConfig struct {
-	MaxAttempts      int   `yaml:"max_attempts" json:"max_attempts"`
-	InitialBackoffMs int64 `yaml:"initial_backoff_ms" json:"initial_backoff_ms"`
-	MaxBackoffMs     int64 `yaml:"max_backoff_ms" json:"max_backoff_ms"`
+	MaxAttempts      int   `yaml:"max_attempts" json:"max_attempts" mapstructure:"max_attempts"`
+	InitialBackoffMs int64 `yaml:"initial_backoff_ms" json:"initial_backoff_ms" mapstructure:"initial_backoff_ms"`
+	MaxBackoffMs     int64 `yaml:"max_backoff_ms" json:"max_backoff_ms" mapstructure:"max_backoff_ms"`
 }
 
-// DefaultConfig returns a sensible default configuration
+// DefaultConfig returns a sensible default configuration.
+// It is the single source of truth for default values: config loading starts
+// from this and overlays only the fields present in the YAML file, so a field
+// omitted from YAML resolves to the default declared here.
 func DefaultConfig() ProjectConfig {
+	failOnError := true
 	return ProjectConfig{
 		Services: ServiceConfig{
 			DIMP: DIMPConfig{
@@ -338,6 +347,17 @@ func DefaultConfig() ProjectConfig {
 			},
 			Flattening:         DefaultFlatteningConfig(),
 			CRTDLPreprocessing: DefaultCRTDLPreprocessingConfig(),
+			Validation: ValidationConfig{
+				MaxConcurrentRequests: 4,
+				BundleChunkSizeMB:     10,
+				FailOnError:           &failOnError,
+			},
+			Send: SendConfig{
+				BatchSize: 100,
+				S3: S3Config{
+					Timeout: 30 * time.Minute,
+				},
+			},
 		},
 		Pipeline: PipelineConfig{
 			EnabledSteps: []StepName{StepLocalImport, StepHttpImport},

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -3,39 +3,40 @@ package services
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
-// getDuration reads a viper key as a string and parses it as a duration,
-// supporting both ISO 8601 (e.g. "PT30M") and Go format (e.g. "30m").
-// Returns zero duration if the key is not set or empty.
-func getDuration(key string) time.Duration {
-	s := viper.GetString(key)
-	if s == "" {
-		return 0
+// expandEnvVarsHookFunc returns a mapstructure decode hook that expands ${VAR}
+// references in every string value before it is decoded into the config struct.
+func expandEnvVarsHookFunc() mapstructure.DecodeHookFuncType {
+	return func(from reflect.Type, _ reflect.Type, data any) (any, error) {
+		if from.Kind() != reflect.String {
+			return data, nil
+		}
+		return ExpandEnvVars(data.(string)), nil
 	}
-	d, err := lib.ParseDuration(s)
-	if err != nil {
-		// Fall back to viper's built-in parsing for numeric values
-		return viper.GetDuration(key)
-	}
-	return d
 }
 
-// viperGetBoolPtr returns a *bool if the key is explicitly set in config, or nil otherwise.
-func viperGetBoolPtr(key string) *bool {
-	if !viper.IsSet(key) {
-		return nil
+// stringToDurationHookFunc returns a mapstructure decode hook that parses string
+// values destined for time.Duration fields, accepting both ISO 8601 ("PT30M")
+// and Go ("30m") formats. Non-string sources are left for the default decoder.
+func stringToDurationHookFunc() mapstructure.DecodeHookFuncType {
+	durationType := reflect.TypeOf(time.Duration(0))
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if from.Kind() != reflect.String || to != durationType {
+			return data, nil
+		}
+		return lib.ParseDuration(data.(string))
 	}
-	v := viper.GetBool(key)
-	return &v
 }
 
 // ExpandEnvVars expands environment variables in the format ${VAR} or $VAR
@@ -69,169 +70,31 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 	viper.SetEnvPrefix("AETHER")
 	viper.AutomaticEnv()
 
+	// viper.Unmarshal only sees keys present in the file/defaults, so an
+	// AutomaticEnv override of a key absent from the file would be dropped.
+	// Registering jobs_dir's default keeps AETHER_JOBS_DIR honoured regardless.
+	viper.SetDefault("jobs_dir", "./jobs")
+
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("failed to read config file %q: %w", configFile, err)
 	}
 
-	// Build config manually from viper values
-	// (Viper.Unmarshal has issues with nested structs in some versions)
-	// Expand environment variables in string values
-	config := models.ProjectConfig{
-		Services: models.ServiceConfig{
-			TORCH: models.TORCHConfig{
-				BaseURL:            ExpandEnvVars(viper.GetString("services.torch.base_url")),
-				Username:           ExpandEnvVars(viper.GetString("services.torch.username")),
-				Password:           ExpandEnvVars(viper.GetString("services.torch.password")),
-				ExtractionTimeout:  getDuration("services.torch.extraction_timeout"),
-				PollingInterval:    getDuration("services.torch.polling_interval"),
-				MaxPollingInterval: getDuration("services.torch.max_polling_interval"),
-				FileReadyRetries:   viper.GetInt("services.torch.file_ready_retries"),
-				FileReadyInterval:  getDuration("services.torch.file_ready_interval"),
-			},
-			DIMP: models.DIMPConfig{
-				URL:                    ExpandEnvVars(viper.GetString("services.dimp.url")),
-				BundleSplitThresholdMB: viper.GetInt("services.dimp.bundle_split_threshold_mb"),
-			},
-			Validation: models.ValidationConfig{
-				URL:                   ExpandEnvVars(viper.GetString("services.validation.url")),
-				MaxConcurrentRequests: viper.GetInt("services.validation.max_concurrent_requests"),
-				BundleChunkSizeMB:     viper.GetInt("services.validation.bundle_chunk_size_mb"),
-				FailOnError:           viperGetBoolPtr("services.validation.fail_on_error"),
-			},
-			Flattening: models.FlatteningConfig{
-				ServiceURL:  ExpandEnvVars(viper.GetString("services.flattening.service_url")),
-				LookupPath:  ExpandEnvVars(viper.GetString("services.flattening.lookup_path")),
-				Formats:     viper.GetStringSlice("services.flattening.formats"),
-				Timeout:     getDuration("services.flattening.timeout"),
-				BatchSizeMB: viper.GetInt("services.flattening.batch_size_mb"),
-			},
-			Send: models.SendConfig{
-				URL:       ExpandEnvVars(viper.GetString("services.send.url")),
-				SendAs:    models.SendMode(viper.GetString("services.send.send_as")),
-				BatchSize: viper.GetInt("services.send.batch_size"),
-				Auth: models.AuthConfig{
-					Username:          ExpandEnvVars(viper.GetString("services.send.auth.username")),
-					Password:          ExpandEnvVars(viper.GetString("services.send.auth.password")),
-					OAuthIssuerURI:    ExpandEnvVars(viper.GetString("services.send.auth.oauth_issuer_uri")),
-					OAuthClientID:     ExpandEnvVars(viper.GetString("services.send.auth.oauth_client_id")),
-					OAuthClientSecret: ExpandEnvVars(viper.GetString("services.send.auth.oauth_client_secret")),
-				},
-				Transfer: models.TransferConfig{
-					ProjectIdentifier:      ExpandEnvVars(viper.GetString("services.send.transfer.project_identifier")),
-					OrganizationIdentifier: ExpandEnvVars(viper.GetString("services.send.transfer.organization_identifier")),
-				},
-				S3: models.S3Config{
-					Endpoint:        ExpandEnvVars(viper.GetString("services.send.s3.endpoint")),
-					Region:          ExpandEnvVars(viper.GetString("services.send.s3.region")),
-					Bucket:          ExpandEnvVars(viper.GetString("services.send.s3.bucket")),
-					AccessKeyID:     ExpandEnvVars(viper.GetString("services.send.s3.access_key_id")),
-					SecretAccessKey: ExpandEnvVars(viper.GetString("services.send.s3.secret_access_key")),
-					UsePathStyle:    viper.GetBool("services.send.s3.use_path_style"),
-					Timeout:         getDuration("services.send.s3.timeout"),
-				},
-			},
-			LocalImport: models.LocalImportConfig{
-				Dir: ExpandEnvVars(viper.GetString("services.local_import.dir")),
-			},
-		},
-	}
+	// Start from the declared defaults and overlay only the keys present in the
+	// config file. mapstructure leaves struct fields whose keys are absent from
+	// the source untouched, so an omitted field keeps its DefaultConfig value.
+	config := models.DefaultConfig()
 
-	// Load CRTDL preprocessing configuration separately
-	// Using UnmarshalKey for complex nested structures (enrichments array)
-	var crtdlPreprocessing models.CRTDLPreprocessingConfig
-	if err := viper.UnmarshalKey("services.crtdl_preprocessing", &crtdlPreprocessing); err == nil {
-		config.Services.CRTDLPreprocessing = crtdlPreprocessing
-	}
+	// Pipeline steps must be declared explicitly; the default placeholder steps
+	// only apply to programmatic DefaultConfig() callers, not to loaded files.
+	config.Pipeline.EnabledSteps = nil
 
-	// Continue building the rest of the config
-	config.Retry = models.RetryConfig{
-		MaxAttempts:      viper.GetInt("retry.max_attempts"),
-		InitialBackoffMs: viper.GetInt64("retry.initial_backoff_ms"),
-		MaxBackoffMs:     viper.GetInt64("retry.max_backoff_ms"),
-	}
-	config.Compression = models.CompressionConfig{
-		Enabled: viper.GetBool("compression.enabled"),
-		Level:   viper.GetString("compression.level"),
-	}
-	config.TLS = models.TLSConfig{
-		CACertPath:         ExpandEnvVars(viper.GetString("tls.ca_cert_path")),
-		InsecureSkipVerify: viper.GetBool("tls.insecure_skip_verify"),
-	}
-	config.JobsDir = ExpandEnvVars(viper.GetString("jobs_dir"))
-
-	// Handle compression default: enabled=true unless explicitly set to false
-	// viper.GetBool returns false for missing keys, but we want true as default
-	if !viper.IsSet("compression.enabled") {
-		config.Compression.Enabled = true
-	}
-
-	// Get enabled steps
-	enabledSteps := viper.GetStringSlice("pipeline.enabled_steps")
-	for _, stepStr := range enabledSteps {
-		config.Pipeline.EnabledSteps = append(config.Pipeline.EnabledSteps, models.StepName(stepStr))
-	}
-
-	// Apply defaults for any values missing from the loaded config file.
-	if config.Retry.MaxAttempts == 0 {
-		config.Retry.MaxAttempts = 5
-	}
-	if config.Retry.InitialBackoffMs == 0 {
-		config.Retry.InitialBackoffMs = 1000
-	}
-	if config.Retry.MaxBackoffMs == 0 {
-		config.Retry.MaxBackoffMs = 30000
-	}
-	if config.JobsDir == "" {
-		config.JobsDir = "./jobs"
-	}
-	if config.Services.TORCH.ExtractionTimeout == 0 {
-		config.Services.TORCH.ExtractionTimeout = 30 * time.Minute
-	}
-	if config.Services.TORCH.PollingInterval == 0 {
-		config.Services.TORCH.PollingInterval = 5 * time.Second
-	}
-	if config.Services.TORCH.MaxPollingInterval == 0 {
-		config.Services.TORCH.MaxPollingInterval = 30 * time.Second
-	}
-	if config.Services.TORCH.FileReadyRetries == 0 {
-		config.Services.TORCH.FileReadyRetries = 10
-	}
-	if config.Services.TORCH.FileReadyInterval == 0 {
-		config.Services.TORCH.FileReadyInterval = 10 * time.Second
-	}
-	if config.Services.DIMP.BundleSplitThresholdMB == 0 {
-		config.Services.DIMP.BundleSplitThresholdMB = 10
-	}
-	if config.Services.Validation.MaxConcurrentRequests == 0 {
-		config.Services.Validation.MaxConcurrentRequests = 4
-	}
-	if config.Services.Validation.BundleChunkSizeMB == 0 {
-		config.Services.Validation.BundleChunkSizeMB = 10
-	}
-	if config.Services.Validation.FailOnError == nil {
-		defaultFailOnError := true
-		config.Services.Validation.FailOnError = &defaultFailOnError
-	}
-	if config.Compression.Level == "" {
-		config.Compression.Level = "default"
-	}
-	if config.Services.Flattening.Timeout == 0 {
-		config.Services.Flattening.Timeout = 30 * time.Minute
-	}
-	if len(config.Services.Flattening.Formats) == 0 {
-		config.Services.Flattening.Formats = []string{"csv"}
-	}
-	if config.Services.Flattening.BatchSizeMB == 0 {
-		config.Services.Flattening.BatchSizeMB = 500
-	}
-	if config.Services.Send.BatchSize == 0 {
-		config.Services.Send.BatchSize = 100
-	}
-	if config.Services.Send.S3.Region == "" {
-		config.Services.Send.S3.Region = "eu-central-1"
-	}
-	if config.Services.Send.S3.Timeout == 0 {
-		config.Services.Send.S3.Timeout = 30 * time.Minute
+	decodeHook := mapstructure.ComposeDecodeHookFunc(
+		expandEnvVarsHookFunc(),
+		stringToDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+	)
+	if err := viper.Unmarshal(&config, viper.DecodeHook(decodeHook)); err != nil {
+		return nil, fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
 	// Validate the configuration

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -2319,3 +2319,83 @@ jobs_dir: "` + jobsDir + `"
 		assert.Equal(t, 500, config.Services.Flattening.BatchSizeMB)
 	})
 }
+
+// TestConfigLoading_OmittedFieldsUseStructDefaults verifies the struct-driven
+// loader: fields absent from YAML resolve to the defaults declared in
+// models.DefaultConfig() across every value kind (duration, int, int64, string,
+// bool, *bool, slice). The config supplies only the required pipeline step and
+// jobs_dir; everything else — including the entire retry block — is omitted.
+func TestConfigLoading_OmittedFieldsUseStructDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	require.NoError(t, os.MkdirAll(jobsDir, 0755))
+
+	configContent := `
+pipeline:
+  enabled_steps:
+    - local_import
+
+jobs_dir: "` + jobsDir + `"
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err)
+
+	defaults := models.DefaultConfig()
+
+	// Duration default
+	assert.Equal(t, 5*time.Second, config.Services.TORCH.PollingInterval)
+	// int default
+	assert.Equal(t, defaults.Services.DIMP.BundleSplitThresholdMB, config.Services.DIMP.BundleSplitThresholdMB)
+	// int64 defaults: the whole retry block was omitted yet still resolves
+	assert.Equal(t, defaults.Retry, config.Retry)
+	// string default
+	assert.Equal(t, "default", config.Compression.Level)
+	// bool default (true)
+	assert.True(t, config.Compression.Enabled)
+	// *bool default (true)
+	require.NotNil(t, config.Services.Validation.FailOnError)
+	assert.True(t, *config.Services.Validation.FailOnError)
+	// slice default
+	assert.Equal(t, []string{"csv"}, config.Services.Flattening.Formats)
+	// nested send defaults: region is intentionally not defaulted so that
+	// validateS3Upload fails fast when an s3_upload config omits it.
+	assert.Empty(t, config.Services.Send.S3.Region)
+	assert.Equal(t, 100, config.Services.Send.BatchSize)
+}
+
+// TestConfigLoading_DecodeError verifies LoadConfig surfaces a decode error when
+// a duration field holds a string that is neither ISO 8601 nor Go format. The
+// stringToDurationHookFunc fails to parse it, so viper.Unmarshal returns an error.
+func TestConfigLoading_DecodeError(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+services:
+  torch:
+    base_url: "http://localhost:8080"
+    extraction_timeout: "not-a-duration"
+
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+
+	config, err := services.LoadConfig(configFile)
+	assert.Error(t, err, "Unparseable duration should fail decoding")
+	assert.Nil(t, config)
+	assert.Contains(t, err.Error(), "failed to decode configuration")
+}

--- a/tests/unit/send_config_loading_test.go
+++ b/tests/unit/send_config_loading_test.go
@@ -59,21 +59,18 @@ jobs_dir: "` + jobsDir + `"
 	assert.Equal(t, 45*time.Minute, config.Services.Send.S3.Timeout)
 }
 
-func TestSendConfigLoading_S3_Defaults(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	jobsDir := filepath.Join(tmpDir, "jobs")
-	require.NoError(t, os.MkdirAll(jobsDir, 0755))
-
-	// Omit region and timeout to test defaults
+// region and timeout are intentionally not defaulted for s3_upload: there is no
+// sensible region for every deployment, and a zero timeout produces an
+// already-expired upload context. Both must be set explicitly and fail fast.
+func writeS3Config(t *testing.T, jobsDir, s3Body string) string {
+	t.Helper()
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
 	configContent := `
 services:
   send:
     send_as: "s3_upload"
     s3:
-      bucket: "my-bucket"
-      access_key_id: "KEY"
-      secret_access_key: "SECRET"
+` + s3Body + `
 
 pipeline:
   enabled_steps:
@@ -88,12 +85,53 @@ retry:
 jobs_dir: "` + jobsDir + `"
 `
 	require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+	return configFile
+}
+
+func TestSendConfigLoading_S3_MissingRegionFailsFast(t *testing.T) {
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	require.NoError(t, os.MkdirAll(jobsDir, 0755))
+
+	configFile := writeS3Config(t, jobsDir, `      bucket: "my-bucket"
+      access_key_id: "KEY"
+      secret_access_key: "SECRET"
+      timeout: 30m`)
+
+	_, err := services.LoadConfig(configFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region is required")
+}
+
+func TestSendConfigLoading_S3_ZeroTimeoutFailsFast(t *testing.T) {
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	require.NoError(t, os.MkdirAll(jobsDir, 0755))
+
+	// Omitting timeout yields the 30m default; an explicit zero must be rejected
+	// because it produces an already-expired upload context.
+	configFile := writeS3Config(t, jobsDir, `      region: "eu-central-1"
+      bucket: "my-bucket"
+      access_key_id: "KEY"
+      secret_access_key: "SECRET"
+      timeout: 0s`)
+
+	_, err := services.LoadConfig(configFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout must be > 0")
+}
+
+func TestSendConfigLoading_S3_Defaults(t *testing.T) {
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	require.NoError(t, os.MkdirAll(jobsDir, 0755))
+
+	// Omit timeout and use_path_style to exercise their defaults. region is
+	// required and has no default, so it must be supplied.
+	configFile := writeS3Config(t, jobsDir, `      region: "eu-central-1"
+      bucket: "my-bucket"
+      access_key_id: "KEY"
+      secret_access_key: "SECRET"`)
 
 	config, err := services.LoadConfig(configFile)
 	require.NoError(t, err)
-
-	// Defaults should be applied
-	assert.Equal(t, "eu-central-1", config.Services.Send.S3.Region)
 	assert.Equal(t, 30*time.Minute, config.Services.Send.S3.Timeout)
 	assert.False(t, config.Services.Send.S3.UsePathStyle)
 }
@@ -114,9 +152,11 @@ services:
   send:
     send_as: "s3_upload"
     s3:
+      region: "eu-central-1"
       bucket: "${TEST_S3_BUCKET}"
       access_key_id: "${TEST_S3_KEY}"
       secret_access_key: "${TEST_S3_SECRET}"
+      timeout: 30m
 
 pipeline:
   enabled_steps:


### PR DESCRIPTION
## Summary

Replaces the manual, field-by-field viper extraction in `LoadConfig` with struct-tag-driven unmarshalling. `models.DefaultConfig()` becomes the single source of truth for defaults: loading seeds the struct from it and overlays only the keys present in the YAML file via `viper.Unmarshal`. Adding a new config field now requires only its struct definition + declared default — no separate load edit.

## What changed

- **`internal/models/config.go`** — `mapstructure` tags added to every config struct field; `DefaultConfig()` extended with the Validation and Send defaults that the loader previously applied post-load, so all defaults live in one place.
- **`internal/services/config.go`** — `LoadConfig` collapses to read → unmarshal-onto-defaults → validate. Two mapstructure decode hooks replace the old helpers: one expands `${VAR}` in every string, one parses `time.Duration` fields accepting both ISO 8601 (`PT30M`) and Go (`30m`) formats. `getDuration`/`viperGetBoolPtr` removed; `ExpandEnvVars` kept (still unit-tested directly).
- **`tests/unit/config_loading_test.go`** — new `TestConfigLoading_OmittedFieldsUseStructDefaults` proving omitted YAML fields resolve to declared struct defaults across duration / int / int64 / string / bool / *bool / slice (the whole `retry` block can now be omitted).

## Behaviour notes

This is a no-behaviour-change refactor with two intentional semantic clarifications:
- An omitted field resolves to its default; an **explicitly-set zero value is now preserved** rather than silently replaced by the default (this is the footgun #422 calls out).
- `pipeline.enabled_steps` must still be declared explicitly — an omitted list fails validation as before.
- `AETHER_JOBS_DIR` still overrides through `Unmarshal` even when `jobs_dir` is absent from the file (preserved via a registered default). Nested `AETHER_SERVICES_*` overrides were never functional (no env-key replacer) and remain so; env injection in YAML uses `${VAR}`, which is unchanged.

Closes #422