### PR TITLE
fix(cli): remove redundant error output on step failure

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,11 @@ For more information:
   Documentation: https://github.com/medizininformatik-initiative/aether
   Report issues: https://github.com/medizininformatik-initiative/aether/issues`,
 	Version: version,
+
+	// A runtime failure already surfaces a single user-facing error via Execute;
+	// let Cobra neither reprint it nor dump the usage/flags block on error.
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 // SetVersion sets the version displayed by --version. Call before Execute.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A subcommand failure must surface a single clean error without Cobra dumping
+// the usage/flags block or printing the error itself. Execute() owns the one
+// user-facing `Error:` line, so Cobra must stay silent on both (issue #467).
+func TestRootCommand_FailureSuppressesUsageAndCobraError(t *testing.T) {
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"pipeline", "start", "only-one-arg"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	err := rootCmd.Execute()
+
+	require.Error(t, err)
+	assert.NotContains(t, out.String(), "Usage:")
+	assert.NotContains(t, out.String(), "Error:")
+}

--- a/internal/lib/logging.go
+++ b/internal/lib/logging.go
@@ -100,14 +100,19 @@ func (l *Logger) Error(message string, fields ...any) {
 	l.log(LogLevelError, "ERROR", message, fields...)
 }
 
-// log formats a message once and fans it out: to the console only when its
-// severity meets the configured level, and to the attached job log file always.
-func (l *Logger) log(lvl LogLevel, label string, message string, fields ...any) {
+// formatLogLine renders a single structured log line shared by every sink.
+func formatLogLine(label string, message string, fields ...any) string {
 	var fieldsStr string
 	if len(fields) > 0 {
 		fieldsStr = fmt.Sprintf(" | %v", fields)
 	}
-	line := fmt.Sprintf("[%s] %s%s", label, message, fieldsStr)
+	return fmt.Sprintf("[%s] %s%s", label, message, fieldsStr)
+}
+
+// log formats a message once and fans it out: to the console only when its
+// severity meets the configured level, and to the attached job log file always.
+func (l *Logger) log(lvl LogLevel, label string, message string, fields ...any) {
+	line := formatLogLine(label, message, fields...)
 
 	if lvl >= l.level {
 		l.console.Println(line)
@@ -115,6 +120,19 @@ func (l *Logger) log(lvl LogLevel, label string, message string, fields ...any) 
 	if l.fileLogger != nil {
 		l.fileLogger.Println(line)
 	}
+}
+
+// logFailure records a structured failure line. When a job log file is attached
+// it writes there only, keeping the console clean because the failure is already
+// surfaced to the user as a top-level `Error:` line. With no file attached it
+// falls back to the console so the record is never silently dropped.
+func (l *Logger) logFailure(label string, message string, fields ...any) {
+	line := formatLogLine(label, message, fields...)
+	if l.fileLogger != nil {
+		l.fileLogger.Println(line)
+		return
+	}
+	l.console.Println(line)
 }
 
 // LogOperation logs the start and completion of an operation
@@ -165,9 +183,12 @@ func LogStepComplete(logger *Logger, stepName string, jobID string, filesProcess
 	)
 }
 
-// LogStepFailed logs a failed pipeline step
+// LogStepFailed records a failed pipeline step to the job log file only. The
+// failure is surfaced to the user as a top-level `Error:` line, so logging it to
+// the console as well would duplicate the same error on stderr.
 func LogStepFailed(logger *Logger, stepName string, jobID string, err error, retryable bool) {
-	logger.Error(
+	logger.logFailure(
+		"ERROR",
 		"Step failed",
 		"step", stepName,
 		"job_id", jobID,

--- a/tests/unit/logging_test.go
+++ b/tests/unit/logging_test.go
@@ -2,6 +2,7 @@ package unit
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,47 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
+
+// A failed step is already surfaced to the user as a top-level `Error:` line, so
+// LogStepFailed must keep its structured record in the job log file only and stay
+// off the console to avoid duplicating the same failure on stderr (issue #467).
+func TestLogStepFailed_FileOnlyNotConsole(t *testing.T) {
+	var console bytes.Buffer
+	logger := lib.NewLoggerWithWriter(lib.LogLevelError, &console)
+
+	logPath := filepath.Join(t.TempDir(), "job.log")
+	require.NoError(t, logger.AttachJobLogFile(logPath))
+
+	lib.LogStepFailed(logger, "torch", "job123", errors.New("boom"), false)
+	require.NoError(t, logger.Close())
+
+	// Console: nothing — the user-facing `Error:` line covers it.
+	assert.Empty(t, console.String())
+
+	// File: full structured record retained for diagnostics.
+	fileContent, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	file := string(fileContent)
+	assert.Contains(t, file, "Step failed")
+	assert.Contains(t, file, "torch")
+	assert.Contains(t, file, "job123")
+	assert.Contains(t, file, "boom")
+}
+
+// Without an attached job log file the failure record has nowhere to go, so it
+// must fall back to the console rather than vanish silently (issue #467).
+func TestLogStepFailed_FallsBackToConsoleWhenNoFile(t *testing.T) {
+	var console bytes.Buffer
+	logger := lib.NewLoggerWithWriter(lib.LogLevelError, &console)
+
+	lib.LogStepFailed(logger, "torch", "job123", errors.New("boom"), false)
+
+	out := console.String()
+	assert.Contains(t, out, "Step failed")
+	assert.Contains(t, out, "torch")
+	assert.Contains(t, out, "job123")
+	assert.Contains(t, out, "boom")
+}
 
 // Console respects the configured level, but the attached job log file always
 // captures full DEBUG output regardless of the console level (issue #409).


### PR DESCRIPTION
## Problem

Closes #467. A TORCH (or any) pipeline step failure produced excessively redundant output: the full error text appeared three times and was followed by a useless usage/flags dump.

Two defects:
- `rootCmd` set neither `SilenceUsage` nor `SilenceErrors`, so Cobra printed `Error:` **and** the `Usage:`/`Flags:` block on a `RunE` failure — then `Execute()` reprinted `Error:` a second time.
- `LogStepFailed` wrote the structured `[ERROR] Step failed` line to the console, duplicating the final `Error:` line.

## Changes

- **`cmd/root.go`**: `SilenceUsage: true, SilenceErrors: true` on `rootCmd`. Cobra stops reprinting the error and dumping usage; `Execute()`'s `Fprintf` remains the single user-facing `Error:` line.
- **`internal/lib/logging.go`**: extract `formatLogLine`, add a `fileOnly` sink, and route `LogStepFailed` to it. The structured failure record (step/job_id/error/retryable) is still persisted to `jobs/<id>/job.log`, just no longer echoed to the console.

## Result

Failure output is now the progress line plus one `Error: ... step failed: ...`. No usage/flags dump. Full diagnostics preserved in `job.log`.

## Tests

- `tests/unit/logging_test.go::TestLogStepFailed_FileOnlyNotConsole` — console empty, file retains the record.
- `cmd/root_test.go::TestRootCommand_FailureSuppressesUsageAndCobraError` — failing subcommand emits no `Usage:` and no Cobra `Error:`.