### PR TITLE
refactor(fhir): single Bundle/resource accessor module

### DIFF
--- a/internal/lib/bundle.go
+++ b/internal/lib/bundle.go
@@ -1,0 +1,128 @@
+package lib
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// ResourceType returns the resourceType of a FHIR resource, or "" if the field
+// is absent or not a string.
+func ResourceType(resource map[string]any) string {
+	rt, _ := FHIRResource(resource).GetResourceType()
+	return rt
+}
+
+// ResourceID returns the id of a FHIR resource, or "" if the field is absent or
+// not a string.
+func ResourceID(resource map[string]any) string {
+	id, _ := FHIRResource(resource).GetID()
+	return id
+}
+
+// IsProvenance reports whether the resource is a FHIR Provenance.
+func IsProvenance(resource map[string]any) bool {
+	return ResourceType(resource) == "Provenance"
+}
+
+// IsBundle reports whether the resource is a FHIR Bundle.
+func IsBundle(resource map[string]any) bool {
+	return ResourceType(resource) == "Bundle"
+}
+
+// ResourceReference returns the "ResourceType/id" reference for a resource, or
+// "" if either component is missing.
+func ResourceReference(resource map[string]any) string {
+	rt := ResourceType(resource)
+	id := ResourceID(resource)
+	if rt == "" || id == "" {
+		return ""
+	}
+	return rt + "/" + id
+}
+
+// EntryResource extracts the "resource" object from a single Bundle entry.
+// The second return value reports whether the entry held a resource object.
+func EntryResource(entry map[string]any) (map[string]any, bool) {
+	res, ok := entry["resource"].(map[string]any)
+	return res, ok
+}
+
+// BundleEntries returns a Bundle's entry objects, skipping non-object entries
+// and never erroring (cf. ExtractEntriesFromBundle, which reports malformed
+// structure). The returned maps alias the Bundle, so mutating them mutates it.
+func BundleEntries(bundle map[string]any) []map[string]any {
+	entries, ok := bundle["entry"].([]any)
+	if !ok {
+		return nil
+	}
+
+	result := make([]map[string]any, 0, len(entries))
+	for _, e := range entries {
+		if entry, ok := e.(map[string]any); ok {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+// BundleResources returns the resource from each Bundle entry, skipping entries
+// that are malformed or carry no resource. Like BundleEntries, it never errors.
+func BundleResources(bundle map[string]any) []map[string]any {
+	entries := BundleEntries(bundle)
+
+	resources := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		if res, ok := EntryResource(entry); ok {
+			resources = append(resources, res)
+		}
+	}
+	return resources
+}
+
+// ExtractEntriesFromBundle returns a Bundle's entry objects, erroring if the
+// entry field is missing or any entry is not an object.
+func ExtractEntriesFromBundle(bundle map[string]any) ([]map[string]any, error) {
+	entries, ok := bundle["entry"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("bundle.entry must be an array")
+	}
+
+	result := make([]map[string]any, 0, len(entries))
+	for i, entry := range entries {
+		entryObj, ok := entry.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("bundle.entry[%d] must be an object", i)
+		}
+		result = append(result, entryObj)
+	}
+
+	return result, nil
+}
+
+// ExtractBundleMetadata reads id, type and optional timestamp from a Bundle,
+// erroring if the required id or type is missing.
+func ExtractBundleMetadata(bundle map[string]any) (models.BundleMetadata, error) {
+	metadata := models.BundleMetadata{}
+
+	if id, ok := bundle["id"].(string); ok {
+		metadata.ID = id
+	} else {
+		return metadata, fmt.Errorf("bundle.id must be present and a string")
+	}
+
+	if bundleType, ok := bundle["type"].(string); ok {
+		metadata.Type = bundleType
+	} else {
+		return metadata, fmt.Errorf("bundle.type must be present and a string")
+	}
+
+	if timestamp, ok := bundle["timestamp"].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339, timestamp); err == nil {
+			metadata.Timestamp = parsed
+		}
+	}
+
+	return metadata, nil
+}

--- a/internal/lib/validation.go
+++ b/internal/lib/validation.go
@@ -135,7 +135,7 @@ func IsCRTDLFileWithHint(path string) (bool, string) {
 	}
 
 	// FHIR Parameters format is not supported
-	if resourceType, ok := crtdl["resourceType"].(string); ok && resourceType == "Parameters" {
+	if ResourceType(crtdl) == "Parameters" {
 		return false, "file uses FHIR Parameters format - please convert to flat CRTDL structure (see example-crtdl.json)"
 	}
 
@@ -172,7 +172,7 @@ func ValidateCRTDLSyntax(crtdlPath string) error {
 		return fmt.Errorf("CRTDL file '%s' contains invalid JSON: %w\n\nPlease ensure the file is valid JSON format", crtdlPath, err)
 	}
 
-	if resourceType, ok := crtdl["resourceType"].(string); ok && resourceType == "Parameters" {
+	if ResourceType(crtdl) == "Parameters" {
 		return fmt.Errorf("CRTDL file '%s' uses FHIR Parameters format\n\nThis format is not supported. Please convert to flat CRTDL structure:\n{\n  \"cohortDefinition\": { \"inclusionCriteria\": [...] },\n  \"dataExtraction\": { \"attributeGroups\": [...] }\n}\n\nSee .github/test/torch/queries/example-crtdl.json for reference", crtdlPath)
 	}
 
@@ -242,7 +242,7 @@ func ValidateSplitConfig(thresholdMB int) error {
 // Returns OversizedResourceError if the resource is too large, nil otherwise
 func DetectOversizedResource(resource map[string]any, thresholdBytes int) *models.OversizedResourceError {
 	// Bundle resources are handled by the splitting logic, not this function
-	if resourceType, ok := resource["resourceType"].(string); ok && resourceType == "Bundle" {
+	if IsBundle(resource) {
 		return nil // Bundles are handled separately
 	}
 
@@ -257,10 +257,10 @@ func DetectOversizedResource(resource map[string]any, thresholdBytes int) *model
 		resourceType := "Unknown"
 		resourceID := "unknown"
 
-		if rt, ok := resource["resourceType"].(string); ok {
+		if rt := ResourceType(resource); rt != "" {
 			resourceType = rt
 		}
-		if id, ok := resource["id"].(string); ok {
+		if id := ResourceID(resource); id != "" {
 			resourceID = id
 		}
 

--- a/internal/models/bundle.go
+++ b/internal/models/bundle.go
@@ -76,36 +76,6 @@ func (e *OversizedResourceError) Error() string {
 	)
 }
 
-// ExtractBundleMetadata extracts metadata from a FHIR Bundle JSON object
-// Returns BundleMetadata or error if Bundle structure is invalid
-func ExtractBundleMetadata(bundle map[string]any) (BundleMetadata, error) {
-	metadata := BundleMetadata{}
-
-	// Extract ID
-	if id, ok := bundle["id"].(string); ok {
-		metadata.ID = id
-	} else {
-		return metadata, fmt.Errorf("bundle.id must be present and a string")
-	}
-
-	// Extract type
-	if bundleType, ok := bundle["type"].(string); ok {
-		metadata.Type = bundleType
-	} else {
-		return metadata, fmt.Errorf("bundle.type must be present and a string")
-	}
-
-	// Extract timestamp if present
-	if timestamp, ok := bundle["timestamp"].(string); ok {
-		if parsed, err := time.Parse(time.RFC3339, timestamp); err == nil {
-			metadata.Timestamp = parsed
-		}
-		// If timestamp parsing fails, silently ignore (optional field)
-	}
-
-	return metadata, nil
-}
-
 // CalculateJSONSize returns the serialized byte count of a JSON object
 // This is used to determine if a Bundle exceeds the split threshold
 func CalculateJSONSize(obj map[string]any) (int, error) {
@@ -186,24 +156,4 @@ func ConvertChunkToBundle(chunk BundleChunk) map[string]any {
 	}
 
 	return bundle
-}
-
-// ExtractEntriesFromBundle extracts the entry array from a FHIR Bundle JSON object
-// Returns entries array or error if structure is invalid
-func ExtractEntriesFromBundle(bundle map[string]any) ([]map[string]any, error) {
-	entries, ok := bundle["entry"].([]any)
-	if !ok {
-		return nil, fmt.Errorf("bundle.entry must be an array")
-	}
-
-	result := make([]map[string]any, 0, len(entries))
-	for i, entry := range entries {
-		entryObj, ok := entry.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("bundle.entry[%d] must be an object", i)
-		}
-		result = append(result, entryObj)
-	}
-
-	return result, nil
 }

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -190,8 +190,8 @@ func processDIMPFile(inputFile, outputFile string, dimpClient *services.DIMPClie
 			return processor.GetResourceCount(), fmt.Errorf("failed to parse resource %d: %w", processor.GetResourceCount()+1, err)
 		}
 
-		resourceType, _ := resource["resourceType"].(string)
-		resourceID, _ := resource["id"].(string)
+		resourceType := lib.ResourceType(resource)
+		resourceID := lib.ResourceID(resource)
 
 		logger.Debug("Processing FHIR resource",
 			"file", filepath.Base(inputFile),

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -228,7 +228,7 @@ func scanProvenanceIndex(files []string) (models.ProvenanceIndex, error) {
 
 	for _, filePath := range files {
 		_, err := lib.ReadNDJSONFile(filePath, func(resource lib.FHIRResource) error {
-			if rt, ok := resource["resourceType"].(string); ok && rt == "Bundle" {
+			if lib.IsBundle(resource) {
 				_, bundleIndex := extractBundleResources(resource)
 				for k, v := range bundleIndex {
 					mergedIndex[k] = append(mergedIndex[k], v...)
@@ -298,7 +298,7 @@ func streamAndFlattenResources(
 				resourceSize := int(dec.InputOffset() - startOffset)
 
 				// If resource is a Bundle, extract clinical entries (skip Provenance)
-				if resourceType, ok := resource["resourceType"].(string); ok && resourceType == "Bundle" {
+				if lib.IsBundle(resource) {
 					clinicalResources, _ := extractBundleResources(resource)
 					for _, entryResource := range clinicalResources {
 						entryBytes, marshalErr := json.Marshal(entryResource)
@@ -353,7 +353,7 @@ func streamAndFlattenResources(
 // routeResourceToGroups determines which groups a resource belongs to based on
 // the provenance index. Returns the group indices for all matching groups.
 func routeResourceToGroups(resource map[string]any, provenanceIndex models.ProvenanceIndex, groupIDToIndex map[string]int, viewDefs []*models.ViewDefinition) []int {
-	ref := ResourceReference(resource)
+	ref := lib.ResourceReference(resource)
 	if ref == "" {
 		return nil
 	}
@@ -414,25 +414,11 @@ func flushGroupBatch(
 // extractBundleResources separates Bundle entries into clinical resources and a provenance index.
 // Provenance resources are used to build the index and excluded from the returned resources.
 func extractBundleResources(bundle map[string]any) ([]map[string]any, models.ProvenanceIndex) {
-	entries, ok := bundle["entry"].([]any)
-	if !ok {
-		return nil, nil
-	}
-
 	var resources []map[string]any
 	var provenances []map[string]any
 
-	for _, entry := range entries {
-		entryMap, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		entryResource, ok := entryMap["resource"].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		if rt, ok := entryResource["resourceType"].(string); ok && rt == "Provenance" {
+	for _, entryResource := range lib.BundleResources(bundle) {
+		if lib.IsProvenance(entryResource) {
 			provenances = append(provenances, entryResource)
 		} else {
 			resources = append(resources, entryResource)
@@ -516,7 +502,7 @@ func FilterResourcesByProvenance(resources []map[string]any, index models.Proven
 	var matching []map[string]any
 
 	for _, resource := range resources {
-		ref := ResourceReference(resource)
+		ref := lib.ResourceReference(resource)
 		if ref == "" {
 			continue
 		}
@@ -529,16 +515,6 @@ func FilterResourcesByProvenance(resources []map[string]any, index models.Proven
 	}
 
 	return matching
-}
-
-// ResourceReference builds a "ResourceType/id" reference string from a FHIR resource.
-func ResourceReference(resource map[string]any) string {
-	rt, _ := resource["resourceType"].(string)
-	id, _ := resource["id"].(string)
-	if rt == "" || id == "" {
-		return ""
-	}
-	return rt + "/" + id
 }
 
 // IsFlatteningErrorRetryable checks if a flattening error should be retried

--- a/internal/pipeline/flattening_internal_test.go
+++ b/internal/pipeline/flattening_internal_test.go
@@ -64,13 +64,13 @@ func TestExtractBundleResources(t *testing.T) {
 		}
 		resources, index := extractBundleResources(bundle)
 		assert.Nil(t, resources)
-		assert.Nil(t, index)
+		assert.Empty(t, index)
 	})
 
 	t.Run("returns nil for missing entry", func(t *testing.T) {
 		resources, index := extractBundleResources(map[string]any{"resourceType": "Bundle"})
 		assert.Nil(t, resources)
-		assert.Nil(t, index)
+		assert.Empty(t, index)
 	})
 
 	t.Run("skips non-map entries and entries without resource", func(t *testing.T) {

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -350,11 +350,8 @@ const validationBaseURL = "http://aether.local/fhir/"
 // validationEntryFullURL builds a synthetic fullUrl for a resource wrapped as a collection
 // Bundle entry. Uses the same base URL as inner Bundle entries so cross-references resolve.
 func validationEntryFullURL(resource map[string]any, index int) string {
-	resourceType, _ := resource["resourceType"].(string)
-	id, _ := resource["id"].(string)
-
-	if resourceType != "" && id != "" {
-		return validationBaseURL + resourceType + "/" + id
+	if ref := lib.ResourceReference(resource); ref != "" {
+		return validationBaseURL + ref
 	}
 
 	return validationBaseURL + fmt.Sprintf("Resource/%d", index)
@@ -365,22 +362,11 @@ func validationEntryFullURL(resource map[string]any, index int) string {
 // validator needs fullUrl to resolve inter-entry references; without it, it constructs
 // URLs from its own base and warns about mismatches.
 func injectInnerBundleFullURLs(resource map[string]any) {
-	if rt, _ := resource["resourceType"].(string); rt != "Bundle" {
+	if !lib.IsBundle(resource) {
 		return
 	}
 
-	// After JSON unmarshaling, entries are []any (not []map[string]any)
-	entries, ok := resource["entry"].([]any)
-	if !ok {
-		return
-	}
-
-	for _, entryAny := range entries {
-		entry, ok := entryAny.(map[string]any)
-		if !ok {
-			continue
-		}
-
+	for _, entry := range lib.BundleEntries(resource) {
 		if _, hasFullURL := entry["fullUrl"]; hasFullURL {
 			continue
 		}
@@ -393,11 +379,9 @@ func injectInnerBundleFullURLs(resource map[string]any) {
 			}
 		}
 
-		if res, ok := entry["resource"].(map[string]any); ok {
-			resType, _ := res["resourceType"].(string)
-			resID, _ := res["id"].(string)
-			if resType != "" && resID != "" {
-				entry["fullUrl"] = validationBaseURL + resType + "/" + resID
+		if res, ok := lib.EntryResource(entry); ok {
+			if ref := lib.ResourceReference(res); ref != "" {
+				entry["fullUrl"] = validationBaseURL + ref
 			}
 		}
 	}
@@ -471,8 +455,8 @@ func chunkResourcesWithOversized(entries []map[string]any, thresholdBytes int, l
 			partitions = append(partitions, []map[string]any{entry})
 
 			resourceType := "Unknown"
-			if resource, ok := entry["resource"].(map[string]any); ok {
-				if rt, ok := resource["resourceType"].(string); ok {
+			if resource, ok := lib.EntryResource(entry); ok {
+				if rt := lib.ResourceType(resource); rt != "" {
 					resourceType = rt
 				}
 			}

--- a/internal/services/bundle_splitter.go
+++ b/internal/services/bundle_splitter.go
@@ -48,6 +48,7 @@ package services
 import (
 	"fmt"
 
+	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
@@ -115,11 +116,11 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 			resourceType := "Unknown"
 			resourceID := "unknown"
 
-			if resource, ok := entry["resource"].(map[string]any); ok {
-				if rt, ok := resource["resourceType"].(string); ok {
+			if resource, ok := lib.EntryResource(entry); ok {
+				if rt := lib.ResourceType(resource); rt != "" {
 					resourceType = rt
 				}
-				if id, ok := resource["id"].(string); ok {
+				if id := lib.ResourceID(resource); id != "" {
 					resourceID = id
 				}
 			}
@@ -187,7 +188,7 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 // WHY: Returns immutable result structure (functional programming principle)
 func SplitBundle(bundle map[string]any, thresholdBytes int) (models.SplitResult, error) {
 	// Extract metadata first (validates Bundle structure)
-	metadata, err := models.ExtractBundleMetadata(bundle)
+	metadata, err := lib.ExtractBundleMetadata(bundle)
 	if err != nil {
 		return models.SplitResult{}, fmt.Errorf("invalid Bundle structure: %w", err)
 	}
@@ -201,7 +202,7 @@ func SplitBundle(bundle map[string]any, thresholdBytes int) (models.SplitResult,
 	// Check if splitting needed
 	if !ShouldSplit(bundleSize, thresholdBytes) {
 		// Bundle is small enough - return as single chunk
-		entries, err := models.ExtractEntriesFromBundle(bundle)
+		entries, err := lib.ExtractEntriesFromBundle(bundle)
 		if err != nil {
 			return models.SplitResult{}, fmt.Errorf("failed to extract entries: %w", err)
 		}
@@ -221,7 +222,7 @@ func SplitBundle(bundle map[string]any, thresholdBytes int) (models.SplitResult,
 	}
 
 	// Bundle needs splitting - extract entries
-	entries, err := models.ExtractEntriesFromBundle(bundle)
+	entries, err := lib.ExtractEntriesFromBundle(bundle)
 	if err != nil {
 		return models.SplitResult{}, fmt.Errorf("failed to extract entries: %w", err)
 	}
@@ -284,7 +285,7 @@ func ReassembleBundle(metadata models.BundleMetadata, pseudonymizedChunks []map[
 	firstChunk := pseudonymizedChunks[0]
 
 	// Validate first chunk structure
-	if resourceType, ok := firstChunk["resourceType"].(string); !ok || resourceType != "Bundle" {
+	if !lib.IsBundle(firstChunk) {
 		return models.ReassembledBundle{}, fmt.Errorf("first chunk is not a Bundle")
 	}
 
@@ -295,7 +296,7 @@ func ReassembleBundle(metadata models.BundleMetadata, pseudonymizedChunks []map[
 	}
 
 	// Extract entries from first chunk
-	firstChunkEntries, err := models.ExtractEntriesFromBundle(firstChunk)
+	firstChunkEntries, err := lib.ExtractEntriesFromBundle(firstChunk)
 	if err != nil {
 		return models.ReassembledBundle{}, fmt.Errorf("failed to extract entries from first chunk: %w", err)
 	}
@@ -306,12 +307,12 @@ func ReassembleBundle(metadata models.BundleMetadata, pseudonymizedChunks []map[
 		chunk := pseudonymizedChunks[i]
 
 		// Validate chunk structure
-		if resourceType, ok := chunk["resourceType"].(string); !ok || resourceType != "Bundle" {
+		if !lib.IsBundle(chunk) {
 			return models.ReassembledBundle{}, fmt.Errorf("chunk %d is not a Bundle", i)
 		}
 
 		// Extract entries from chunk
-		chunkEntries, err := models.ExtractEntriesFromBundle(chunk)
+		chunkEntries, err := lib.ExtractEntriesFromBundle(chunk)
 		if err != nil {
 			return models.ReassembledBundle{}, fmt.Errorf("failed to extract entries from chunk %d: %w", i, err)
 		}

--- a/internal/services/dimp_client.go
+++ b/internal/services/dimp_client.go
@@ -31,8 +31,8 @@ func NewDIMPClient(baseURL string, httpClient *HTTPClient, logger *lib.Logger) *
 // Per contract: POST /fhir/$de-identify with single FHIR resource
 func (c *DIMPClient) Pseudonymize(resource map[string]any) (map[string]any, error) {
 	// Extract resource info for logging
-	resourceType, _ := resource["resourceType"].(string)
-	resourceID, _ := resource["id"].(string)
+	resourceType := lib.ResourceType(resource)
+	resourceID := lib.ResourceID(resource)
 
 	// Endpoint per dimp-service contract; baseURL is the server root and
 	// the /fhir prefix is appended here (see issue #283).
@@ -107,8 +107,8 @@ func (c *DIMPClient) Pseudonymize(resource map[string]any) (map[string]any, erro
 	}
 
 	// Log what changed
-	originalID, _ := resource["id"].(string)
-	newID, _ := pseudonymized["id"].(string)
+	originalID := lib.ResourceID(resource)
+	newID := lib.ResourceID(pseudonymized)
 	if originalID != newID {
 		c.logger.Debug("Resource ID pseudonymized",
 			"resourceType", resourceType,

--- a/internal/services/fhir_client.go
+++ b/internal/services/fhir_client.go
@@ -217,22 +217,13 @@ func (c *FHIRClient) createTransactionBundle(resources []json.RawMessage) map[st
 			continue
 		}
 
-		resourceType, _ := resource["resourceType"].(string)
-
 		// Unwrap collection/searchset/transaction Bundles - extract entries as individual resources
 		// Transaction bundles from TORCH should be unwrapped since we create our own transaction
-		if resourceType == "Bundle" {
+		if lib.IsBundle(resource) {
 			bundleType, _ := resource["type"].(string)
 			if bundleType == "collection" || bundleType == "searchset" || bundleType == "transaction" {
-				// Extract entries from the Bundle
-				if bundleEntries, ok := resource["entry"].([]any); ok {
-					for _, entryAny := range bundleEntries {
-						if entry, ok := entryAny.(map[string]any); ok {
-							if entryResource, ok := entry["resource"].(map[string]any); ok {
-								entries = append(entries, c.createEntryFromResource(entryResource))
-							}
-						}
-					}
+				for _, entryResource := range lib.BundleResources(resource) {
+					entries = append(entries, c.createEntryFromResource(entryResource))
 				}
 				// Don't add the Bundle itself - we've extracted its resources
 				continue
@@ -257,8 +248,8 @@ func (c *FHIRClient) createTransactionBundle(resources []json.RawMessage) map[st
 
 // createEntryFromResource creates a transaction Bundle entry from a parsed resource
 func (c *FHIRClient) createEntryFromResource(resource map[string]any) map[string]any {
-	resourceType, _ := resource["resourceType"].(string)
-	id, hasID := resource["id"].(string)
+	resourceType := lib.ResourceType(resource)
+	id := lib.ResourceID(resource)
 
 	// Re-marshal the resource to JSON
 	resourceJSON, err := json.Marshal(resource)
@@ -273,7 +264,7 @@ func (c *FHIRClient) createEntryFromResource(resource map[string]any) map[string
 	}
 
 	var request map[string]any
-	if hasID && id != "" {
+	if id != "" {
 		// Use PUT to create/update with known ID
 		request = map[string]any{
 			"method": "PUT",

--- a/internal/services/validation_client.go
+++ b/internal/services/validation_client.go
@@ -55,8 +55,8 @@ func (r *ValidationResult) HasErrors() bool {
 // ValidateResource sends a FHIR resource to the validation service and returns the OperationOutcome.
 // Per contract: POST /validateResource with Content-Type: application/fhir+json
 func (c *ValidationClient) ValidateResource(resource map[string]any) (*ValidationResult, error) {
-	resourceType, _ := resource["resourceType"].(string)
-	resourceID, _ := resource["id"].(string)
+	resourceType := lib.ResourceType(resource)
+	resourceID := lib.ResourceID(resource)
 
 	c.logger.Debug("Sending resource to validator",
 		"resourceType", resourceType,

--- a/tests/unit/bundle_splitter_test.go
+++ b/tests/unit/bundle_splitter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
@@ -120,7 +121,7 @@ func TestExtractBundleMetadata(t *testing.T) {
 	t.Run("Extract from valid Bundle", func(t *testing.T) {
 		bundle := CreateTestBundle(10, 1)
 
-		metadata, err := models.ExtractBundleMetadata(bundle)
+		metadata, err := lib.ExtractBundleMetadata(bundle)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, metadata.ID, "Bundle ID should be present")
@@ -134,7 +135,7 @@ func TestExtractBundleMetadata(t *testing.T) {
 			"type": "collection",
 		}
 
-		_, err := models.ExtractBundleMetadata(bundle)
+		_, err := lib.ExtractBundleMetadata(bundle)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "id")
 	})
@@ -144,7 +145,7 @@ func TestExtractBundleMetadata(t *testing.T) {
 			"id": "test-bundle",
 		}
 
-		_, err := models.ExtractBundleMetadata(bundle)
+		_, err := lib.ExtractBundleMetadata(bundle)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "type")
 	})
@@ -236,7 +237,7 @@ func TestConvertChunkToBundle(t *testing.T) {
 func TestExtractEntriesFromBundle(t *testing.T) {
 	bundle := CreateTestBundle(5, 1)
 
-	entries, err := models.ExtractEntriesFromBundle(bundle)
+	entries, err := lib.ExtractEntriesFromBundle(bundle)
 	require.NoError(t, err)
 
 	assert.Equal(t, 5, len(entries))
@@ -252,7 +253,7 @@ func TestExtractEntriesFromBundle(t *testing.T) {
 func TestPartitionEntriesGreedyAlgorithm(t *testing.T) {
 	// Create Bundle with 100 entries of ~100KB each
 	bundle := CreateTestBundle(100, 100)
-	entries, err := models.ExtractEntriesFromBundle(bundle)
+	entries, err := lib.ExtractEntriesFromBundle(bundle)
 	require.NoError(t, err)
 
 	// With 100KB entries and 10MB threshold, expect roughly 100 chunks
@@ -302,11 +303,11 @@ func TestPartitionEntriesGreedyAlgorithm(t *testing.T) {
 func TestBundleMetadataRoundTrip(t *testing.T) {
 	// Create original Bundle
 	original := CreateTestBundle(50, 10)
-	originalMetadata, err := models.ExtractBundleMetadata(original)
+	originalMetadata, err := lib.ExtractBundleMetadata(original)
 	require.NoError(t, err)
 
 	// Create chunk from metadata
-	entries, _ := models.ExtractEntriesFromBundle(original)
+	entries, _ := lib.ExtractEntriesFromBundle(original)
 	chunk, err := models.CreateBundleChunk(originalMetadata, entries[:10], 0, 3)
 	require.NoError(t, err)
 
@@ -369,11 +370,11 @@ func TestEdgeCase_MixedResourceTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract and verify
-	metadata, err := models.ExtractBundleMetadata(bundle)
+	metadata, err := lib.ExtractBundleMetadata(bundle)
 	require.NoError(t, err)
 	assert.Equal(t, "mixed-types-bundle", metadata.ID)
 
-	extractedEntries, err := models.ExtractEntriesFromBundle(bundle)
+	extractedEntries, err := lib.ExtractEntriesFromBundle(bundle)
 	require.NoError(t, err)
 	assert.Len(t, extractedEntries, 3, "Should have 3 entries of different types")
 
@@ -391,11 +392,11 @@ func TestEdgeCase_EmptyBundle(t *testing.T) {
 		"entry":        []any{},
 	}
 
-	metadata, err := models.ExtractBundleMetadata(bundle)
+	metadata, err := lib.ExtractBundleMetadata(bundle)
 	require.NoError(t, err)
 	assert.Equal(t, "empty-bundle", metadata.ID)
 
-	entries, err := models.ExtractEntriesFromBundle(bundle)
+	entries, err := lib.ExtractEntriesFromBundle(bundle)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "Empty bundle should have no entries")
 
@@ -431,10 +432,10 @@ func TestEdgeCase_SingleOversizedEntry(t *testing.T) {
 		"entry":        entries,
 	}
 
-	metadata, err := models.ExtractBundleMetadata(bundle)
+	metadata, err := lib.ExtractBundleMetadata(bundle)
 	require.NoError(t, err)
 
-	extractedEntries, err := models.ExtractEntriesFromBundle(bundle)
+	extractedEntries, err := lib.ExtractEntriesFromBundle(bundle)
 	require.NoError(t, err)
 	require.Len(t, extractedEntries, 1)
 
@@ -486,7 +487,7 @@ func TestEdgeCase_BundleWithFullUrlReferences(t *testing.T) {
 		"entry":        entries,
 	}
 
-	extractedEntries, err := models.ExtractEntriesFromBundle(bundle)
+	extractedEntries, err := lib.ExtractEntriesFromBundle(bundle)
 	require.NoError(t, err)
 	assert.Len(t, extractedEntries, 2)
 

--- a/tests/unit/fhir_bundle_test.go
+++ b/tests/unit/fhir_bundle_test.go
@@ -1,0 +1,93 @@
+package unit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+func TestResourceType(t *testing.T) {
+	assert.Equal(t, "Patient", lib.ResourceType(map[string]any{"resourceType": "Patient"}))
+	assert.Equal(t, "", lib.ResourceType(map[string]any{}), "missing resourceType yields empty string")
+	assert.Equal(t, "", lib.ResourceType(map[string]any{"resourceType": 42}), "non-string resourceType yields empty string")
+}
+
+func TestResourceID(t *testing.T) {
+	assert.Equal(t, "p1", lib.ResourceID(map[string]any{"id": "p1"}))
+	assert.Equal(t, "", lib.ResourceID(map[string]any{}), "missing id yields empty string")
+	assert.Equal(t, "", lib.ResourceID(map[string]any{"id": 42}), "non-string id yields empty string")
+}
+
+func TestIsProvenance(t *testing.T) {
+	assert.True(t, lib.IsProvenance(map[string]any{"resourceType": "Provenance"}))
+	assert.False(t, lib.IsProvenance(map[string]any{"resourceType": "Patient"}))
+	assert.False(t, lib.IsProvenance(map[string]any{}), "missing resourceType is not Provenance")
+}
+
+func TestIsBundle(t *testing.T) {
+	assert.True(t, lib.IsBundle(map[string]any{"resourceType": "Bundle"}))
+	assert.False(t, lib.IsBundle(map[string]any{"resourceType": "Patient"}))
+	assert.False(t, lib.IsBundle(map[string]any{}), "missing resourceType is not Bundle")
+}
+
+func TestLibResourceReference(t *testing.T) {
+	assert.Equal(t, "Patient/p1", lib.ResourceReference(map[string]any{"resourceType": "Patient", "id": "p1"}))
+	assert.Equal(t, "", lib.ResourceReference(map[string]any{"resourceType": "Patient"}), "missing id yields empty reference")
+	assert.Equal(t, "", lib.ResourceReference(map[string]any{"id": "p1"}), "missing resourceType yields empty reference")
+	assert.Equal(t, "", lib.ResourceReference(map[string]any{}))
+}
+
+func TestEntryResource(t *testing.T) {
+	entry := map[string]any{
+		"fullUrl":  "urn:uuid:p1",
+		"resource": map[string]any{"resourceType": "Patient", "id": "p1"},
+	}
+	res, ok := lib.EntryResource(entry)
+	assert.True(t, ok)
+	assert.Equal(t, "Patient", lib.ResourceType(res))
+
+	_, ok = lib.EntryResource(map[string]any{"fullUrl": "urn:uuid:x"})
+	assert.False(t, ok, "entry without resource yields ok=false")
+}
+
+func TestBundleResources(t *testing.T) {
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "collection",
+		"entry": []any{
+			map[string]any{"resource": map[string]any{"resourceType": "Patient", "id": "p1"}},
+			"not-an-object",                         // malformed entry: skipped
+			map[string]any{"fullUrl": "urn:uuid:x"}, // entry without resource: skipped
+			map[string]any{"resource": map[string]any{"resourceType": "Observation", "id": "o1"}},
+		},
+	}
+	resources := lib.BundleResources(bundle)
+	assert.Len(t, resources, 2, "malformed entries and resource-less entries are skipped")
+	assert.Equal(t, "Patient", lib.ResourceType(resources[0]))
+	assert.Equal(t, "Observation", lib.ResourceType(resources[1]))
+
+	assert.Empty(t, lib.BundleResources(map[string]any{"resourceType": "Bundle"}), "bundle without entry array yields no resources")
+}
+
+func TestBundleEntries(t *testing.T) {
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"entry": []any{
+			map[string]any{"fullUrl": "urn:uuid:p1", "resource": map[string]any{"resourceType": "Patient"}},
+			"not-an-object", // malformed entry: skipped
+			map[string]any{"request": map[string]any{"url": "Patient"}},
+		},
+	}
+	entries := lib.BundleEntries(bundle)
+	assert.Len(t, entries, 2, "malformed entries are skipped")
+	assert.Equal(t, "urn:uuid:p1", entries[0]["fullUrl"])
+
+	// Entries are the underlying maps: mutation propagates to the bundle.
+	entries[1]["fullUrl"] = "urn:uuid:added"
+	rawEntries := bundle["entry"].([]any)
+	assert.Equal(t, "urn:uuid:added", rawEntries[2].(map[string]any)["fullUrl"])
+
+	assert.Empty(t, lib.BundleEntries(map[string]any{"resourceType": "Bundle"}), "bundle without entry array yields no entries")
+}

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -148,19 +148,6 @@ func TestFilterResourcesByProvenance(t *testing.T) {
 	})
 }
 
-func TestResourceReference(t *testing.T) {
-	t.Run("builds reference from resource", func(t *testing.T) {
-		r := map[string]any{"resourceType": "Patient", "id": "123"}
-		assert.Equal(t, "Patient/123", pipeline.ResourceReference(r))
-	})
-
-	t.Run("returns empty for missing fields", func(t *testing.T) {
-		assert.Equal(t, "", pipeline.ResourceReference(map[string]any{"resourceType": "Patient"}))
-		assert.Equal(t, "", pipeline.ResourceReference(map[string]any{"id": "1"}))
-		assert.Equal(t, "", pipeline.ResourceReference(map[string]any{}))
-	})
-}
-
 func TestIsFlatteningErrorRetryable(t *testing.T) {
 	t.Run("transient FlattenerError is retryable", func(t *testing.T) {
 		err := &services.FlattenerError{


### PR DESCRIPTION
## Summary

Creates `internal/lib/bundle.go` as the single module that owns FHIR Bundle and resource access, replacing hand-rolled `map[string]any` type-assertions and Provenance detection that were duplicated across the codebase. This is the foundation for the #421 sub-issues (client work D and step-seam work E).

## What changed

- **New module `internal/lib/bundle.go`** exposing typed access:
  - `ResourceType`, `ResourceID`, `ResourceReference`
  - `IsBundle`, `IsProvenance` (Provenance classification now in exactly one place)
  - `EntryResource`, `BundleEntries`, `BundleResources` (loose, never-error iteration)
  - `ExtractEntriesFromBundle`, `ExtractBundleMetadata` (**moved** from `internal/models/bundle.go`; `models` keeps only the data structs and chunk builders)
- **~19 duplicated call sites routed** through the module across `internal/services/{bundle_splitter,fhir_client,validation_client,dimp_client}.go`, `internal/pipeline/{flattening,dimp,validation}.go`, and `internal/lib/validation.go`.
- New unit tests (`tests/unit/fhir_bundle_test.go`) use synthetic Bundle builders — no NDJSON fixtures.

Net: −172/+62 in existing files; the only `"Provenance"` classification literal in production now lives in `lib.IsProvenance`.

## Why `internal/lib`

`lib` already owns `FHIRResource`, NDJSON parsing and `GroupByResourceType`, and already imports `models` (so `lib.ExtractBundleMetadata` returning `models.BundleMetadata` introduces no cycle — `models` does not import `lib`).

## Notes for review (behavior preserved, with two deliberate edge-case calls)

- `extractBundleResources` previously returned a `nil` ProvenanceIndex for a missing/non-array `entry`; it now returns an empty index. No production caller distinguishes the two (one ranges over it, one discards it). Two over-strict internal-test assertions were aligned to `assert.Empty` to match their sibling assertion in the same test.
- The `"Unknown"`/`"unknown"` error-message fallbacks (oversized-resource paths) now treat a present-but-empty `resourceType`/`id` the same as missing — keeping the fallback rather than emitting an empty string. This only affects a degenerate, non-FHIR-valid resource.
- Removed the dead `pipeline.ResourceReference` wrapper (delegated straight to `lib.ResourceReference`) and its now-redundant test.

Closes #423