### PR TITLE
chore(deps): bump mii-fhir-validator E2E image to 0.0.1-alpha.7

### DIFF
--- a/.github/test/validator/compose.yaml
+++ b/.github/test/validator/compose.yaml
@@ -4,7 +4,7 @@
 
 services:
   fhir-validator:
-    image: ghcr.io/medizininformatik-initiative/mii-fhir-validator:0.0.1-alpha.4@sha256:aace6edc3204582eb7f568a8e39bd50b9cfa666b8769c0e83939a3ce9378bd86
+    image: ghcr.io/medizininformatik-initiative/mii-fhir-validator:0.0.1-alpha.7@sha256:c237b8b36a641cc57a59be2d2a29035ca4f39e0b6c71b26ab4e88e7f7c4fd6a1
     ports: [ ":8080" ]
     networks: [ "aether" ]
     volumes:


### PR DESCRIPTION
## Summary

The `mii-fhir-validator` image used by the E2E Validation Tests was pinned to `0.0.1-alpha.4` while `0.0.1-alpha.7` was available — 3 pre-releases behind, because Renovate was not tracking it (see #472). Bump to the latest pre-release.

```
ghcr.io/medizininformatik-initiative/mii-fhir-validator:0.0.1-alpha.7@sha256:c237b8b36a641cc57a59be2d2a29035ca4f39e0b6c71b26ab4e88e7f7c4fd6a1
```

## Verification

Ran alpha.7 locally with `TX_SERVER=n/a` against the E2E test resources:

- Patient (valid) → no error-severity issues
- Condition / InvalidPatient (invalid) → error-severity issues detected
- All validations return in tens of milliseconds

## Note on ordering

> [!IMPORTANT]
> This needs #475 (`TX_SERVER=n/a`) merged for the **E2E Validation Tests** job to pass — alpha.7 still defaults to the external `tx.fhir.org` terminology server and hangs without it (verified). Rebase onto `main` after #475 merges.

## Related

- #475 — disables the external terminology server (the actual CI fix)
- #472 — Renovate tracking so the image stops going stale

Closes #471