### PR TITLE
feat(torch): re-attach to in-flight extractions + liveness timeout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Context
+
+Glossary of domain language for aether. Terms only — no implementation detail.
+
+## Pipeline
+
+- **Pipeline job** — one execution of the Data Use Process in aether, identified by an aether job ID, persisted on disk under `jobs/<job-id>/`. Has an ordered list of steps and a status.
+- **Import step** — the pipeline step that brings FHIR data into the job. One of three modes: local import, HTTP import, or **TORCH extraction**.
+
+## TORCH extraction
+
+- **TORCH** — external FHIR extraction service. Given a CRTDL query it selects a cohort and extracts the requested resources.
+- **Extraction job** — the server-side unit of work TORCH runs in response to a kick-off. Identified by a **TORCH job ID** (a UUID, distinct from the aether pipeline job ID). Long-running for large cohorts (can run for hours at 100k+ patients).
+- **Job handle** — the identifier aether persists so it can reconnect to an extraction job it already started: the TORCH job ID (and the status URL derived from / returned with it). Without a persisted handle, a crashed aether run cannot tell TORCH "I already started this."
+- **Re-attach** — on resume, reconnecting to an existing extraction job (polling its status) instead of submitting a new kick-off. The opposite of re-submitting, which would start the extraction over from scratch.
+- **Orphan** — a server-side extraction job that is still running (or holding results) but for which aether has lost or never persisted the handle. Causes duplicate load on the source FHIR server when aether re-submits (each kick-off mints a new TORCH job ID — there is no dedup). TORCH has no time-based expiry: jobs and results persist until an explicit `DELETE`, after which a garbage collector reclaims the directory. Orphans do not self-clean.
+- **Re-roll** — TORCH's own recovery on restart: in-progress extraction jobs are reset to a reprocessable state, so a persisted **job handle** stays valid and **re-attach** works across a TORCH restart.
+
+## Extraction job status
+
+The lifecycle a TORCH extraction job moves through (coding system `https://medizininformatik-initiative.de/torch/job-status`):
+
+- **PENDING** — accepted, not yet started.
+- **RUNNING_GET_COHORT** — selecting the cohort.
+- **RUNNING_PROCESS_BATCH** — extracting patient batches.
+- **RUNNING_PROCESS_CORE** — assembling the shared (non-patient) `core` resources.
+- **PAUSED** — paused, resumable.
+- **TEMP_FAILED** — failed transiently; **not terminal**, TORCH will retry.
+- **COMPLETED** / **FAILED** / **CANCELLED** — terminal. (`DELETED` is internal bookkeeping and never appears in a Task response.)

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -13,9 +13,11 @@ services:
     username: "test"
     password: "test"
 
-    # Maximum time to wait for extraction completion
-    # Accepts ISO 8601 (e.g. PT30M) or Go format (e.g. 30m)
-    # Default: PT30M (30 minutes, reasonable for typical cohort sizes)
+    # Liveness window: max time to wait WITHOUT a response from TORCH, not a
+    # total cap. Reset on every status response (200/202), so a long-running
+    # extraction that keeps responding never trips it — aether only gives up
+    # when TORCH goes silent for this long. See docs/adr/0001-extraction-timeout-liveness.md.
+    # Accepts ISO 8601 (e.g. PT30M) or Go format (e.g. 30m). Default: PT30M.
     extraction_timeout: PT30M
 
     # Initial polling interval when checking extraction status

--- a/docs/adr/0001-extraction-timeout-liveness.md
+++ b/docs/adr/0001-extraction-timeout-liveness.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+---
+
+# `extraction_timeout` is a liveness (no-progress) timeout, not a total cap
+
+TORCH extractions for large cohorts (100k+ patients) legitimately run for hours, but the
+`extraction_timeout` config (default 30 min) was a hard total cap measured from the start of each
+poll run — so a healthy long job was killed for being long, and resuming only restarted the same
+30-minute clock. We redefine `extraction_timeout` as the maximum time aether will wait **since last
+contact with TORCH**, reset on every `202`/`200` poll response. A healthy job (polling at least every
+`max_polling_interval`) never trips it; aether only gives up when TORCH goes silent.
+
+## Considered options
+
+- **Redefine the existing `extraction_timeout` key (chosen)** — no new config surface; the new
+  meaning is what operators actually want. Cost: a silent behavior change for anyone who relied on it
+  as a total-cost ceiling (rare; called out in the config comment and changelog).
+- **Add a new `poll_liveness_timeout` key, keep `extraction_timeout` as a total cap** — cleaner
+  naming but adds config surface and a deprecation story for a meaning almost nobody wants.
+- **Liveness timeout plus a large absolute ceiling** — rejected for now; the only case it guards is a
+  TORCH job stuck returning `202` forever (a TORCH bug), which an operator can interrupt manually.
+
+## Consequences
+
+- A TORCH job that stays responsive (`202`) but never completes will be polled indefinitely until
+  manually interrupted. Accepted as a TORCH-side fault, not aether's to bound.

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -109,7 +109,7 @@ services:
 | `base_url` | string | - | TORCH server URL (required if torch step enabled) |
 | `username` | string | - | Authentication username |
 | `password` | string | - | Authentication password |
-| `extraction_timeout` | duration | PT30M | Max wait time for extraction. Also serves as the safety net for transient polling errors — polling retries until this timeout is exceeded. |
+| `extraction_timeout` | duration | PT30M | Liveness window, not a total cap: max time to wait without a response from TORCH. Reset on every status response (200/202), so a long but responsive extraction never trips it. See [ADR 0001](../adr/0001-extraction-timeout-liveness.md). |
 | `polling_interval` | duration | PT5S | Initial status check interval |
 | `max_polling_interval` | duration | PT30S | Max interval (exponential backoff cap) |
 | `file_ready_retries` | int | 10 | Number of retries for file availability check |

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -54,17 +54,15 @@ services:
     polling_interval: PT10S      # Default is PT5S
 ```
 
-For extractions that may take several days (e.g., large patient cohorts), set `extraction_timeout_minutes` accordingly:
-
-```yaml
-services:
-  torch:
-    extraction_timeout_minutes: 4320  # 3 days
-```
+`extraction_timeout` is a **liveness window**, not a total cap: it bounds how long aether waits *without a response from TORCH*, and it resets on every status response (`200`/`202`). A multi-hour extraction that keeps responding never trips it, so you no longer need to size the timeout to the whole extraction — the default `PT30M` means "give up after 30 minutes of TORCH silence". See [ADR 0001](../adr/0001-extraction-timeout-liveness.md).
 
 ### Polling Resilience
 
-During status polling, transient HTTP errors (timeouts, connection resets) are treated as recoverable. If TORCH is temporarily unable to respond to status requests — for example, because it is saturated with CPU-intensive FHIR operations — aether logs a warning and continues polling with exponential backoff rather than failing the entire extraction. The `extraction_timeout_minutes` setting acts as the safety net: polling only stops when this overall timeout is exceeded.
+During status polling, transient HTTP errors (timeouts, connection resets) and transient TORCH responses (`503`/`429`/`408`) are treated as recoverable: aether logs a warning and keeps polling with exponential backoff rather than failing the extraction. A `500` is a terminal job failure and fails fast. Because the timeout is a liveness window (reset on every `200`/`202`), polling only stops when TORCH stays silent for longer than `extraction_timeout`.
+
+### Resuming an Interrupted Extraction
+
+When aether submits an extraction it persists the TORCH **job handle** (job ID + status URL) to disk *before* the long poll. If aether is interrupted (process killed, connection lost, timeout), `aether pipeline continue <job-id>` **re-attaches** to the same in-flight TORCH job and resumes polling — it does not re-submit the CRTDL, so the source FHIR server is not extracted twice. If the handle is no longer valid on TORCH (`404`/`410`, i.e. the job was cancelled or deleted), aether logs a warning, clears the stale handle, and submits a fresh extraction.
 
 ### Direct TORCH URL Import
 

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -11,6 +11,7 @@ type PipelineJob struct {
 	InputType          InputType      `json:"input_type"`                     // "local_directory" | "http_url" | "crtdl_file" | "torch_result_url"
 	CRTDLPath          string         `json:"crtdl_path,omitempty"`           // Optional CRTDL file, decoupled from InputSource (see issue #286)
 	TORCHExtractionURL string         `json:"torch_extraction_url,omitempty"` // Content-Location URL for TORCH polling/resume
+	TORCHJobID         string         `json:"torch_job_id,omitempty"`         // TORCH job ID (handle) for re-attaching to an in-flight extraction
 	CurrentStep        string         `json:"current_step"`                   // Current pipeline step
 	Status             JobStatus      `json:"status"`                         // Job execution status
 	Steps              []PipelineStep `json:"steps"`                          // Ordered list of pipeline steps

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -144,15 +145,22 @@ func failImportStep(job *models.PipelineJob, err error, errorType models.ErrorTy
 func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClient *services.HTTPClient, logger *lib.Logger, showProgress bool, compress bool, compressionLevel string) ([]models.FHIRDataFile, error) {
 	torchClient := services.NewTORCHClient(job.Config.Services.TORCH, httpClient, logger)
 
-	extractionURL, err := torchClient.SubmitExtraction(job.CRTDLPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to submit TORCH extraction: %w", err)
+	if job.TORCHJobID != "" {
+		logger.Info("Re-attaching to in-flight TORCH extraction", "job_id", job.TORCHJobID, "url", job.TORCHExtractionURL)
+	} else if err := submitAndPersistTORCHHandle(job, torchClient, logger); err != nil {
+		return nil, err
 	}
 
-	job.TORCHExtractionURL = extractionURL
-	logger.Info("TORCH extraction URL stored for resumption", "url", extractionURL)
-
-	fileURLs, err := torchClient.PollExtractionStatus(extractionURL, showProgress)
+	fileURLs, err := torchClient.PollExtractionStatus(job.TORCHExtractionURL, showProgress)
+	if errors.Is(err, services.ErrHandleDead) {
+		logger.Warn("TORCH job handle is gone; clearing handle and re-submitting a fresh extraction", "stale_job_id", job.TORCHJobID)
+		job.TORCHJobID = ""
+		job.TORCHExtractionURL = ""
+		if err := submitAndPersistTORCHHandle(job, torchClient, logger); err != nil {
+			return nil, err
+		}
+		fileURLs, err = torchClient.PollExtractionStatus(job.TORCHExtractionURL, showProgress)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("TORCH extraction failed: %w", err)
 	}
@@ -167,6 +175,25 @@ func executeTORCHExtraction(job *models.PipelineJob, importDir string, httpClien
 		return nil, fmt.Errorf("failed to download TORCH files: %w", err)
 	}
 	return files, nil
+}
+
+// submitAndPersistTORCHHandle submits the CRTDL for extraction, then persists
+// the resulting job handle (TORCHJobID + URL) to disk before any long poll, so
+// a crash mid-extraction leaves a recoverable handle to re-attach to.
+func submitAndPersistTORCHHandle(job *models.PipelineJob, torchClient *services.TORCHClient, logger *lib.Logger) error {
+	extractionURL, err := torchClient.SubmitExtraction(job.CRTDLPath)
+	if err != nil {
+		return fmt.Errorf("failed to submit TORCH extraction: %w", err)
+	}
+
+	job.TORCHExtractionURL = extractionURL
+	job.TORCHJobID = services.JobIDFromStatusURL(extractionURL)
+	if err := UpdateJob(job.Config.JobsDir, job); err != nil {
+		return fmt.Errorf("failed to persist TORCH job handle: %w", err)
+	}
+
+	logger.Info("TORCH extraction submitted; handle persisted for resume", "job_id", job.TORCHJobID, "url", extractionURL)
+	return nil
 }
 
 // executeTORCHDownload downloads files from a direct TORCH result URL
@@ -201,8 +228,10 @@ func classifyImportError(err error, step models.StepName) models.ErrorType {
 		return models.ErrorTypeNonTransient
 	}
 
-	// Check for TORCH-specific errors
-	if torchErr, ok := err.(*services.TORCHError); ok {
+	// Check for TORCH-specific errors, including wrapped ones (submit/poll paths
+	// wrap the TORCHError with context).
+	var torchErr *services.TORCHError
+	if errors.As(err, &torchErr) {
 		return torchErr.ErrorType
 	}
 

--- a/internal/pipeline/import_reattach_test.go
+++ b/internal/pipeline/import_reattach_test.go
@@ -1,0 +1,264 @@
+package pipeline
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+func writeTestCRTDL(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "query.crtdl")
+	require.NoError(t, os.WriteFile(path, []byte(`{"cohortDefinition":{},"dataExtraction":{}}`), 0o644))
+	return path
+}
+
+// reattachTestServer serves a TORCH stand-in. It records whether the
+// $extract-data kick-off endpoint was hit so tests can assert re-attach
+// behavior (poll an existing job without re-submitting).
+type reattachTestServer struct {
+	server      *httptest.Server
+	submitCount int32
+}
+
+func (s *reattachTestServer) submits() int { return int(atomic.LoadInt32(&s.submitCount)) }
+
+func (s *reattachTestServer) baseURL() string { return s.server.URL }
+
+func (s *reattachTestServer) close() { s.server.Close() }
+
+func newTORCHTestClientConfig(baseURL string) models.TORCHConfig {
+	return models.TORCHConfig{
+		BaseURL:            baseURL,
+		ExtractionTimeout:  1 * time.Minute,
+		PollingInterval:    1 * time.Second,
+		MaxPollingInterval: 1 * time.Second,
+	}
+}
+
+func newReattachJob(t *testing.T, torchCfg models.TORCHConfig) *models.PipelineJob {
+	t.Helper()
+	cfg := models.DefaultConfig()
+	cfg.JobsDir = t.TempDir()
+	cfg.Services.TORCH = torchCfg
+	cfg.Compression.Enabled = false
+	return &models.PipelineJob{
+		JobID:     "550e8400-e29b-41d4-a716-446655440000",
+		InputType: models.InputTypeCRTDL,
+		Status:    models.JobStatusInProgress,
+		Config:    cfg,
+	}
+}
+
+func newTestHTTPClient(logger *lib.Logger) *services.HTTPClient {
+	return services.NewHTTPClient(
+		10*time.Second,
+		models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100},
+		models.TLSConfig{},
+		logger,
+	)
+}
+
+// Slice 1: resuming with a stored TORCHJobID must re-attach (poll the
+// existing job) and must NOT submit a new extraction.
+func TestExecuteTORCHExtraction_ReattachSkipsSubmit(t *testing.T) {
+	rt := &reattachTestServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fhir/$extract-data", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&rt.submitCount, 1)
+		w.Header().Set("Content-Location", rt.baseURL()+"/fhir/__status/should-not-happen")
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/fhir/__status/existing-job", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"type":"Patient","url":"` + rt.baseURL() + `/output/patients.ndjson"}]}`))
+	})
+	mux.HandleFunc("/output/patients.ndjson", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"p1"}` + "\n"))
+	})
+	rt.server = httptest.NewServer(mux)
+	defer rt.close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job := newReattachJob(t, newTORCHTestClientConfig(rt.baseURL()))
+	job.TORCHJobID = "existing-job"
+	job.TORCHExtractionURL = rt.baseURL() + "/fhir/__status/existing-job"
+
+	files, err := executeTORCHExtraction(job, t.TempDir(), newTestHTTPClient(logger), logger, false, false, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, rt.submits(), "re-attach must not POST $extract-data")
+	assert.Len(t, files, 1, "should download the file from the re-attached job")
+}
+
+// Slice 2: after a fresh submit, the job handle (TORCHJobID + URL) must be
+// persisted to disk BEFORE the long poll begins, so a crash mid-extraction
+// leaves a recoverable handle.
+func TestExecuteTORCHExtraction_PersistsHandleBeforePolling(t *testing.T) {
+	const torchJobID = "fresh-job-uuid-123"
+	var handleOnDiskAtPoll string
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job := newReattachJob(t, models.TORCHConfig{}) // BaseURL filled in below
+	job.CRTDLPath = writeTestCRTDL(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fhir/$extract-data", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Location", "http://"+r.Host+"/fhir/__status/"+torchJobID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/fhir/__status/"+torchJobID, func(w http.ResponseWriter, r *http.Request) {
+		// Polling has begun — the handle must already be on disk by now.
+		reloaded, err := LoadJob(job.Config.JobsDir, job.JobID)
+		if err == nil {
+			handleOnDiskAtPoll = reloaded.TORCHJobID
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"type":"Patient","url":"http://` + r.Host + `/output/p.ndjson"}]}`))
+	})
+	mux.HandleFunc("/output/p.ndjson", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"p1"}` + "\n"))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	job.Config.Services.TORCH = newTORCHTestClientConfig(server.URL)
+	require.NoError(t, UpdateJob(job.Config.JobsDir, job)) // initial on-disk state, no handle yet
+
+	files, err := executeTORCHExtraction(job, t.TempDir(), newTestHTTPClient(logger), logger, false, false, "")
+
+	require.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Equal(t, torchJobID, job.TORCHJobID, "handle set in memory")
+	assert.Equal(t, torchJobID, handleOnDiskAtPoll, "handle persisted to disk before polling")
+}
+
+// Slice 3: a dead handle (404/410) on re-attach must clear the stale handle
+// and re-submit a fresh extraction.
+func TestExecuteTORCHExtraction_DeadHandleResubmits(t *testing.T) {
+	const newJobID = "fresh-after-410"
+	rt := &reattachTestServer{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fhir/__status/stale-job", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGone) // 410 — handle is dead
+	})
+	mux.HandleFunc("/fhir/$extract-data", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&rt.submitCount, 1)
+		w.Header().Set("Content-Location", "http://"+r.Host+"/fhir/__status/"+newJobID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+	mux.HandleFunc("/fhir/__status/"+newJobID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"type":"Patient","url":"http://` + r.Host + `/output/p.ndjson"}]}`))
+	})
+	mux.HandleFunc("/output/p.ndjson", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"p1"}` + "\n"))
+	})
+	rt.server = httptest.NewServer(mux)
+	defer rt.close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job := newReattachJob(t, newTORCHTestClientConfig(rt.baseURL()))
+	job.CRTDLPath = writeTestCRTDL(t)
+	job.TORCHJobID = "stale-job"
+	job.TORCHExtractionURL = rt.baseURL() + "/fhir/__status/stale-job"
+
+	files, err := executeTORCHExtraction(job, t.TempDir(), newTestHTTPClient(logger), logger, false, false, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, rt.submits(), "dead handle must trigger exactly one re-submit")
+	assert.Equal(t, newJobID, job.TORCHJobID, "handle replaced with the fresh job ID")
+	assert.Len(t, files, 1)
+}
+
+// Slice 4: a fresh extraction whose submit TORCH rejects must surface the
+// wrapped submit error — there is no handle to persist and nothing to poll.
+func TestExecuteTORCHExtraction_FreshSubmitError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fhir/$extract-data", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job := newReattachJob(t, newTORCHTestClientConfig(server.URL))
+	job.CRTDLPath = writeTestCRTDL(t)
+
+	files, err := executeTORCHExtraction(job, t.TempDir(), newTestHTTPClient(logger), logger, false, false, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to submit TORCH extraction")
+	assert.Empty(t, files)
+}
+
+// Slice 5: a dead handle clears cleanly, but if the follow-up re-submit is
+// then rejected the re-submit error must surface (not the stale-handle state).
+func TestExecuteTORCHExtraction_DeadHandleResubmitError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fhir/__status/stale-job", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGone) // 410 — handle is dead
+	})
+	mux.HandleFunc("/fhir/$extract-data", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job := newReattachJob(t, newTORCHTestClientConfig(server.URL))
+	job.CRTDLPath = writeTestCRTDL(t)
+	job.TORCHJobID = "stale-job"
+	job.TORCHExtractionURL = server.URL + "/fhir/__status/stale-job"
+
+	files, err := executeTORCHExtraction(job, t.TempDir(), newTestHTTPClient(logger), logger, false, false, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to submit TORCH extraction")
+	assert.Empty(t, files)
+}
+
+// Slice 6: a submit that succeeds but whose handle cannot be persisted
+// (unwritable JobsDir) must surface the persist error before any polling —
+// the whole point of persisting is to fail loudly if the handle is unsafe.
+func TestExecuteTORCHExtraction_PersistHandleError(t *testing.T) {
+	const torchJobID = "fresh-job-uuid-999"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fhir/$extract-data", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Location", "http://"+r.Host+"/fhir/__status/"+torchJobID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job := newReattachJob(t, newTORCHTestClientConfig(server.URL))
+	job.CRTDLPath = writeTestCRTDL(t)
+
+	// Point JobsDir at a regular file so SaveJobState's MkdirAll fails.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+	job.Config.JobsDir = blocker
+
+	files, err := executeTORCHExtraction(job, t.TempDir(), newTestHTTPClient(logger), logger, false, false, "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist TORCH job handle")
+	assert.Empty(t, files)
+}

--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -100,6 +101,11 @@ func (e *TORCHError) IsRetryable() bool {
 
 // ErrExtractionTimeout is returned when extraction polling exceeds configured timeout
 var ErrExtractionTimeout = fmt.Errorf("TORCH extraction timeout exceeded")
+
+// ErrHandleDead is returned from polling when the status endpoint reports the
+// job handle no longer exists (404 Not Found or 410 Gone). The caller should
+// clear the stored handle and re-submit a fresh extraction.
+var ErrHandleDead = fmt.Errorf("TORCH job handle is gone (404 or 410)")
 
 // ErrInvalidCRTDL is returned when CRTDL file is malformed
 var ErrInvalidCRTDL = fmt.Errorf("invalid CRTDL file")
@@ -197,6 +203,26 @@ func (c *TORCHClient) SubmitExtraction(crtdlPath string) (string, error) {
 	c.logger.Info("TORCH extraction submitted successfully", "extraction_url", contentLocation)
 
 	return contentLocation, nil
+}
+
+// JobIDFromStatusURL returns the TORCH job ID — the last path segment of a
+// status / Content-Location URL (e.g. ".../fhir/__status/{jobId}") — or "" if
+// none can be parsed. The job ID is the handle aether persists to re-attach.
+func JobIDFromStatusURL(statusURL string) string {
+	trimmed := strings.TrimRight(statusURL, "/")
+	if trimmed == "" {
+		return ""
+	}
+
+	if u, err := url.Parse(trimmed); err == nil && u.Path != "" {
+		trimmed = strings.TrimRight(u.Path, "/")
+	}
+
+	base := path.Base(trimmed)
+	if base == "." || base == "/" {
+		return ""
+	}
+	return base
 }
 
 // SubmitExtractionWithContent submits already-encoded CRTDL content for extraction to TORCH server.
@@ -361,23 +387,32 @@ func (c *TORCHClient) PollExtractionStatus(extractionURL string, showProgress bo
 		}
 
 		// Handle response
-		complete, urls, diagnostics, handleErr := handlePollResponse(resp, c)
-		if handleErr != nil {
-			return nil, handleErr
+		outcome := c.handlePollResponse(resp)
+		if outcome.err != nil {
+			if outcome.retryable {
+				time.Sleep(pollConfig.PollInterval)
+				pollConfig.UpdateInterval()
+				continue
+			}
+			return nil, outcome.err
 		}
 
-		if complete {
+		// 200/202 are contact with a live job — reset the liveness window so a
+		// long but responsive extraction never trips extraction_timeout.
+		pollConfig.RecordContact()
+
+		if outcome.complete {
 			c.logger.Info("TORCH extraction completed", "polls", pollConfig.PollCount)
-			return urls, nil
+			return outcome.fileURLs, nil
 		}
 
 		// Log progress diagnostics from OperationOutcome (only when changed)
-		if diagnostics != "" && diagnostics != lastDiagnostics {
-			c.logger.Info("TORCH extraction progress", "diagnostics", diagnostics)
+		if outcome.diagnostics != "" && outcome.diagnostics != lastDiagnostics {
+			c.logger.Info("TORCH extraction progress", "diagnostics", outcome.diagnostics)
 			if spinner != nil {
-				spinner.UpdateMessage(diagnostics)
+				spinner.UpdateMessage(outcome.diagnostics)
 			}
-			lastDiagnostics = diagnostics
+			lastDiagnostics = outcome.diagnostics
 		}
 
 		// Still in progress - wait with exponential backoff

--- a/internal/services/torch_client_internal_test.go
+++ b/internal/services/torch_client_internal_test.go
@@ -39,3 +39,24 @@ func TestMakeAbsoluteURL(t *testing.T) {
 		})
 	}
 }
+
+func TestJobIDFromStatusURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "status url", in: "http://torch:8080/fhir/__status/abc-123", want: "abc-123"},
+		{name: "trailing slash", in: "http://torch:8080/fhir/__status/abc-123/", want: "abc-123"},
+		{name: "query string ignored", in: "http://torch:8080/fhir/__status/abc-123?x=1", want: "abc-123"},
+		{name: "https", in: "https://torch.example/fhir/__status/uuid", want: "uuid"},
+		{name: "bare id", in: "abc-123", want: "abc-123"},
+		{name: "empty", in: "", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, JobIDFromStatusURL(tc.in))
+		})
+	}
+}

--- a/internal/services/torch_poller.go
+++ b/internal/services/torch_poller.go
@@ -11,10 +11,13 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
-// PollConfig holds configuration for extraction polling
+// PollConfig holds configuration and timing state for extraction polling.
+// LastContact anchors the liveness window (reset on every 200/202); PollStart
+// is the wall-clock start, kept only for reporting total elapsed time.
 type PollConfig struct {
 	Timeout         time.Duration
-	StartTime       time.Time
+	LastContact     time.Time
+	PollStart       time.Time
 	PollInterval    time.Duration
 	MaxPollInterval time.Duration
 	PollCount       int
@@ -22,9 +25,11 @@ type PollConfig struct {
 
 // NewPollConfig creates polling configuration from TORCH client settings
 func NewPollConfig(cfg models.TORCHConfig) *PollConfig {
+	now := time.Now()
 	return &PollConfig{
 		Timeout:         cfg.ExtractionTimeout,
-		StartTime:       time.Now(),
+		LastContact:     now,
+		PollStart:       now,
 		PollInterval:    cfg.PollingInterval,
 		MaxPollInterval: cfg.MaxPollingInterval,
 		PollCount:       0,
@@ -44,8 +49,21 @@ func createPollRequest(extractionURL string, c *TORCHClient) (*http.Request, err
 	return req, nil
 }
 
-// handlePollResponse processes a polling response and returns completion status, file URLs, and progress diagnostics
-func handlePollResponse(resp *http.Response, c *TORCHClient) (complete bool, fileURLs []string, diagnostics string, err error) {
+// pollOutcome is the result of interpreting a single status poll response.
+// When err is set, retryable says whether the poll loop should keep polling
+// (transient) or give up (terminal).
+type pollOutcome struct {
+	complete    bool
+	fileURLs    []string
+	diagnostics string
+	retryable   bool
+	err         error
+}
+
+// handlePollResponse interprets a status poll response: completion + file URLs
+// on 200, in-progress diagnostics on 202, a dead-handle signal on 404/410, and
+// a retryable/terminal error otherwise.
+func (c *TORCHClient) handlePollResponse(resp *http.Response) pollOutcome {
 	defer func() { _ = resp.Body.Close() }()
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
@@ -53,32 +71,48 @@ func handlePollResponse(resp *http.Response, c *TORCHClient) (complete bool, fil
 	switch resp.StatusCode {
 	case http.StatusAccepted, http.StatusProcessing:
 		// Still in progress (202 Accepted or 102 Processing)
-		diagnostics = extractProgressDiagnostics(bodyBytes)
-		return false, nil, diagnostics, nil
+		return pollOutcome{diagnostics: extractProgressDiagnostics(bodyBytes)}
 
 	case http.StatusOK:
-		// Extraction complete - parse result
 		c.logger.Info("TORCH extraction completed")
 		c.logger.Debug("TORCH extraction response body", "body", string(bodyBytes))
 		fileURLs, err := c.parseExtractionResult(bodyBytes)
 		if err != nil {
-			return false, nil, "", err
+			return pollOutcome{err: err}
 		}
-		return true, fileURLs, "", nil
+		return pollOutcome{complete: true, fileURLs: fileURLs}
+
+	case http.StatusNotFound, http.StatusGone:
+		// Handle is dead — the job no longer exists on TORCH. Signal the caller
+		// to clear the stored handle and re-submit a fresh extraction.
+		c.logger.Warn("TORCH job handle is gone", "status_code", resp.StatusCode, "status", resp.Status)
+		return pollOutcome{err: ErrHandleDead}
 
 	default:
-		// Error response
+		// TORCH returns 500 only for a terminal job failure (TEMP_FAILED is
+		// surfaced as 202/503), so treat it as non-transient here even though
+		// 5xx is retryable for generic HTTP calls. Other 5xx, 408, and 429 stay
+		// transient and retryable; 4xx is terminal.
 		errorType := lib.ClassifyHTTPError(resp.StatusCode)
-		c.logger.Error("TORCH extraction failed",
-			"status_code", resp.StatusCode,
-			"status", resp.Status,
-			"error_body", string(bodyBytes))
+		if resp.StatusCode == http.StatusInternalServerError {
+			errorType = models.ErrorTypeNonTransient
+		}
+		retryable := errorType == models.ErrorTypeTransient
+		logFields := []any{"status_code", resp.StatusCode, "status", resp.Status, "error_body", string(bodyBytes)}
+		if retryable {
+			c.logger.Warn("TORCH poll returned transient error, will retry", logFields...)
+		} else {
+			c.logger.Error("TORCH extraction failed", logFields...)
+		}
 
-		return false, nil, "", &TORCHError{
-			Operation:  "poll",
-			StatusCode: resp.StatusCode,
-			Message:    string(bodyBytes),
-			ErrorType:  errorType,
+		return pollOutcome{
+			retryable: retryable,
+			err: &TORCHError{
+				Operation:  "poll",
+				StatusCode: resp.StatusCode,
+				Message:    string(bodyBytes),
+				ErrorType:  errorType,
+			},
 		}
 	}
 }
@@ -117,14 +151,22 @@ func CalculateNextPollInterval(current, max time.Duration) time.Duration {
 	return next
 }
 
-// CheckTimeout checks if polling has exceeded timeout
+// CheckTimeout reports whether the liveness window has elapsed since the last
+// contact with TORCH. extraction_timeout is a no-progress window, not a total
+// cap: a healthy job resets it on every 200/202 (see RecordContact).
 func (pc *PollConfig) CheckTimeout() bool {
-	return time.Since(pc.StartTime) > pc.Timeout
+	return time.Since(pc.LastContact) > pc.Timeout
 }
 
-// GetElapsedTime returns time elapsed since polling started
+// RecordContact resets the liveness window. Call it on every 200/202 response
+// so a long but responsive extraction never trips extraction_timeout.
+func (pc *PollConfig) RecordContact() {
+	pc.LastContact = time.Now()
+}
+
+// GetElapsedTime returns the total time elapsed since polling started.
 func (pc *PollConfig) GetElapsedTime() time.Duration {
-	return time.Since(pc.StartTime)
+	return time.Since(pc.PollStart)
 }
 
 // IncrementPollCount increments the poll attempt counter

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -1229,6 +1229,182 @@ func TestPipeline_TORCHExtraction_JobResumption(t *testing.T) {
 	t.Logf("Job resumption test passed: extraction completed successfully after simulated restart")
 }
 
+// TestPipeline_TORCHExtraction_ReattachViaImportStep verifies that when a job
+// already carries a TORCH handle (TORCHJobID + URL) from a prior session,
+// ExecuteImportStep re-attaches by polling the existing extraction and never
+// re-submits a fresh one. Exercises the re-attach branch of
+// executeTORCHExtraction through the exported pipeline entry point.
+func TestPipeline_TORCHExtraction_ReattachViaImportStep(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	crtdlPath := filepath.Join(tempDir, "reattach.json")
+	crtdlJSON, _ := json.Marshal(map[string]any{
+		"cohortDefinition": map[string]any{"version": "1.0.0", "inclusionCriteria": []any{}},
+		"dataExtraction":   map[string]any{"attributeGroups": []any{}},
+	})
+	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
+
+	submitCount := 0
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/fhir/$extract-data" {
+			submitCount++
+			w.Header().Set("Content-Location", server.URL+"/fhir/extraction/should-not-submit")
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/fhir/extraction/existing-job" {
+			result := map[string]any{
+				"resourceType": "Parameters",
+				"parameter": []map[string]any{
+					{"name": "output", "part": []map[string]any{
+						{"name": "url", "valueUrl": server.URL + "/output/reattached.ndjson"},
+					}},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(result)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/output/reattached.ndjson" {
+			w.Header().Set("Content-Type", "application/fhir+ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"reattached-1"}` + "\n"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	config := models.ProjectConfig{
+		Services: models.ServiceConfig{
+			TORCH: models.TORCHConfig{
+				BaseURL:            server.URL,
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 1 * time.Second,
+			},
+		},
+		Pipeline: models.PipelineConfig{EnabledSteps: []models.StepName{models.StepTorchImport}},
+		Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000},
+		JobsDir:  jobsDir,
+	}
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
+	require.NoError(t, err)
+
+	// Simulate an in-flight extraction handle persisted from a prior session.
+	job.TORCHJobID = "existing-job"
+	job.TORCHExtractionURL = server.URL + "/fhir/extraction/existing-job"
+
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
+	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, submitCount, "re-attach must not POST $extract-data")
+	assert.Equal(t, "existing-job", updatedJob.TORCHJobID, "handle preserved on re-attach")
+
+	importStep, found := models.GetStepByName(*updatedJob, models.StepTorchImport)
+	require.True(t, found)
+	assert.Equal(t, models.StepStatusCompleted, importStep.Status)
+	assert.Greater(t, updatedJob.TotalFiles, 0)
+}
+
+// TestPipeline_TORCHExtraction_DeadHandleResubmitsViaImportStep verifies that a
+// stale handle whose status endpoint returns 410 Gone is cleared and a fresh
+// extraction is submitted. Exercises the ErrHandleDead re-submit branch of
+// executeTORCHExtraction through the exported pipeline entry point.
+func TestPipeline_TORCHExtraction_DeadHandleResubmitsViaImportStep(t *testing.T) {
+	tempDir := t.TempDir()
+	jobsDir := filepath.Join(tempDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	crtdlPath := filepath.Join(tempDir, "deadhandle.json")
+	crtdlJSON, _ := json.Marshal(map[string]any{
+		"cohortDefinition": map[string]any{"version": "1.0.0", "inclusionCriteria": []any{}},
+		"dataExtraction":   map[string]any{"attributeGroups": []any{}},
+	})
+	_ = os.WriteFile(crtdlPath, crtdlJSON, 0644)
+
+	const newJobPath = "/fhir/extraction/fresh-after-410"
+	submitCount := 0
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stale handle is dead.
+		if r.Method == "GET" && r.URL.Path == "/fhir/extraction/stale-job" {
+			w.WriteHeader(http.StatusGone)
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/fhir/$extract-data" {
+			submitCount++
+			w.Header().Set("Content-Location", server.URL+newJobPath)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == newJobPath {
+			result := map[string]any{
+				"resourceType": "Parameters",
+				"parameter": []map[string]any{
+					{"name": "output", "part": []map[string]any{
+						{"name": "url", "valueUrl": server.URL + "/output/fresh.ndjson"},
+					}},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(result)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/output/fresh.ndjson" {
+			w.Header().Set("Content-Type", "application/fhir+ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"fresh-1"}` + "\n"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	config := models.ProjectConfig{
+		Services: models.ServiceConfig{
+			TORCH: models.TORCHConfig{
+				BaseURL:            server.URL,
+				ExtractionTimeout:  1 * time.Minute,
+				PollingInterval:    1 * time.Second,
+				MaxPollingInterval: 1 * time.Second,
+			},
+		},
+		Pipeline: models.PipelineConfig{EnabledSteps: []models.StepName{models.StepTorchImport}},
+		Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 100, MaxBackoffMs: 1000},
+		JobsDir:  jobsDir,
+	}
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	job, err := pipeline.CreateJob(models.GenerateJobID(), "", crtdlPath, config, logger)
+	require.NoError(t, err)
+
+	// Simulate a stale handle from a prior session that TORCH no longer knows about.
+	job.TORCHJobID = "stale-job"
+	job.TORCHExtractionURL = server.URL + "/fhir/extraction/stale-job"
+
+	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
+	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, submitCount, "dead handle must trigger exactly one re-submit")
+	assert.Equal(t, services.JobIDFromStatusURL(server.URL+newJobPath), updatedJob.TORCHJobID,
+		"handle replaced with the fresh job ID")
+
+	importStep, found := models.GetStepByName(*updatedJob, models.StepTorchImport)
+	require.True(t, found)
+	assert.Equal(t, models.StepStatusCompleted, importStep.Status)
+	assert.Greater(t, updatedJob.TotalFiles, 0)
+}
+
 // Integration test - verify error handling when CRTDL preprocessing fails
 // Covers error paths in internal/pipeline/import.go (preprocessCRTDL function)
 

--- a/tests/unit/torch_poller_test.go
+++ b/tests/unit/torch_poller_test.go
@@ -32,12 +32,12 @@ func TestNewPollConfig(t *testing.T) {
 	assert.Equal(t, 2*time.Second, config.PollInterval)
 	assert.Equal(t, 30*time.Second, config.MaxPollInterval)
 	assert.Equal(t, 0, config.PollCount)
-	assert.True(t, time.Since(config.StartTime) < 1*time.Second)
+	assert.True(t, time.Since(config.LastContact) < 1*time.Second)
 }
 
 func TestPollConfig_CheckTimeout_NotExceeded(t *testing.T) {
 	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 1*time.Second, 30*time.Second))
-	config.StartTime = time.Now()
+	config.LastContact = time.Now()
 
 	// Should not timeout immediately
 	assert.False(t, config.CheckTimeout())
@@ -45,7 +45,7 @@ func TestPollConfig_CheckTimeout_NotExceeded(t *testing.T) {
 
 func TestPollConfig_CheckTimeout_Exceeded(t *testing.T) {
 	config := services.NewPollConfig(newTestTORCHConfig(1*time.Minute, 1*time.Second, 30*time.Second))
-	config.StartTime = time.Now().Add(-2 * time.Minute)
+	config.LastContact = time.Now().Add(-2 * time.Minute)
 
 	// Should timeout
 	assert.True(t, config.CheckTimeout())
@@ -53,7 +53,7 @@ func TestPollConfig_CheckTimeout_Exceeded(t *testing.T) {
 
 func TestPollConfig_GetElapsedTime(t *testing.T) {
 	config := services.NewPollConfig(newTestTORCHConfig(10*time.Minute, 1*time.Second, 30*time.Second))
-	config.StartTime = time.Now().Add(-5 * time.Second)
+	config.PollStart = time.Now().Add(-5 * time.Second)
 
 	elapsed := config.GetElapsedTime()
 	// Should be approximately 5 seconds (allow some slack)
@@ -122,7 +122,7 @@ func TestCalculateNextPollInterval(t *testing.T) {
 func TestPollConfig_StateProgression(t *testing.T) {
 	config := services.NewPollConfig(newTestTORCHConfig(5*time.Minute, 1*time.Second, 10*time.Second))
 	startTime := time.Now()
-	config.StartTime = startTime
+	config.LastContact = startTime
 
 	// Initial state
 	assert.Equal(t, 0, config.PollCount)
@@ -176,7 +176,7 @@ func TestHandlePollResponse_Error(t *testing.T) {
 
 func TestPollConfig_MultipleTimeouts(t *testing.T) {
 	config := services.NewPollConfig(newTestTORCHConfig(1*time.Minute, 1*time.Second, 30*time.Second))
-	config.StartTime = time.Now().Add(-10 * time.Minute)
+	config.LastContact = time.Now().Add(-10 * time.Minute)
 
 	// Should timeout regardless of how many times we check
 	assert.True(t, config.CheckTimeout())

--- a/tests/unit/torch_status_test.go
+++ b/tests/unit/torch_status_test.go
@@ -1,0 +1,158 @@
+package unit
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+func fastPollConfig(serverURL string) models.TORCHConfig {
+	return models.TORCHConfig{
+		BaseURL:            serverURL,
+		ExtractionTimeout:  10 * time.Second,
+		PollingInterval:    5 * time.Millisecond,
+		MaxPollingInterval: 5 * time.Millisecond,
+	}
+}
+
+func newPollTestClient(t *testing.T, cfg models.TORCHConfig) *services.TORCHClient {
+	t.Helper()
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(
+		5*time.Second,
+		models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 1, MaxBackoffMs: 1},
+		models.TLSConfig{},
+		logger,
+	)
+	return services.NewTORCHClient(cfg, httpClient, logger)
+}
+
+// Slice 4: a 500 from the status endpoint is a terminal job failure — fail
+// immediately, do not retry until timeout.
+func TestPollExtractionStatus_500FailsTerminally(t *testing.T) {
+	var polls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&polls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := newPollTestClient(t, fastPollConfig(server.URL))
+	_, err := client.PollExtractionStatus(server.URL+"/fhir/__status/job-x", false)
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, services.ErrExtractionTimeout), "must fail terminally, not by timeout")
+	var torchErr *services.TORCHError
+	require.ErrorAs(t, err, &torchErr)
+	assert.Equal(t, models.ErrorTypeNonTransient, torchErr.ErrorType, "500 is a terminal failure")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&polls), "500 must not be retried")
+}
+
+// Slice 4: a 503 is transient — keep polling until the job responds.
+func TestPollExtractionStatus_503RetriesThenSucceeds(t *testing.T) {
+	var polls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&polls, 1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"type":"Patient","url":"http://` + r.Host + `/out.ndjson"}]}`))
+	}))
+	defer server.Close()
+
+	client := newPollTestClient(t, fastPollConfig(server.URL))
+	fileURLs, err := client.PollExtractionStatus(server.URL+"/fhir/__status/job-x", false)
+
+	require.NoError(t, err)
+	assert.Len(t, fileURLs, 1)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&polls), int32(3), "503 should be retried until success")
+}
+
+// Slice 5: extraction_timeout is a liveness (no-progress) window. A job that
+// keeps emitting 202 resets the window on every contact, so it must NOT time
+// out even when it runs longer than extraction_timeout.
+func TestPollExtractionStatus_LivenessResetsOn202(t *testing.T) {
+	var polls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&polls, 1)
+		if n <= 5 {
+			w.WriteHeader(http.StatusAccepted) // 202 in-progress, keeps contact alive
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[{"type":"Patient","url":"http://` + r.Host + `/out.ndjson"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := models.TORCHConfig{
+		BaseURL:            server.URL,
+		ExtractionTimeout:  80 * time.Millisecond, // shorter than the total run below
+		PollingInterval:    30 * time.Millisecond,
+		MaxPollingInterval: 30 * time.Millisecond,
+	}
+	client := newPollTestClient(t, cfg)
+
+	fileURLs, err := client.PollExtractionStatus(server.URL+"/fhir/__status/job-x", false)
+
+	require.NoError(t, err, "periodic 202 must reset the liveness window")
+	assert.Len(t, fileURLs, 1)
+}
+
+// Slice 5 (companion): true silence — TORCH never makes progress (continuous
+// 503, no 200/202) — must trip the liveness timeout rather than poll forever.
+func TestPollExtractionStatus_SilencePastWindowTimesOut(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // never any 200/202 contact
+	}))
+	defer server.Close()
+
+	cfg := models.TORCHConfig{
+		BaseURL:            server.URL,
+		ExtractionTimeout:  50 * time.Millisecond,
+		PollingInterval:    20 * time.Millisecond,
+		MaxPollingInterval: 20 * time.Millisecond,
+	}
+	client := newPollTestClient(t, cfg)
+
+	_, err := client.PollExtractionStatus(server.URL+"/fhir/__status/job-x", false)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrExtractionTimeout, "silence past the window must time out")
+}
+
+// TestJobIDFromStatusURL covers handle extraction from status URLs, including
+// the degenerate inputs that must yield an empty job ID rather than a bogus
+// path segment.
+func TestJobIDFromStatusURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"status url with job id", "https://torch.example/fhir/__status/job-42", "job-42"},
+		{"trailing slash trimmed", "https://torch.example/fhir/__status/job-42/", "job-42"},
+		{"empty string", "", ""},
+		{"only slashes", "///", ""},
+		{"dot path yields no segment", ".", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, services.JobIDFromStatusURL(tt.url))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Makes large TORCH extractions (100k+ patients) survivable. Today a long extraction cannot survive aether's process death or a runtime longer than `extraction_timeout`: on `continue` aether re-submits the CRTDL and TORCH starts over, orphaning the first job on the source FHIR server. This adopts TORCH's jobId-keyed job model so aether **re-attaches** to an in-flight extraction instead of restarting it.

## Changes

- **Persist job handle after submit** — `TORCHJobID` + status URL written to disk *before* the long poll, so a crash mid-extraction leaves a recoverable handle. New `PipelineJob.TORCHJobID`.
- **Re-attach guard** — `executeTORCHExtraction` polls an existing handle instead of submitting; covers `pipeline start`, `pipeline continue`, and `job run`.
- **Status-code branching** on `GET /fhir/__status/{jobId}`: `200` done · `202` keep polling · `503`/`408`/`429`/other-`5xx` retry · `500` terminal fast-fail · `404`/`410` clear handle + re-submit fresh.
- **Liveness `extraction_timeout`** — redefined as time since last contact with TORCH, reset on every `200`/`202` (ADR 0001). A responsive multi-hour extraction no longer times out; aether only gives up on silence.
- **Docs** — ADR 0001, domain glossary (`CONTEXT.md`), config comment, and the torch-integration + config-reference guides updated to the new semantics.

## Notes / decisions

- `500`-is-terminal is **localized to the TORCH poll path**, not the global `IsTransientHTTPStatus`. TORCH surfaces `TEMP_FAILED` as `202`/`503` and uses `500` only for terminal job failure, so generic HTTP-import / DIMP / send retry semantics are intentionally left unchanged.
- Out of scope (separate follow-ups): `$cancel`/`$pause`/`$resume`, `Task` reads, and orphan cleanup / a `delete` command.
- Pre-existing CLI naming: the manual step invocation is `--step torch` (not `torch_import`); re-attach is reachable through all normal entry points.

Closes #470