### PR TITLE
chore(renovate): track mii-fhir-validator Docker image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,16 +25,18 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "ghcr.io/medizininformatik-initiative/torch",
-        "ghcr.io/medizininformatik-initiative/fhir-flattener"
+        "ghcr.io/medizininformatik-initiative/fhir-flattener",
+        "ghcr.io/medizininformatik-initiative/mii-fhir-validator"
       ],
       "versioning": "semver",
       "ignoreUnstable": false
     },
     {
-      "description": "Only allow stable releases and alpha/beta pre-releases for torch (exclude test/dev tags)",
+      "description": "Only allow stable releases and alpha/beta pre-releases for MII pre-release images (exclude test/dev tags)",
       "matchDatasources": ["docker"],
       "matchPackageNames": [
-        "ghcr.io/medizininformatik-initiative/torch"
+        "ghcr.io/medizininformatik-initiative/torch",
+        "ghcr.io/medizininformatik-initiative/mii-fhir-validator"
       ],
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(-(alpha|beta)\\.\\d+)?$/"
     }


### PR DESCRIPTION
## Problem

Renovate is not tracking the `mii-fhir-validator` Docker image, so it silently fell behind (pinned `0.0.1-alpha.4`, latest `0.0.1-alpha.7`). The other MII pre-release images (`torch`, `fhir-flattener`) are tracked; the validator was simply never added.

The pre-release (`-alpha.N`) tracking is enabled only via an explicit `packageRule` (`versioning: semver` + `ignoreUnstable: false`). Without that, the `config:best-practices` preset ignores unstable/pre-release tags, so Renovate never proposes an alpha bump.

## Change

- Add `ghcr.io/medizininformatik-initiative/mii-fhir-validator` to the semver/`ignoreUnstable` rule.
- Add it to the `allowedVersions` rule (previously torch-only) so only stable and `alpha`/`beta` pre-releases are offered, excluding test/dev tags. Generalized that rule's description accordingly.

## Related

- #471 — immediate bump to alpha.7 (what this prevents from recurring)
- #475 — the underlying E2E Validation fix

Closes #472