### PR TITLE
docs: fix dead documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ aether pipeline continue aether.yaml <job-id>
 ## More Information
 
 - [Full Documentation](https://medizininformatik-initiative.github.io/aether/)
-- [Configuration Options](https://medizininformatik-initiative.github.io/aether/getting-started/configuration)
-- [Pipeline Steps](https://medizininformatik-initiative.github.io/aether/guides/pipeline-steps)
+- [Configuration Options](https://medizininformatik-initiative.github.io/aether/v0.10.1/getting-started/configuration.html)
+- [Pipeline Steps](https://medizininformatik-initiative.github.io/aether/v0.10.1/guides/pipeline-steps.html)
 
 ## License
 


### PR DESCRIPTION
## Summary

Fixes two dead links in the README's "More Information" section. Both deep links dropped the version segment and `.html` extension, returning 404:

- `Configuration Options` → now `/aether/v0.10.1/getting-started/configuration.html`
- `Pipeline Steps` → now `/aether/v0.10.1/guides/pipeline-steps.html` (same defect, not mentioned in the issue)

Both target URLs verified `200`.

## Follow-up

Versioned links go stale each release. Filed #488 to add a version-independent `/aether/stable/` docs alias so these links stop churning.

Closes #484