### PR TITLE
fix(config): wire nested AETHER_* environment overrides

### DIFF
--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -446,7 +446,11 @@ Directory for job state and data files.
 
 ## Environment Variables
 
-All string values support environment variable substitution:
+aether exposes two independent environment-variable mechanisms.
+
+### In-file substitution (`${VAR}`)
+
+All string values support `${VAR}` substitution, expanded when the file is read:
 
 ```yaml
 services:
@@ -456,6 +460,22 @@ services:
   send:
     url: "${FHIR_SERVER_URL}"
 ```
+
+### Overrides (`AETHER_*`)
+
+Every configuration key can be overridden with an `AETHER_`-prefixed variable,
+including keys omitted from the YAML file. The name is the full config path,
+uppercased, with `.` replaced by `_`:
+
+```bash
+export AETHER_SERVICES_TORCH_BASE_URL="http://torch.internal:8080"
+export AETHER_SERVICES_DIMP_URL="http://dimp.internal:8080/fhir"
+export AETHER_RETRY_MAX_ATTEMPTS=8
+```
+
+Scope is **all** keys (nested service blocks, durations, integers, booleans).
+Precedence: CLI flags → `AETHER_*` env → config file → built-in defaults. An unset
+variable leaves the key at its file value or default.
 
 ## Example Configurations
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -210,7 +210,13 @@ services:
 
 ## Environment Variables
 
-Use environment variables for sensitive data:
+aether supports two independent environment-variable mechanisms.
+
+### In-file substitution: `${VAR}`
+
+Any string value in the YAML file may reference an environment variable with
+`${VAR}`. The reference is expanded when the file is read — useful for keeping
+secrets out of the file:
 
 ```yaml
 services:
@@ -223,6 +229,30 @@ services:
 export TORCH_USERNAME="researcher"
 export TORCH_PASSWORD="secret"
 ```
+
+### Overrides: `AETHER_*`
+
+Any configuration key can be overridden with an `AETHER_`-prefixed environment
+variable, **even when the key is absent from the YAML file**. The variable name
+is the full config path, uppercased, with dots replaced by underscores:
+
+| Config key                          | Environment variable                       |
+| ----------------------------------- | ------------------------------------------ |
+| `jobs_dir`                          | `AETHER_JOBS_DIR`                          |
+| `services.torch.base_url`           | `AETHER_SERVICES_TORCH_BASE_URL`          |
+| `services.dimp.url`                 | `AETHER_SERVICES_DIMP_URL`                |
+| `retry.max_attempts`                | `AETHER_RETRY_MAX_ATTEMPTS`               |
+| `services.send.s3.bucket`           | `AETHER_SERVICES_SEND_S3_BUCKET`          |
+
+```bash
+export AETHER_SERVICES_TORCH_BASE_URL="http://torch.internal:8080"
+```
+
+Scope: **all** keys are overridable, including nested service blocks, durations
+(`AETHER_SERVICES_TORCH_EXTRACTION_TIMEOUT=PT45M`), integers, and booleans.
+Precedence is CLI flags → `AETHER_*` env → config file → built-in defaults, so an
+override wins over a value set in the file. Keys whose variable is unset keep
+their default.
 
 ## Next Steps
 

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -52,6 +52,37 @@ func ExpandEnvVars(s string) string {
 	return expanded
 }
 
+// bindEnvOverrides registers an AETHER_* environment binding for every leaf
+// field of the config struct, walking nested structs via their mapstructure
+// tags. Binding is required because viper's AutomaticEnv only consults keys it
+// already knows; an unbound nested key absent from the YAML file is never looked
+// up. Binding an unset variable is safe: viper returns no value, so the field
+// keeps the default from models.DefaultConfig().
+func bindEnvOverrides(t reflect.Type, prefix string) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		name, _, _ := strings.Cut(field.Tag.Get("mapstructure"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		key := name
+		if prefix != "" {
+			key = prefix + "." + name
+		}
+		fieldType := field.Type
+		for fieldType.Kind() == reflect.Pointer {
+			fieldType = fieldType.Elem()
+		}
+		// Recurse into nested config structs; everything else (time.Duration,
+		// slices, maps, scalars) is a bindable leaf.
+		if fieldType.Kind() == reflect.Struct {
+			bindEnvOverrides(fieldType, key)
+			continue
+		}
+		_ = viper.BindEnv(key)
+	}
+}
+
 // LoadConfig loads configuration from the given file and merges with CLI flags.
 // The config file path is required; auto-discovery of ./aether.yaml or
 // ~/.config/aether/aether.yaml is intentionally not performed.
@@ -64,16 +95,23 @@ func LoadConfig(configFile string) (*models.ProjectConfig, error) {
 	if configFile == "" {
 		return nil, fmt.Errorf("config file is required: pass aether.yaml as the first positional argument (e.g. `aether pipeline start aether.yaml crtdl.json`)")
 	}
+	// Start from a clean singleton so repeated loads don't accumulate stale
+	// config or env bindings from a previous call.
+	viper.Reset()
 	viper.SetConfigFile(configFile)
 
-	// Enable environment variable override with AETHER_ prefix
+	// Enable AETHER_ environment overrides. The key replacer maps nested config
+	// keys to env names, e.g. services.torch.base_url -> AETHER_SERVICES_TORCH_BASE_URL.
 	viper.SetEnvPrefix("AETHER")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
-	// viper.Unmarshal only sees keys present in the file/defaults, so an
-	// AutomaticEnv override of a key absent from the file would be dropped.
-	// Registering jobs_dir's default keeps AETHER_JOBS_DIR honoured regardless.
-	viper.SetDefault("jobs_dir", "./jobs")
+	// AutomaticEnv only consults keys viper already knows (keys present in the
+	// file plus bound keys), so a nested key absent from the file would never be
+	// looked up. Binding every config key makes all of them overridable via env,
+	// including keys omitted from the YAML file. BindEnv relies on the prefix set
+	// just above to form the AETHER_* variable name.
+	bindEnvOverrides(reflect.TypeOf(models.ProjectConfig{}), "")
 
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("failed to read config file %q: %w", configFile, err)

--- a/tests/unit/config_env_override_test.go
+++ b/tests/unit/config_env_override_test.go
@@ -1,0 +1,157 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// writeEnvTestConfig writes a config file with the given body plus a valid
+// jobs_dir and returns the config file path.
+func writeEnvTestConfig(t *testing.T, body string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	require.NoError(t, os.MkdirAll(jobsDir, 0755))
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	content := body + "\njobs_dir: " + jobsDir + "\n"
+	require.NoError(t, os.WriteFile(configFile, []byte(content), 0644))
+	return configFile
+}
+
+// TestEnvOverride_NestedTorchBaseURL_AbsentFromFile is the canonical regression
+// for issue #435: a nested key (services.torch.base_url) omitted from the YAML
+// file is supplied entirely via AETHER_SERVICES_TORCH_BASE_URL. The torch step
+// is enabled, so without the override TORCH.Validate would reject the empty
+// base_url — proving the env value reaches both the struct and validation.
+func TestEnvOverride_NestedTorchBaseURL_AbsentFromFile(t *testing.T) {
+	t.Setenv("AETHER_SERVICES_TORCH_BASE_URL", "http://torch.env.example:9000")
+
+	configFile := writeEnvTestConfig(t, `
+pipeline:
+  enabled_steps:
+    - torch
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000`)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "env-provided base_url should satisfy validation")
+	assert.Equal(t, "http://torch.env.example:9000", config.Services.TORCH.BaseURL)
+}
+
+// TestEnvOverride_NestedDIMPURL_AbsentFromFile covers a second nested key in a
+// different service block (services.dimp.url). The dimp step requires a service
+// URL, so the override is what lets validation pass.
+func TestEnvOverride_NestedDIMPURL_AbsentFromFile(t *testing.T) {
+	t.Setenv("AETHER_SERVICES_DIMP_URL", "http://dimp.env.example:8080/fhir")
+
+	configFile := writeEnvTestConfig(t, `
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000`)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err, "env-provided dimp url should satisfy validation")
+	assert.Equal(t, "http://dimp.env.example:8080/fhir", config.Services.DIMP.URL)
+}
+
+// TestEnvOverride_DeeplyNestedKey verifies the reflection walk binds keys more
+// than two levels deep (services.send.s3.bucket).
+func TestEnvOverride_DeeplyNestedKey(t *testing.T) {
+	t.Setenv("AETHER_SERVICES_SEND_S3_BUCKET", "env-bucket")
+
+	configFile := writeEnvTestConfig(t, `
+pipeline:
+  enabled_steps:
+    - local_import
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000`)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, "env-bucket", config.Services.Send.S3.Bucket)
+}
+
+// TestEnvOverride_TypedKeys verifies env overrides decode into non-string field
+// types (int, bool, duration), proving the "all keys" scope is type-correct.
+func TestEnvOverride_TypedKeys(t *testing.T) {
+	t.Setenv("AETHER_RETRY_MAX_ATTEMPTS", "9")                      // int, non-service block
+	t.Setenv("AETHER_TLS_INSECURE_SKIP_VERIFY", "true")             // bool
+	t.Setenv("AETHER_SERVICES_TORCH_EXTRACTION_TIMEOUT", "PT45M")   // duration
+	t.Setenv("AETHER_SERVICES_DIMP_BUNDLE_SPLIT_THRESHOLD_MB", "5") // int, service block
+
+	configFile := writeEnvTestConfig(t, `
+pipeline:
+  enabled_steps:
+    - local_import
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000`)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, 9, config.Retry.MaxAttempts, "int override")
+	assert.True(t, config.TLS.InsecureSkipVerify, "bool override")
+	assert.Equal(t, 45*time.Minute, config.Services.TORCH.ExtractionTimeout, "duration override")
+	assert.Equal(t, 5, config.Services.DIMP.BundleSplitThresholdMB, "service-block int override")
+}
+
+// TestEnvOverride_UnsetKeepsDefaults verifies that binding env keys does not
+// clobber struct defaults when the variables are unset — fields omitted from the
+// file retain their models.DefaultConfig() values.
+func TestEnvOverride_UnsetKeepsDefaults(t *testing.T) {
+	configFile := writeEnvTestConfig(t, `
+pipeline:
+  enabled_steps:
+    - local_import
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000`)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, config.Services.TORCH.ExtractionTimeout, "duration default preserved")
+	assert.Equal(t, 10, config.Services.DIMP.BundleSplitThresholdMB, "int default preserved")
+	assert.True(t, config.Compression.Enabled, "bool default preserved")
+	assert.Equal(t, "default", config.Compression.Level, "string default preserved")
+}
+
+// TestEnvOverride_EnvWinsOverFileValue verifies precedence: an env override
+// takes priority over a value present in the config file.
+func TestEnvOverride_EnvWinsOverFileValue(t *testing.T) {
+	t.Setenv("AETHER_SERVICES_DIMP_URL", "http://dimp.env.example:8080/fhir")
+
+	configFile := writeEnvTestConfig(t, `
+services:
+  dimp:
+    url: "http://dimp.file.example:1234/fhir"
+pipeline:
+  enabled_steps:
+    - local_import
+    - dimp
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000`)
+
+	config, err := services.LoadConfig(configFile)
+	require.NoError(t, err)
+	assert.Equal(t, "http://dimp.env.example:8080/fhir", config.Services.DIMP.URL, "env should win over file")
+}


### PR DESCRIPTION
## Summary

Nested `AETHER_SERVICES_*` environment overrides (e.g. `AETHER_SERVICES_TORCH_BASE_URL`) were non-functional. Two root causes, both fixed:

1. **No env key replacer** — viper mapped `services.torch.base_url` to `AETHER_SERVICES.TORCH.BASE_URL` (dots kept verbatim), which never matched the underscore env name. Added `viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))`.
2. **`AutomaticEnv` is lazy** — `viper.Unmarshal` only iterates keys present in the file or with registered defaults/bindings, so a nested key absent from the file was never looked up. Added a reflection walk that `BindEnv` every config key.

## Scope decision

**All** config keys are overridable via `AETHER_*`, including nested service blocks, durations, integers, and booleans. The reflection walk is self-maintaining — new config fields get env override automatically, avoiding the wiring-omission class of bug. Precedence: CLI flags → `AETHER_*` env → config file → built-in defaults.

`LoadConfig` now calls `viper.Reset()` first so repeated loads do not accumulate stale config or bindings from the global viper singleton.

## Verification

New `tests/unit/config_env_override_test.go` covers: nested override absent from file (`services.torch.base_url`, `services.dimp.url`), deeply nested key (`services.send.s3.bucket`), typed keys (int/bool/duration), no-clobber of defaults when unset, and env-over-file precedence. Full unit suite passes; `go vet` and `golangci-lint` clean.

## Docs

Documented the `AETHER_*` override mechanism (distinct from in-YAML `${VAR}` substitution) in `docs/getting-started/configuration.md` and `docs/api-reference/config-reference.md`.

Closes #435