### PR TITLE
fix(ci): disable external terminology server in E2E validation tests

### DIFF
--- a/.github/test/validator/compose.yaml
+++ b/.github/test/validator/compose.yaml
@@ -13,6 +13,11 @@ services:
       JAVA_TOOL_OPTIONS: "-Xmx1g"
       VALIDATOR_ENABLED: "true"
       FHIR_VERSION: "4.0"
+      # Disable the external terminology server (tx.fhir.org). Without this the
+      # validator hangs on the first real validation doing terminology lookups,
+      # blowing past aether's HTTP timeout. The E2E assertions only need
+      # structural/internal-binding validation, which works with -tx n/a.
+      TX_SERVER: "n/a"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/validateResource", "-X", "POST", "-H", "Content-Type: application/fhir+json", "-d", "{\"resourceType\":\"Patient\"}"]
       interval: 15s

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -412,7 +412,7 @@ jobs:
       - name: Capture service logs on failure
         if: failure()
         run: |
-          docker compose -f .github/test/validator/compose.yaml logs > docker-logs-validation.txt
+          docker compose -f .github/test/compose.yaml logs fhir-validator > docker-logs-validation.txt
 
       - name: Upload service logs
         if: failure()


### PR DESCRIPTION
## Problem

The **E2E Validation Tests** job fails on `main` and open PRs (e.g. [run 28350548328](https://github.com/medizininformatik-initiative/aether/actions/runs/28350548328/job/84054414249)). The `mii-fhir-validator` hangs on the first real validation while doing terminology lookups against the external public server `http://tx.fhir.org`, blowing past aether's 30s HTTP timeout → 3 retries fail → validation step fails → no report files → every check FAILs.

The compose sets no `TX_SERVER`, so the validator falls back to `tx.fhir.org`. The trivial `{"resourceType":"Patient"}` healthcheck needs no terminology and returns instantly, so `docker compose --wait` reports the validator ready before it is warm for real workloads. tx.fhir.org being slow/overloaded turned a latent flake into a consistent failure.

Not caused by #466 — the `actions/checkout` v7 bump cannot affect validator HTTP. The job last passed at `613ee07`; the only diff to the failing merge is the checkout bump.

## Fix

- Set `TX_SERVER=n/a` on the validator service → `-tx n/a` (no external terminology server). The E2E assertions only need structural / internal-binding validation, which the validator performs locally against loaded HL7 terminology packages. A local Blaze tx server (the other option) would add a multi-GB SNOMED RF2 download and an 8GB-heap service to CI for no extra value on these assertions.
- Fix the failure log capture: it used `-f .github/test/validator/compose.yaml`, a different compose project than the one that started the services (`.github/test/compose.yaml`), so it captured nothing — a 0-byte artifact that hid the root cause.

## Verification

Ran the actual `run-validation-e2e-test.sh` locally against the patched compose:

- All 7 checks PASS, script exit 0
- Validation completes in **~300ms** (was 180s+ timeout)
- Patient → informational only (no errors); Condition & InvalidPatient → error-severity issues detected (structural errors like `Condition.subject: minimum required = 1` are still caught)

## Related

- #471 — bump validator image to alpha.7
- #472 — Renovate tracking so the image stops going stale

Closes #473