### PR TITLE
refactor(pipeline): unify steps behind one Step seam

### DIFF
--- a/cmd/job.go
+++ b/cmd/job.go
@@ -327,6 +327,20 @@ func isStepEnabledInConfig(config *models.ProjectConfig, stepName models.StepNam
 func executeStepManually(job *models.PipelineJob, stepName models.StepName, config *models.ProjectConfig, logger *lib.Logger) error {
 	jobDir := services.GetJobDir(config.JobsDir, job.JobID)
 
+	// A completed step is terminal for the pipeline's transition gate, so
+	// re-running it manually would otherwise fail with an illegal
+	// completed->in_progress transition. Reset it to pending first so the manual
+	// re-run works (the step's own idempotent skip logic handles already-produced
+	// output). The gate stays strict for the automatic RunLoop, which never
+	// re-enters a completed step.
+	if s, ok := models.GetStepByName(*job, stepName); ok && s.Status == models.StepStatusCompleted {
+		s.Status = models.StepStatusPending
+		s.StartedAt = nil
+		s.CompletedAt = nil
+		s.LastError = nil
+		*job = models.ReplaceStep(*job, s)
+	}
+
 	switch stepName {
 	case models.StepTorchImport, models.StepLocalImport, models.StepHttpImport:
 		// Validate step name matches input type (imported from pipeline.go logic)

--- a/cmd/job_test.go
+++ b/cmd/job_test.go
@@ -1,10 +1,19 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 func TestFormatStatusField_DisplayWidthMatchesHeader(t *testing.T) {
@@ -23,4 +32,55 @@ func TestFormatStatusField_DisplayWidthMatchesHeader(t *testing.T) {
 func TestFormatStatusField_UnknownStatusStillPads(t *testing.T) {
 	field := formatStatusField(getJobStatusSymbol("mystery"), "mystery")
 	assert.Equal(t, statusFieldWidth, runewidth.StringWidth(field))
+}
+
+// TestExecuteStepManually_RerunsCompletedDIMPStep is the regression guard for
+// `aether job run --step dimp` on an already-completed step: it must re-run the
+// step (matching pre-refactor behavior), not hard-fail on an illegal
+// completed->in_progress transition.
+func TestExecuteStepManually_RerunsCompletedDIMPStep(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resource map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&resource)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resource)
+	}))
+	defer server.Close()
+
+	jobsDir := t.TempDir()
+	jobID := "550e8400-e29b-41d4-a716-446655440000"
+	importDir := filepath.Join(jobsDir, jobID, "import")
+	require.NoError(t, os.MkdirAll(importDir, 0o755))
+	f, err := os.Create(filepath.Join(importDir, "patients.ndjson"))
+	require.NoError(t, err)
+	require.NoError(t, json.NewEncoder(f).Encode(map[string]any{"resourceType": "Patient", "id": "p1"}))
+	require.NoError(t, f.Close())
+
+	steps := []models.StepName{models.StepLocalImport, models.StepDIMP}
+	config := &models.ProjectConfig{
+		JobsDir:  jobsDir,
+		Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		Services: models.ServiceConfig{DIMP: models.DIMPConfig{URL: server.URL, BundleSplitThresholdMB: 10}},
+		Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100},
+	}
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		Status:      models.JobStatusInProgress,
+		InputSource: importDir,
+		InputType:   models.InputTypeLocal,
+		CurrentStep: string(models.StepDIMP),
+		Steps:       models.InitializeSteps(steps),
+		Config:      *config,
+	}
+	// The DIMP step already ran to completion in a prior invocation.
+	d, _ := models.GetStepByName(*job, models.StepDIMP)
+	completed := models.ReplaceStep(*job, models.CompleteStep(d, 1, 0))
+	job = &completed
+
+	err = executeStepManually(job, models.StepDIMP, config, lib.NewLogger(lib.LogLevelError))
+
+	require.NoError(t, err)
+	s, ok := models.GetStepByName(*job, models.StepDIMP)
+	require.True(t, ok)
+	assert.Equal(t, models.StepStatusCompleted, s.Status)
 }

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,8 +17,6 @@ var (
 	noProgress     bool
 	localImportDir string // CLI flag for local import directory override
 	allowHTTPCRTDL bool   // CLI flag acknowledging http_import + CRTDL semantic mismatch
-	// errPipelinePaused is returned when the pipeline pauses at a wait step
-	errPipelinePaused = errors.New("pipeline paused at wait step")
 )
 
 // pipelineCmd represents the pipeline command group
@@ -168,171 +165,6 @@ func init() {
 	pipelineStartCmd.Flags().BoolVar(&allowHTTPCRTDL, "allow-http-crtdl", false, "Acknowledge that combining http_import with a CRTDL may not match the endpoint's data")
 }
 
-// validateImportStepMatch ensures the step name is compatible with the input type
-// CRTDL is compatible with both torch (for TORCH extraction) and local_import (for local import + flattening)
-func validateImportStepMatch(inputType models.InputType, stepName models.StepName) error {
-	switch inputType {
-	case models.InputTypeCRTDL:
-		// CRTDL is compatible with torch (extraction) or local_import (flattening with local data)
-		if stepName != models.StepTorchImport && stepName != models.StepLocalImport {
-			return fmt.Errorf("input type %s requires step '%s' or '%s', but got '%s'", inputType, models.StepTorchImport, models.StepLocalImport, stepName)
-		}
-	case models.InputTypeTORCHURL:
-		if stepName != models.StepTorchImport {
-			return fmt.Errorf("input type %s requires step '%s', but got '%s'", inputType, models.StepTorchImport, stepName)
-		}
-	case models.InputTypeLocal:
-		if stepName != models.StepLocalImport {
-			return fmt.Errorf("input type %s requires step '%s', but got '%s'", inputType, models.StepLocalImport, stepName)
-		}
-	case models.InputTypeHTTP:
-		if stepName != models.StepHttpImport {
-			return fmt.Errorf("input type %s requires step '%s', but got '%s'", inputType, models.StepHttpImport, stepName)
-		}
-	default:
-		return fmt.Errorf("unknown input type: %s", inputType)
-	}
-	return nil
-}
-
-// executeStep executes a single pipeline step based on its name
-// Returns error if step execution fails
-func executeStep(job *models.PipelineJob, stepName models.StepName, config *models.ProjectConfig, logger *lib.Logger, noProgress bool) error {
-	jobDir := services.GetJobDir(config.JobsDir, job.JobID)
-
-	switch stepName {
-	case models.StepTorchImport, models.StepLocalImport, models.StepHttpImport:
-		if err := validateImportStepMatch(job.InputType, stepName); err != nil {
-			return fmt.Errorf("step validation failed: %w", err)
-		}
-
-		httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
-		showProgress := !noProgress
-
-		importedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, showProgress)
-		if err != nil {
-			return fmt.Errorf("%s step failed: %w", stepName, err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, importedJob); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ %s step completed (%d files)\n", stepName, importedJob.TotalFiles)
-		return nil
-
-	case models.StepDIMP:
-		fmt.Println("Starting DIMP pseudonymization step...")
-		if err := pipeline.ExecuteDIMPStep(job, jobDir, logger); err != nil {
-			failedJob := pipeline.FailJob(job, err.Error())
-			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-				logger.Error("Failed to save job state", "error", saveErr)
-			}
-			return fmt.Errorf("DIMP step failed: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ DIMP pseudonymization completed\n")
-		return nil
-
-	case models.StepValidation:
-		fmt.Println("Starting validation step...")
-		if err := pipeline.ExecuteValidationStep(job, jobDir, logger); err != nil {
-			failedJob := pipeline.FailJob(job, err.Error())
-			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-				logger.Error("Failed to save job state", "error", saveErr)
-			}
-			return fmt.Errorf("validation step failed: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ Validation completed\n")
-		return nil
-
-	case models.StepFlattening:
-		fmt.Println("Starting flattening step...")
-		if err := pipeline.ExecuteFlatteningStep(job, jobDir, logger); err != nil {
-			failedJob := pipeline.FailJob(job, err.Error())
-			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-				logger.Error("Failed to save job state", "error", saveErr)
-			}
-			return fmt.Errorf("flattening step failed: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ Flattening completed\n")
-		return nil
-
-	case models.StepSend:
-		fmt.Println("Starting send step...")
-		if err := pipeline.ExecuteSendStep(job, jobDir, logger); err != nil {
-			failedJob := pipeline.FailJob(job, err.Error())
-			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-				logger.Error("Failed to save job state", "error", saveErr)
-			}
-			return fmt.Errorf("send step failed: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ Send completed\n")
-		return nil
-
-	case models.StepWait:
-		// Execute wait step - creates empty wait directory and pauses pipeline
-		stepIndex := -1
-		for i, step := range job.Config.Pipeline.EnabledSteps {
-			if step == models.StepWait && string(step) == job.CurrentStep {
-				stepIndex = i
-				break
-			}
-		}
-		if stepIndex == -1 {
-			return fmt.Errorf("wait step not found in enabled steps")
-		}
-
-		if err := pipeline.ExecuteWaitStep(job, config.JobsDir, stepIndex); err != nil {
-			return fmt.Errorf("wait step failed: %w", err)
-		}
-
-		// Mark the wait step as waiting (job stays in_progress)
-		for i := range job.Steps {
-			if job.Steps[i].Name == models.StepWait && job.Steps[i].Status == models.StepStatusInProgress {
-				job.Steps[i].Status = models.StepStatusWaiting
-				break
-			}
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		waitDir, err := services.NewJobLayout(config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps).WaitDir(stepIndex)
-		if err != nil {
-			return fmt.Errorf("failed to resolve wait directory: %w", err)
-		}
-		fmt.Printf("\n⏸ Pipeline paused at wait step\n")
-		fmt.Printf("  Wait directory: %s\n", waitDir)
-		fmt.Printf("  The directory is EMPTY - place your modified data there\n")
-		fmt.Printf("\n  To continue: aether pipeline continue <config> %s\n", job.JobID)
-		return errPipelinePaused // Signal to break out of pipeline loop
-
-	default:
-		return fmt.Errorf("unknown step: %s", stepName)
-	}
-}
-
 func runPipelineStart(cmd *cobra.Command, args []string) error {
 	// Positional contract: <config> <crtdl> [input]. The third positional, if
 	// supplied, is the input source for the enabled import step.
@@ -428,74 +260,18 @@ func runPipelineStart(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Starting %s step...\n", startedJob.CurrentStep)
-	httpClient := services.NewHTTPClient(
-		time.Duration(config.Retry.InitialBackoffMs)*time.Millisecond*10, // Longer timeout for downloads
-		config.Retry,
-		config.TLS,
-		logger,
-	)
 
-	showProgress := !noProgress
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, showProgress)
-
+	final, err := pipeline.RunLoop(startedJob, logger, pipeline.RunOptions{NoProgress: noProgress})
 	if err != nil {
-		failedJob := pipeline.FailJob(importedJob, err.Error())
-		if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-			logger.Error("Failed to save job state", "error", saveErr)
+		if errors.Is(err, pipeline.ErrPaused) {
+			return nil // Paused at a wait step; RunLoop persisted the state.
 		}
-		return fmt.Errorf("%s step failed: %w", startedJob.CurrentStep, err)
+		return err // RunLoop already marked the job failed and saved it.
 	}
 
-	if saveErr := pipeline.UpdateJob(config.JobsDir, importedJob); saveErr != nil {
-		logger.Error("Failed to save job state", "error", saveErr)
-	}
-
-	fmt.Printf("\n✓ %s completed successfully\n", importedJob.CurrentStep)
-	fmt.Printf("  Files: %d\n", importedJob.TotalFiles)
-	fmt.Printf("  Size: %s\n", formatBytes(importedJob.TotalBytes))
-	fmt.Printf("\n")
-
-	currentJob := importedJob
-	for {
-		currentStepName := models.StepName(currentJob.CurrentStep)
-		nextStepName := currentJob.Config.Pipeline.GetNextStep(currentStepName)
-
-		if nextStepName == "" {
-			fmt.Println("All steps completed, marking job as complete...")
-			completedJob := pipeline.CompleteJob(currentJob)
-			if err := pipeline.UpdateJob(config.JobsDir, completedJob); err != nil {
-				return fmt.Errorf("failed to update job: %w", err)
-			}
-			fmt.Printf("\n✓ Pipeline completed successfully\n")
-			fmt.Printf("Job ID: %s\n", completedJob.JobID)
-			return nil
-		}
-
-		fmt.Printf("\nAdvancing to step: %s\n", nextStepName)
-		advancedJob, err := pipeline.AdvanceToNextStep(currentJob)
-		if err != nil {
-			return fmt.Errorf("failed to advance to next step: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, advancedJob); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		if err := executeStep(advancedJob, nextStepName, config, logger, noProgress); err != nil {
-			// Check if this is a "paused" signal from wait step
-			if err == errPipelinePaused {
-				return nil // Exit gracefully - pipeline is paused
-			}
-			// Mark job as failed
-			failedJob := pipeline.FailJob(advancedJob, err.Error())
-			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-				logger.Error("Failed to save failed job state", "error", saveErr)
-			}
-			return err
-		}
-
-		currentJob = advancedJob
-	}
+	fmt.Printf("\n✓ Pipeline completed successfully\n")
+	fmt.Printf("Job ID: %s\n", final.JobID)
+	return nil
 }
 
 func runPipelineStatus(cmd *cobra.Command, args []string) error {
@@ -593,17 +369,15 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 
 	currentStepName := models.StepName(job.CurrentStep)
 	currentStep, found := models.GetStepByName(*job, currentStepName)
-
-	var stepToExecute models.StepName
-	var jobToExecute *models.PipelineJob
-
 	if !found {
 		return fmt.Errorf("current step %s not found in job", currentStepName)
 	}
 
+	// If the current step already completed, advance to the next before running.
+	// Every other status (pending/in_progress/failed/waiting) resumes in place —
+	// RunLoop's transition guard and the idempotent wait step handle each.
 	if currentStep.Status == models.StepStatusCompleted {
 		nextStepName := job.Config.Pipeline.GetNextStep(currentStepName)
-
 		if nextStepName == "" {
 			fmt.Println("All steps completed, marking job as complete...")
 			completedJob := pipeline.CompleteJob(job)
@@ -619,154 +393,27 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to advance to next step: %w", err)
 		}
-
 		if err := pipeline.UpdateJob(config.JobsDir, advancedJob); err != nil {
 			return fmt.Errorf("failed to save job state: %w", err)
 		}
-
-		stepToExecute = nextStepName
-		jobToExecute = advancedJob
-	} else if currentStepName == models.StepWait && currentStep.Status == models.StepStatusWaiting {
-		// Special handling for wait step in "waiting" status
-		// Check if wait directory has files - if so, complete wait step and continue
-		fmt.Printf("Resuming incomplete step: %s (status: %s)\n", currentStepName, currentStep.Status)
-
-		// Find the wait step index to get the previous step
-		waitStepIndex := -1
-		for i, step := range job.Config.Pipeline.EnabledSteps {
-			if step == models.StepWait && string(step) == job.CurrentStep {
-				waitStepIndex = i
-				break
-			}
-		}
-		if waitStepIndex == -1 {
-			return fmt.Errorf("wait step not found in enabled steps")
-		}
-
-		waitDir, err := services.NewJobLayout(config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps).WaitDir(waitStepIndex)
-		if err != nil {
-			return fmt.Errorf("failed to resolve wait directory: %w", err)
-		}
-		fileCount, err := pipeline.CountFilesInDir(waitDir)
-		if err != nil {
-			return fmt.Errorf("failed to check wait directory: %w", err)
-		}
-
-		if fileCount == 0 {
-			// Directory is empty - stay paused
-			fmt.Printf("\n⏸ Pipeline still paused at wait step\n")
-			fmt.Printf("  Wait directory: %s\n", waitDir)
-			fmt.Printf("  The directory is EMPTY - place your modified data there\n")
-			fmt.Printf("\n  To continue: aether pipeline continue <config> %s\n", job.JobID)
-			return errPipelinePaused
-		}
-
-		// Files present - mark wait step as completed and continue
-		fmt.Printf("  Found %d file(s) in wait directory\n", fileCount)
-		fmt.Printf("  ✓ Wait step completed\n\n")
-
-		// Mark wait step as completed
-		for i := range job.Steps {
-			if job.Steps[i].Name == models.StepWait && job.Steps[i].Status == models.StepStatusWaiting {
-				now := time.Now()
-				job.Steps[i].Status = models.StepStatusCompleted
-				job.Steps[i].CompletedAt = &now
-				break
-			}
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		// Get and advance to next step
-		nextStepName := job.Config.Pipeline.GetNextStep(currentStepName)
-		if nextStepName == "" {
-			// No more steps - mark job as complete
-			fmt.Println("All steps completed, marking job as complete...")
-			completedJob := pipeline.CompleteJob(job)
-			if err := pipeline.UpdateJob(config.JobsDir, completedJob); err != nil {
-				return fmt.Errorf("failed to update job: %w", err)
-			}
-			fmt.Println("✓ Job completed successfully")
-			return nil
-		}
-
-		// Advance to next step
-		fmt.Printf("Advancing to step: %s\n", nextStepName)
-		advancedJob, err := pipeline.AdvanceToNextStep(job)
-		if err != nil {
-			return fmt.Errorf("failed to advance to next step: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, advancedJob); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		stepToExecute = nextStepName
-		jobToExecute = advancedJob
+		job = advancedJob
 	} else {
 		fmt.Printf("Resuming incomplete step: %s (status: %s)\n", currentStepName, currentStep.Status)
-		stepToExecute = currentStepName
-		jobToExecute = job
 	}
 
 	fmt.Printf("\nResuming pipeline execution...\n")
-	fmt.Printf("Executing step: %s\n\n", stepToExecute)
 
-	if err := executeStep(jobToExecute, stepToExecute, config, logger, noProgress); err != nil {
-		if err == errPipelinePaused {
-			return nil // Exit gracefully - pipeline is paused at wait step
+	final, err := pipeline.RunLoop(job, logger, pipeline.RunOptions{NoProgress: noProgress})
+	if err != nil {
+		if errors.Is(err, pipeline.ErrPaused) {
+			return nil // Still paused at a wait step; RunLoop persisted the state.
 		}
-		// Mark job as failed
-		failedJob := pipeline.FailJob(jobToExecute, err.Error())
-		if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-			logger.Error("Failed to save failed job state", "error", saveErr)
-		}
-		return err
+		return err // RunLoop already marked the job failed and saved it.
 	}
 
-	// Loop through remaining steps (same as runPipelineStart)
-	currentJob := jobToExecute
-	for {
-		currentStepName := models.StepName(currentJob.CurrentStep)
-		nextStepName := currentJob.Config.Pipeline.GetNextStep(currentStepName)
-
-		if nextStepName == "" {
-			fmt.Println("All steps completed, marking job as complete...")
-			completedJob := pipeline.CompleteJob(currentJob)
-			if err := pipeline.UpdateJob(config.JobsDir, completedJob); err != nil {
-				return fmt.Errorf("failed to update job: %w", err)
-			}
-			fmt.Printf("\n✓ Pipeline completed successfully\n")
-			fmt.Printf("Job ID: %s\n", completedJob.JobID)
-			return nil
-		}
-
-		fmt.Printf("\nAdvancing to step: %s\n", nextStepName)
-		advancedJob, err := pipeline.AdvanceToNextStep(currentJob)
-		if err != nil {
-			return fmt.Errorf("failed to advance to next step: %w", err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, advancedJob); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		if err := executeStep(advancedJob, nextStepName, config, logger, noProgress); err != nil {
-			if err == errPipelinePaused {
-				return nil // Exit gracefully - pipeline is paused at wait step
-			}
-			// Mark job as failed
-			failedJob := pipeline.FailJob(advancedJob, err.Error())
-			if saveErr := pipeline.UpdateJob(config.JobsDir, failedJob); saveErr != nil {
-				logger.Error("Failed to save failed job state", "error", saveErr)
-			}
-			return err
-		}
-
-		currentJob = advancedJob
-	}
+	fmt.Printf("\n✓ Pipeline completed successfully\n")
+	fmt.Printf("Job ID: %s\n", final.JobID)
+	return nil
 }
 
 func getStatusSymbol(status models.StepStatus) string {

--- a/internal/models/transitions.go
+++ b/internal/models/transitions.go
@@ -60,6 +60,26 @@ func UpdateJobMetrics(job PipelineJob, files int, bytes int64) PipelineJob {
 	return job
 }
 
+// CanTransitionTo reports whether a step may legally move from one status to
+// another. It is the single gate consulted before every step-status mutation.
+// in_progress -> in_progress is allowed so a step left in_progress by a killed
+// process can be re-entered on resume.
+func CanTransitionTo(from, to StepStatus) bool {
+	switch from {
+	case StepStatusPending:
+		return to == StepStatusInProgress
+	case StepStatusInProgress:
+		return to == StepStatusInProgress || to == StepStatusCompleted ||
+			to == StepStatusFailed || to == StepStatusWaiting
+	case StepStatusFailed:
+		return to == StepStatusInProgress
+	case StepStatusWaiting:
+		return to == StepStatusInProgress || to == StepStatusCompleted
+	default: // StepStatusCompleted is terminal
+		return false
+	}
+}
+
 // StartStep creates a new PipelineStep with in_progress status
 // Pure function - returns new instance
 func StartStep(step PipelineStep) PipelineStep {

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -33,62 +33,49 @@ func ResetDIMPFactory() {
 	dimpFactory = defaultDIMPFactory
 }
 
-// ExecuteDIMPStep processes FHIR resources through the DIMP pseudonymization service
-// Reads from import/ directory, writes to dimp/ directory
-// Orchestrates Bundle splitting and oversized resource detection before pseudonymization
+// dimpStep pseudonymizes FHIR resources through the DIMP service.
+// Reads from import/ directory, writes to dimp/ directory. Orchestrates Bundle
+// splitting and oversized resource detection before pseudonymization.
+type dimpStep struct{}
+
+func (dimpStep) Name() models.StepName { return models.StepDIMP }
+
+// ExecuteDIMPStep runs the DIMP pseudonymization step through the shared lifecycle.
 func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	return runStep(dimpStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+}
+
+func (dimpStep) Run(ctx *StepContext) (StepResult, error) {
+	job := ctx.Job
+	logger := ctx.Logger
 	stepName := models.StepDIMP
 
-	if !isStepEnabled(job.Config, stepName) {
-		logger.Info("DIMP step not enabled, skipping", "job_id", job.JobID)
-		return nil
-	}
-
-	logger.Debug("DIMP step starting", "job_id", job.JobID)
-
-	step := getOrCreateStep(job, stepName)
-	step.Status = models.StepStatusInProgress
-	now := time.Now()
-	step.StartedAt = &now
-
 	if job.Config.Services.DIMP.URL == "" {
-		err := fmt.Errorf("DIMP service URL not configured")
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("DIMP service URL not configured")
 	}
 
 	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 	dimpClient := dimpFactory(job.Config.Services.DIMP.URL, httpClient, logger)
 
-	layout := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps)
+	layout := services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), job.Config.Pipeline.EnabledSteps)
 	importDir := layout.InputDir(stepName)
 	outputDir := layout.OutputDir(stepName)
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to create output directory: %w", err)
+		return StepResult{}, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	files, err := findFHIRFiles(importDir)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to list import files: %w", err)
+		return StepResult{}, fmt.Errorf("failed to list import files: %w", err)
 	}
 
 	if len(files) == 0 {
-		err := fmt.Errorf("no FHIR NDJSON files found in %s", importDir)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("no FHIR NDJSON files found in %s", importDir)
 	}
 
 	if err := models.DetectDuplicateFHIRFiles(files); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, err
 	}
 
 	fmt.Printf("Processing %d FHIR file(s) through DIMP...\n\n", len(files))
@@ -103,7 +90,6 @@ func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger)
 	compressionLevel := job.Config.Compression.Level
 
 	totalResourcesProcessed := 0
-	filesProcessed := 0
 	for fileIdx, inputFile := range files {
 		baseName := lib.GetUncompressedFilename(filepath.Base(inputFile))
 		outputBaseName := "dimped_" + baseName
@@ -116,7 +102,6 @@ func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger)
 				"filename", baseName,
 				"output_file", outputFile,
 				"job_id", job.JobID)
-			filesProcessed++
 			if lineCount, err := lib.CountResourcesInFile(outputFile); err == nil {
 				totalResourcesProcessed += lineCount
 			}
@@ -132,32 +117,20 @@ func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger)
 				"resources_processed_so_far", totalResourcesProcessed,
 				"error", err,
 				"job_id", job.JobID)
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, isServiceErrorRetryable(err))
-			recordStepError(step, err, classifyServiceError(err))
-			return fmt.Errorf("failed to process %s: %w", baseName, err)
+			return StepResult{}, fmt.Errorf("failed to process %s: %w", baseName, err)
 		}
 
 		fmt.Printf("  ✓ %s (%d resources)\n", baseName, resourcesProcessed)
-
 		totalResourcesProcessed += resourcesProcessed
-		filesProcessed++
 	}
-
-	step.Status = models.StepStatusCompleted
-	step.FilesProcessed = len(files)
-	completedAt := time.Now()
-	step.CompletedAt = &completedAt
-
-	duration := completedAt.Sub(*step.StartedAt)
 
 	logger.Debug("DIMP step completed",
 		"files_processed", len(files),
 		"resources_processed", totalResourcesProcessed,
-		"duration", duration,
 		"job_id", job.JobID,
 	)
 
-	return nil
+	return StepResult{FilesProcessed: len(files)}, nil
 }
 
 // processDIMPFile processes a single NDJSON file through DIMP
@@ -313,13 +286,4 @@ func getOrCreateStep(job *models.PipelineJob, stepName models.StepName) *models.
 	}
 	job.Steps = append(job.Steps, step)
 	return &job.Steps[len(job.Steps)-1]
-}
-
-func recordStepError(step *models.PipelineStep, err error, errorType models.ErrorType) {
-	step.Status = models.StepStatusFailed
-	step.LastError = &models.StepError{
-		Type:      errorType,
-		Message:   err.Error(),
-		Timestamp: time.Now(),
-	}
 }

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
@@ -41,38 +40,34 @@ type groupBatch struct {
 	isFirstBatch bool // true until first flush
 }
 
-// ExecuteFlatteningStep transforms FHIR NDJSON data into CSV files using the fhir-flattener API
-// Reads from dimp/ (if DIMP enabled) or import/ directory
-// Outputs to csv/ directory
+// flatteningStep transforms FHIR NDJSON data into CSV files using the fhir-flattener API.
+// Reads from dimp/ (if DIMP enabled) or import/ directory, outputs to csv/.
+type flatteningStep struct{}
+
+func (flatteningStep) Name() models.StepName { return models.StepFlattening }
+
+// ExecuteFlatteningStep runs the flattening step through the shared lifecycle. It
+// is the exported single-step entrypoint used by the black-box tests; it has no
+// production caller yet (the cmd manual path wires only import and dimp today).
+// To be folded into one exported pipeline.RunStep — see issue #516.
 func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	return runStep(flatteningStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+}
+
+func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
+	job := ctx.Job
+	logger := ctx.Logger
 	stepName := models.StepFlattening
-
-	if !isStepEnabled(job.Config, stepName) {
-		logger.Info("Flattening step not enabled, skipping", "job_id", job.JobID)
-		return nil
-	}
-
-	logger.Debug("Flattening step starting", "job_id", job.JobID)
-
-	step := getOrCreateStep(job, stepName)
-	step.Status = models.StepStatusInProgress
-	now := time.Now()
-	step.StartedAt = &now
 
 	// Validate flattening configuration
 	if err := job.Config.Services.Flattening.Validate(); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, err
 	}
 
 	// CRTDL file is required for flattening. It may come from the positional
 	// arg (for torch) or from --crtdl (for http_import/local_import).
 	if job.CRTDLPath == "" {
-		err := fmt.Errorf("flattening step requires a CRTDL file: pass one as the positional input or via --crtdl")
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("flattening step requires a CRTDL file: pass one as the positional input or via --crtdl")
 	}
 
 	// Load CRTDL document
@@ -80,9 +75,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 	logger.Debug("Loading CRTDL file", "path", crtdlPath)
 	crtdl, err := services.ParseCRTDL(crtdlPath)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to parse CRTDL file: %w", err)
+		return StepResult{}, fmt.Errorf("failed to parse CRTDL file: %w", err)
 	}
 
 	// Load lookup tables
@@ -90,42 +83,31 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 	logger.Debug("Loading lookup tables", "path", lookupPath)
 	lookupTables, err := services.LoadLookupTables(lookupPath)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to load lookup tables: %w", err)
+		return StepResult{}, fmt.Errorf("failed to load lookup tables: %w", err)
 	}
 
 	// Validate lookup tables
 	if err := services.ValidateLookupTables(lookupTables); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("invalid lookup tables: %w", err)
+		return StepResult{}, fmt.Errorf("invalid lookup tables: %w", err)
 	}
 
-	layout := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps)
+	layout := services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), job.Config.Pipeline.EnabledSteps)
 	inputDir := layout.InputDir(stepName)
 	outputDir := layout.OutputDir(stepName)
 	viewDefDir := layout.ViewDefinitionsDir()
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to create output directory: %w", err)
+		return StepResult{}, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	// Find FHIR NDJSON files in input directory
 	files, err := findFHIRFiles(inputDir)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to list input files: %w", err)
+		return StepResult{}, fmt.Errorf("failed to list input files: %w", err)
 	}
 
 	if len(files) == 0 {
-		err := fmt.Errorf("no FHIR NDJSON files found in %s", inputDir)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("no FHIR NDJSON files found in %s", inputDir)
 	}
 
 	logger.Info("Streaming FHIR resources from input files",
@@ -136,9 +118,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 	// Pass 1: scan input files for provenance index
 	provenanceIndex, err := scanProvenanceIndex(files)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to load resources: %w", err)
+		return StepResult{}, fmt.Errorf("failed to load resources: %w", err)
 	}
 
 	logger.Info("Built provenance index",
@@ -202,9 +182,7 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		job.Config.Services.Flattening.GetBatchSizeBytes(),
 	)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, IsFlatteningErrorRetryable(err))
-		recordStepError(step, err, ClassifyFlatteningError(err))
-		return err
+		return StepResult{}, err
 	}
 
 	// Print per-group progress
@@ -221,19 +199,11 @@ func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.L
 		fmt.Printf("  ✓ %s (%d resources → %s)\n", group.Name, totals[i], filenames[i])
 	}
 
-	step.Status = models.StepStatusCompleted
-	step.FilesProcessed = totalFilesWritten
-	completedAt := time.Now()
-	step.CompletedAt = &completedAt
-
-	duration := completedAt.Sub(*step.StartedAt)
-
 	logger.Debug("Flattening step completed",
 		"files_written", totalFilesWritten,
-		"duration", duration,
 		"job_id", job.JobID)
 
-	return nil
+	return StepResult{FilesProcessed: totalFilesWritten}, nil
 }
 
 // scanProvenanceIndex performs a lightweight first pass over all input files,

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -28,132 +28,119 @@ func ResetExtractorFactory() {
 	extractorFactory = defaultExtractorFactory
 }
 
-// ExecuteImportStep performs the import step of the pipeline
-// Uses the current step (from job.CurrentStep) to determine import method
-// For local_import: uses config.Services.LocalImport.Dir or job.InputSource
-// For torch: uses TORCH extraction with CRTDL from job.InputSource
-// For http_import: downloads from URL in job.InputSource
-// Updates job state with progress and imported files
+// importStep imports FHIR data into the import/ directory. It carries its own
+// step name (torch/local/http) because the registry maps all three names to it
+// and the name selects both the import method and the error-classification rule.
+type importStep struct {
+	name models.StepName
+}
+
+func (s importStep) Name() models.StepName { return s.name }
+
+// ClassifyError preserves import's step-name-gated classification (network
+// errors are transient only for http/torch imports).
+func (s importStep) ClassifyError(err error) models.ErrorType {
+	return classifyImportError(err, s.name)
+}
+
+// ExecuteImportStep runs the import step through the shared lifecycle. On failure
+// it also marks the job failed (models.AddError), matching import's historical
+// job-level failure behavior, and returns the (mutated) job either way.
 func ExecuteImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *services.HTTPClient, showProgress bool) (*models.PipelineJob, error) {
-	startTime := time.Now()
+	ctx := &StepContext{
+		Job:          job,
+		JobDir:       services.GetJobDir(job.Config.JobsDir, job.JobID),
+		Logger:       logger,
+		HTTPClient:   httpClient,
+		ShowProgress: showProgress,
+	}
+	if err := runStep(importStep{name: models.StepName(job.CurrentStep)}, ctx); err != nil {
+		updated := models.AddError(*job, err.Error())
+		return &updated, err
+	}
+	return job, nil
+}
 
-	currentStep := models.StepName(job.CurrentStep)
-	lib.LogStepStart(logger, string(currentStep), job.JobID)
+// Run selects the import method from the step name. It builds its own HTTP
+// client when none was injected (the orchestration-loop path), using the
+// longer download-safe timeout.
+func (s importStep) Run(ctx *StepContext) (StepResult, error) {
+	job := ctx.Job
+	logger := ctx.Logger
+	currentStep := s.name
 
-	// Get import output directory
+	httpClient := ctx.HTTPClient
+	if httpClient == nil {
+		httpClient = services.NewHTTPClient(
+			time.Duration(job.Config.Retry.InitialBackoffMs)*time.Millisecond*10,
+			job.Config.Retry, job.Config.TLS, logger)
+	}
+
 	importDir := services.GetJobOutputDir(job.Config.JobsDir, job.JobID, currentStep)
-
-	// Get compression settings
 	compress := job.Config.Compression.Enabled
 	compressionLevel := job.Config.Compression.Level
 
-	// Execute import based on the current step (enabled import step)
 	var importedFiles []models.FHIRDataFile
 	var err error
 
 	switch currentStep {
 	case models.StepLocalImport:
-		// Determine source directory: config dir takes precedence, fallback to job.InputSource
+		// Config dir takes precedence, fallback to job.InputSource
 		sourceDir := job.Config.Services.LocalImport.Dir
 		if sourceDir == "" {
 			sourceDir = job.InputSource
 		}
-
-		// Validate source directory
-		if err := services.ValidateImportSource(sourceDir, models.InputTypeLocal); err != nil {
-			updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
-			lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
-			return &updatedJob, err
+		if verr := services.ValidateImportSource(sourceDir, models.InputTypeLocal); verr != nil {
+			return StepResult{}, verr
 		}
-
 		logger.Info("Importing from local directory", "source", sourceDir, "compress", compress)
 		importedFiles, err = services.ImportFromLocalDirectory(sourceDir, importDir, logger, compress, compressionLevel)
 
 	case models.StepHttpImport:
-		// Validate HTTP URL
-		if err := services.ValidateImportSource(job.InputSource, models.InputTypeHTTP); err != nil {
-			updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
-			lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
-			return &updatedJob, err
+		if verr := services.ValidateImportSource(job.InputSource, models.InputTypeHTTP); verr != nil {
+			return StepResult{}, verr
 		}
-
 		logger.Info("Downloading from URL", "source", job.InputSource, "compress", compress)
-		if showProgress {
+		if ctx.ShowProgress {
 			importedFiles, err = services.DownloadFromURLWithProgress(job.InputSource, importDir, httpClient, logger, compress, compressionLevel)
 		} else {
 			importedFiles, err = services.DownloadFromURL(job.InputSource, importDir, httpClient, logger, false, compress, compressionLevel)
 		}
 
 	case models.StepTorchImport:
-		// TORCH result URL: poll directly, skip extraction submission.
-		// Otherwise: submit the attached CRTDL for extraction.
+		// TORCH result URL: poll directly. Otherwise: submit the CRTDL for extraction.
 		if job.InputType == models.InputTypeTORCHURL {
-			if err := services.ValidateImportSource(job.InputSource, models.InputTypeTORCHURL); err != nil {
-				updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
-				lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
-				return &updatedJob, err
+			if verr := services.ValidateImportSource(job.InputSource, models.InputTypeTORCHURL); verr != nil {
+				return StepResult{}, verr
 			}
-
 			logger.Info("Downloading from TORCH result URL", "source", job.InputSource, "compress", compress)
-			importedFiles, err = executeTORCHDownload(job, importDir, httpClient, logger, showProgress, compress, compressionLevel)
+			importedFiles, err = executeTORCHDownload(job, importDir, httpClient, logger, ctx.ShowProgress, compress, compressionLevel)
 		} else {
-			if err := services.ValidateImportSource(job.CRTDLPath, models.InputTypeCRTDL); err != nil {
-				updatedJob := failImportStep(job, err, models.ErrorTypeNonTransient, 0)
-				lib.LogStepFailed(logger, string(currentStep), job.JobID, err, false)
-				return &updatedJob, err
+			if verr := services.ValidateImportSource(job.CRTDLPath, models.InputTypeCRTDL); verr != nil {
+				return StepResult{}, verr
 			}
-
 			logger.Info("Extracting data from TORCH using CRTDL", "crtdl", job.CRTDLPath, "compress", compress)
-			importedFiles, err = executeTORCHExtraction(job, importDir, httpClient, logger, showProgress, compress, compressionLevel)
+			importedFiles, err = executeTORCHExtraction(job, importDir, httpClient, logger, ctx.ShowProgress, compress, compressionLevel)
 		}
 
 	default:
-		err = fmt.Errorf("unsupported import step: %s", currentStep)
+		return StepResult{}, fmt.Errorf("unsupported import step: %s", currentStep)
 	}
 
-	// Handle errors
 	if err != nil {
-		// Classify error type
-		errorType := classifyImportError(err, currentStep)
-		updatedJob := failImportStep(job, err, errorType, 0)
-		lib.LogStepFailed(logger, string(currentStep), job.JobID, err, errorType == models.ErrorTypeTransient)
-		return &updatedJob, err
+		return StepResult{}, err
 	}
 
-	// Calculate total bytes imported
 	var totalBytes int64
 	for _, file := range importedFiles {
 		totalBytes += file.FileSize
 	}
 
-	// Update job with imported file metrics
-	updatedJob := models.UpdateJobMetrics(*job, len(importedFiles), totalBytes)
+	// Job-level totals are non-lifecycle state the import step owns.
+	job.TotalFiles = len(importedFiles)
+	job.TotalBytes = totalBytes
 
-	// Complete the import step
-	importStep, _ := models.GetStepByName(updatedJob, currentStep)
-	completedStep := models.CompleteStep(importStep, len(importedFiles), totalBytes)
-	updatedJob = models.ReplaceStep(updatedJob, completedStep)
-
-	duration := time.Since(startTime)
-	lib.LogStepComplete(logger, string(currentStep), job.JobID, len(importedFiles), duration)
-
-	return &updatedJob, nil
-}
-
-// failImportStep marks the import step as failed
-func failImportStep(job *models.PipelineJob, err error, errorType models.ErrorType, httpStatus int) models.PipelineJob {
-	currentStep := models.StepName(job.CurrentStep)
-	importStep, found := models.GetStepByName(*job, currentStep)
-	if !found {
-		// Step not found - shouldn't happen, but handle gracefully
-		return models.AddError(*job, err.Error())
-	}
-
-	failedStep := models.FailStep(importStep, errorType, err.Error(), httpStatus)
-	updatedJob := models.ReplaceStep(*job, failedStep)
-	updatedJob = models.AddError(updatedJob, err.Error())
-
-	return updatedJob
+	return StepResult{FilesProcessed: len(importedFiles), BytesProcessed: totalBytes}, nil
 }
 
 // executeTORCHExtraction submits the (already prepared) CRTDL to TORCH,

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -1,0 +1,74 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// RunOptions carries orchestration-loop settings.
+type RunOptions struct {
+	NoProgress bool
+}
+
+// RunLoop drives a job from its current step to completion or a wait-step pause.
+// It is the single loop shared by pipeline start and continue: it executes the
+// current step through runStep, persists after each step, advances to the next,
+// and completes the job when no step remains. On ErrPaused it stops cleanly
+// (the job stays in_progress); on any other step error it fails the job.
+//
+// The job must already be positioned at the step to run (CurrentStep set). Fake
+// steps injected via SetStepRegistryForTesting make this loop unit-testable
+// without real services.
+func RunLoop(job *models.PipelineJob, logger *lib.Logger, opts RunOptions) (*models.PipelineJob, error) {
+	for {
+		stepName := models.StepName(job.CurrentStep)
+		step, ok := stepLookup(stepName)
+		if !ok {
+			return job, fmt.Errorf("unknown step: %s", stepName)
+		}
+
+		ctx := &StepContext{
+			Job:          job,
+			JobDir:       services.GetJobDir(job.Config.JobsDir, job.JobID),
+			Logger:       logger,
+			ShowProgress: !opts.NoProgress,
+		}
+
+		if err := runStep(step, ctx); err != nil {
+			if errors.Is(err, ErrPaused) {
+				_ = UpdateJob(job.Config.JobsDir, job)
+				return job, ErrPaused
+			}
+			failed := FailJob(job, err.Error())
+			if saveErr := UpdateJob(job.Config.JobsDir, failed); saveErr != nil {
+				logger.Error("Failed to save failed job state", "error", saveErr)
+			}
+			return failed, err
+		}
+
+		if err := UpdateJob(job.Config.JobsDir, job); err != nil {
+			return job, fmt.Errorf("failed to save job state: %w", err)
+		}
+
+		if job.Config.Pipeline.GetNextStep(stepName) == "" {
+			completed := CompleteJob(job)
+			if err := UpdateJob(job.Config.JobsDir, completed); err != nil {
+				return completed, fmt.Errorf("failed to save job state: %w", err)
+			}
+			return completed, nil
+		}
+
+		advanced, err := AdvanceToNextStep(job)
+		if err != nil {
+			return job, fmt.Errorf("failed to advance to next step: %w", err)
+		}
+		job = advanced
+		if err := UpdateJob(job.Config.JobsDir, job); err != nil {
+			return job, fmt.Errorf("failed to save job state: %w", err)
+		}
+	}
+}

--- a/internal/pipeline/registry.go
+++ b/internal/pipeline/registry.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import "github.com/medizininformatik-initiative/aether/internal/models"
+
+// stepRegistry maps every pipeline step name to its Step implementation. The
+// three import names share importStep, each carrying its own name; send's three
+// sub-modes live inside sendStep.Run.
+var stepRegistry = map[models.StepName]Step{
+	models.StepTorchImport: importStep{name: models.StepTorchImport},
+	models.StepLocalImport: importStep{name: models.StepLocalImport},
+	models.StepHttpImport:  importStep{name: models.StepHttpImport},
+	models.StepDIMP:        dimpStep{},
+	models.StepValidation:  validationStep{},
+	models.StepFlattening:  flatteningStep{},
+	models.StepSend:        sendStep{},
+	models.StepWait:        waitStep{},
+}
+
+func defaultStepLookup(name models.StepName) (Step, bool) {
+	s, ok := stepRegistry[name]
+	return s, ok
+}
+
+// stepLookup resolves a step name to its Step. Overridable in tests so the
+// orchestration loop can run against fake steps.
+var stepLookup = defaultStepLookup
+
+// StepFor returns the Step registered for name. It is the exported registry
+// accessor used by the black-box tests; production dispatch (RunLoop) goes through
+// the unexported stepLookup directly, so this has no production caller.
+// To be reconsidered alongside the pipeline.RunStep unification — see issue #516.
+func StepFor(name models.StepName) (Step, bool) { return stepLookup(name) }
+
+// SetStepRegistryForTesting replaces the step lookup for tests.
+func SetStepRegistryForTesting(lookup func(models.StepName) (Step, bool)) { stepLookup = lookup }
+
+// ResetStepRegistry restores the default step lookup.
+func ResetStepRegistry() { stepLookup = defaultStepLookup }

--- a/internal/pipeline/registry_test.go
+++ b/internal/pipeline/registry_test.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+func TestStepRegistry_ResolvesEveryStep(t *testing.T) {
+	names := []models.StepName{
+		models.StepTorchImport, models.StepLocalImport, models.StepHttpImport,
+		models.StepDIMP, models.StepValidation, models.StepFlattening,
+		models.StepSend, models.StepWait,
+	}
+	for _, n := range names {
+		s, ok := StepFor(n)
+		require.True(t, ok, "expected registry entry for %s", n)
+		assert.Equal(t, n, s.Name(), "registered step should report its own name")
+	}
+}
+
+func TestStepRegistry_UnknownStep(t *testing.T) {
+	_, ok := StepFor(models.StepName("bogus"))
+	assert.False(t, ok)
+}
+
+func TestStepRegistry_OverrideForTesting(t *testing.T) {
+	fake := &fakeStep{name: models.StepDIMP}
+	SetStepRegistryForTesting(func(models.StepName) (Step, bool) { return fake, true })
+	defer ResetStepRegistry()
+
+	s, ok := StepFor(models.StepDIMP)
+	require.True(t, ok)
+	assert.Same(t, fake, s)
+}

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,71 +60,59 @@ func putWithAuth(targetURL, contentType string, body []byte, config models.SendC
 	return httpClient.Do(req)
 }
 
-// ExecuteSendStep sends pipeline output to the configured destination.
-// Supports two modes:
-// - direct_resource_load: Sends NDJSON files directly to a FHIR server using transaction bundles
-// - transfer_load: Prepares and sends to a transfer FHIR server using Binary/DocumentReference
+// sendStep sends pipeline output to the configured destination, dispatching on
+// Services.Send.SendAs:
+//   - direct_resource_load: NDJSON files to a FHIR server via transaction bundles
+//   - transfer_load: to a transfer FHIR server via Binary/DocumentReference
+//   - s3_upload: to an S3 bucket
+type sendStep struct{}
+
+func (sendStep) Name() models.StepName { return models.StepSend }
+
+// ExecuteSendStep runs the send step through the shared lifecycle. It is the
+// exported single-step entrypoint used by the black-box tests; it has no
+// production caller yet (the cmd manual path wires only import and dimp today).
+// To be folded into one exported pipeline.RunStep — see issue #516.
 func ExecuteSendStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	stepName := models.StepSend
+	return runStep(sendStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+}
 
-	if !isStepEnabled(job.Config, stepName) {
-		logger.Info("Send step not enabled, skipping", "job_id", job.JobID)
-		return nil
-	}
-
-	logger.Debug("Send step starting", "job_id", job.JobID)
-
-	step := getOrCreateStep(job, stepName)
-	step.Status = models.StepStatusInProgress
-	now := time.Now()
-	step.StartedAt = &now
+func (sendStep) Run(ctx *StepContext) (StepResult, error) {
+	job := ctx.Job
+	logger := ctx.Logger
 
 	if err := job.Config.Services.Send.Validate(); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, err
 	}
 
-	// Route to appropriate send implementation based on send mode
 	sendMode := job.Config.Services.Send.SendAs
-
-	var err error
 	switch sendMode {
 	case models.SendModeDirectResourceLoad:
-		err = executeDirectResourceLoadSend(job, jobDir, step, logger)
+		return executeDirectResourceLoadSend(job, ctx.JobDir, logger)
 	case models.SendModeTransferLoad:
-		err = executeTransferLoadSend(job, jobDir, step, logger)
+		return executeTransferLoadSend(job, ctx.JobDir, logger)
 	case models.SendModeS3Upload:
-		err = executeS3UploadSend(job, jobDir, step, logger)
+		return executeS3UploadSend(job, ctx.JobDir, logger)
 	default:
-		err = fmt.Errorf("unknown send mode: %s", sendMode)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
+		return StepResult{}, fmt.Errorf("unknown send mode: %s", sendMode)
 	}
-
-	return err
 }
 
 // executeTransferLoadSend sends files to a transfer FHIR server.
 // For each file: zips it, base64-encodes it, and wraps it in a FHIR Binary resource.
 // Then creates a DocumentReference linking all Binaries and uploads them.
-func executeTransferLoadSend(job *models.PipelineJob, jobDir string, step *models.PipelineStep, logger *lib.Logger) error {
+func executeTransferLoadSend(job *models.PipelineJob, jobDir string, logger *lib.Logger) (StepResult, error) {
 	stepName := models.StepSend
 
 	inputDir := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps).InputDir(stepName)
 
 	files, err := findAllFilesRecursive(inputDir)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to list input files: %w", err)
+		return StepResult{}, fmt.Errorf("failed to list input files: %w", err)
 	}
 
 	if len(files) == 0 {
-		err := fmt.Errorf("no files found in %s", inputDir)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("no files found in %s", inputDir)
 	}
 
 	fmt.Printf("Preparing %d file(s) for transfer...\n\n", len(files))
@@ -136,9 +123,7 @@ func executeTransferLoadSend(job *models.PipelineJob, jobDir string, step *model
 
 		entry, err := createBinaryFromFile(filePath)
 		if err != nil {
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-			recordStepError(step, err, models.ErrorTypeNonTransient)
-			return fmt.Errorf("failed to process %s: %w", fileName, err)
+			return StepResult{}, fmt.Errorf("failed to process %s: %w", fileName, err)
 		}
 
 		binaryResources = append(binaryResources, entry)
@@ -163,41 +148,29 @@ func executeTransferLoadSend(job *models.PipelineJob, jobDir string, step *model
 	for i, binary := range binaryResources {
 		fmt.Printf("  Uploading Binary %d/%d...\n", i+1, len(binaryResources))
 		if err := uploadBinary(binary, sendConfig, httpClient, logger); err != nil {
-			retryable := isSendErrorRetryable(err)
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, retryable)
-			recordStepError(step, err, classifySendError(err))
-			return fmt.Errorf("failed to upload Binary %s: %w", binary.id, err)
+			return StepResult{}, fmt.Errorf("failed to upload Binary %s: %w", binary.id, err)
 		}
 	}
 
 	// Upload DocumentReference
 	fmt.Println("  Uploading DocumentReference...")
 	if err := uploadDocumentReference(docRef, sendConfig, httpClient, logger); err != nil {
-		retryable := isSendErrorRetryable(err)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, retryable)
-		recordStepError(step, err, classifySendError(err))
-		return fmt.Errorf("failed to upload DocumentReference: %w", err)
+		return StepResult{}, fmt.Errorf("failed to upload DocumentReference: %w", err)
 	}
 
 	fmt.Printf("\n✓ Transfer complete (%d files sent)\n", len(files))
 
-	step.Status = models.StepStatusCompleted
-	step.FilesProcessed = len(files)
-	completedAt := time.Now()
-	step.CompletedAt = &completedAt
-
 	logger.Debug("Transfer load send step completed",
 		"files_sent", len(files),
-		"duration", completedAt.Sub(*step.StartedAt),
 		"job_id", job.JobID)
 
-	return nil
+	return StepResult{FilesProcessed: len(files)}, nil
 }
 
 // executeDirectResourceLoadSend uploads NDJSON files to a FHIR server using transaction bundles.
 // Core files (core.ndjson) are loaded first before other NDJSON files to ensure
 // base resources are created before dependent resources.
-func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step *models.PipelineStep, logger *lib.Logger) error {
+func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, logger *lib.Logger) (StepResult, error) {
 	stepName := models.StepSend
 
 	inputDir := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps).InputDir(stepName)
@@ -205,16 +178,11 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 	// Find NDJSON files
 	files, err := findNDJSONFiles(inputDir)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to list NDJSON files in %s: %w", inputDir, err)
+		return StepResult{}, fmt.Errorf("failed to list NDJSON files in %s: %w", inputDir, err)
 	}
 
 	if len(files) == 0 {
-		err := fmt.Errorf("no NDJSON files found in %s", inputDir)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("no NDJSON files found in %s", inputDir)
 	}
 
 	// Partition files: core files first, then others
@@ -251,9 +219,7 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 		// Open file (handles both compressed and uncompressed)
 		reader, err := lib.OpenFileForReading(filePath)
 		if err != nil {
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-			recordStepError(step, err, models.ErrorTypeNonTransient)
-			return fmt.Errorf("failed to open %s: %w", filepath.Base(filePath), err)
+			return StepResult{}, fmt.Errorf("failed to open %s: %w", filepath.Base(filePath), err)
 		}
 
 		// Upload file
@@ -263,9 +229,7 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 		}
 
 		if err != nil {
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, isFHIRErrorRetryable(err))
-			recordStepError(step, err, classifyFHIRError(err))
-			return fmt.Errorf("failed to upload %s: %w", filepath.Base(filePath), err)
+			return StepResult{}, fmt.Errorf("failed to upload %s: %w", filepath.Base(filePath), err)
 		}
 
 		filesProcessed++
@@ -275,23 +239,15 @@ func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, step 
 			filepath.Base(filePath), stats.ResourcesUploaded, stats.BatchesSent)
 	}
 
-	step.Status = models.StepStatusCompleted
-	step.FilesProcessed = filesProcessed
-	completedAt := time.Now()
-	step.CompletedAt = &completedAt
-
-	duration := completedAt.Sub(*step.StartedAt)
-
 	logger.Debug("Direct resource load send step completed",
 		"files_processed", filesProcessed,
 		"resources_uploaded", totalResources,
-		"duration", duration,
 		"fhir_url", fhirURL,
 		"job_id", job.JobID)
 
 	fmt.Printf("\n✓ Uploaded %d resources from %d files to FHIR server\n", totalResources, filesProcessed)
 
-	return nil
+	return StepResult{FilesProcessed: filesProcessed}, nil
 }
 
 // findNDJSONFiles finds all NDJSON files in a directory (both .ndjson and .ndjson.zst)
@@ -329,25 +285,6 @@ func partitionCoreFiles(files []string) (coreFiles, otherFiles []string) {
 		}
 	}
 	return coreFiles, otherFiles
-}
-
-// isFHIRErrorRetryable checks if a FHIR error should be retried
-func isFHIRErrorRetryable(err error) bool {
-	if fhirErr, ok := err.(*services.FHIRError); ok {
-		return fhirErr.IsRetryable()
-	}
-	return lib.IsNetworkError(err)
-}
-
-// classifyFHIRError classifies a FHIR error as transient or non-transient
-func classifyFHIRError(err error) models.ErrorType {
-	if fhirErr, ok := err.(*services.FHIRError); ok {
-		return fhirErr.ErrorType
-	}
-	if lib.IsNetworkError(err) {
-		return models.ErrorTypeTransient
-	}
-	return models.ErrorTypeNonTransient
 }
 
 // binaryEntry holds a FHIR Binary resource and its metadata
@@ -553,23 +490,19 @@ func findAllFilesRecursive(dir string) ([]string, error) {
 
 // executeS3UploadSend uploads files from the input directory to an S3 bucket.
 // Uses an upload manifest for retry resilience — previously uploaded files are skipped.
-func executeS3UploadSend(job *models.PipelineJob, jobDir string, step *models.PipelineStep, logger *lib.Logger) error {
+func executeS3UploadSend(job *models.PipelineJob, jobDir string, logger *lib.Logger) (StepResult, error) {
 	stepName := models.StepSend
+	startTime := time.Now()
 
 	inputDir := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps).InputDir(stepName)
 
 	files, err := findAllFilesRecursive(inputDir)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to list input files: %w", err)
+		return StepResult{}, fmt.Errorf("failed to list input files: %w", err)
 	}
 
 	if len(files) == 0 {
-		err := fmt.Errorf("no files found in %s", inputDir)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("no files found in %s", inputDir)
 	}
 
 	s3Config := job.Config.Services.Send.S3
@@ -577,9 +510,7 @@ func executeS3UploadSend(job *models.PipelineJob, jobDir string, step *models.Pi
 	// Create uploader via factory (allows test injection)
 	uploader, err := s3UploaderFactory(s3Config, job.Config.Services.Send.Auth, job.Config.TLS, logger)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to create S3 uploader: %w", err)
+		return StepResult{}, fmt.Errorf("failed to create S3 uploader: %w", err)
 	}
 
 	// Load or create upload manifest for retry resilience
@@ -619,21 +550,16 @@ func executeS3UploadSend(job *models.PipelineJob, jobDir string, step *models.Pi
 		// Get file size for logging
 		info, err := os.Stat(filePath)
 		if err != nil {
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-			recordStepError(step, err, models.ErrorTypeNonTransient)
 			_ = models.SaveManifest(manifest, manifestPath)
-			return fmt.Errorf("failed to stat file %s: %w", filepath.Base(filePath), err)
+			return StepResult{}, fmt.Errorf("failed to stat file %s: %w", filepath.Base(filePath), err)
 		}
 		fileSize := info.Size()
 
 		etag, err := uploader.UploadFile(ctx, filePath, s3Key)
 		if err != nil {
-			retryable := isSendErrorRetryable(err)
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, retryable)
-			recordStepError(step, err, classifySendError(err))
 			// Save manifest before returning so progress is not lost
 			_ = models.SaveManifest(manifest, manifestPath)
-			return fmt.Errorf("failed to upload %s to S3: %w", filepath.Base(filePath), err)
+			return StepResult{}, fmt.Errorf("failed to upload %s to S3: %w", filepath.Base(filePath), err)
 		}
 
 		manifest.AddUploadedFile(filePath, s3Key, etag, fileSize)
@@ -652,12 +578,7 @@ func executeS3UploadSend(job *models.PipelineJob, jobDir string, step *models.Pi
 	manifest.MarkCompleted()
 	_ = models.SaveManifest(manifest, manifestPath)
 
-	step.Status = models.StepStatusCompleted
-	step.FilesProcessed = filesUploaded
-	completedAt := time.Now()
-	step.CompletedAt = &completedAt
-
-	duration := completedAt.Sub(*step.StartedAt)
+	duration := time.Since(startTime)
 	fmt.Printf("\n✓ Uploaded %d files (%s) to s3://%s in %s\n",
 		filesUploaded, formatSize(totalBytes), uploader.GetBucket(), duration.Truncate(time.Second))
 
@@ -668,7 +589,7 @@ func executeS3UploadSend(job *models.PipelineJob, jobDir string, step *models.Pi
 		"duration", duration,
 		"job_id", job.JobID)
 
-	return nil
+	return StepResult{FilesProcessed: filesUploaded}, nil
 }
 
 // FormatSizeForTesting exposes formatSize for unit tests.
@@ -707,29 +628,8 @@ func (e *SendError) Error() string {
 	return fmt.Sprintf("send failed: HTTP %d: %s", e.StatusCode, e.Message)
 }
 
-func isSendErrorRetryable(err error) bool {
-	var sendErr *SendError
-	if errors.As(err, &sendErr) {
-		return sendErr.ErrorType == models.ErrorTypeTransient
-	}
-	var s3Err *services.S3Error
-	if errors.As(err, &s3Err) {
-		return s3Err.IsRetryable()
-	}
-	return lib.IsNetworkError(err)
-}
-
-func classifySendError(err error) models.ErrorType {
-	var sendErr *SendError
-	if errors.As(err, &sendErr) {
-		return sendErr.ErrorType
-	}
-	var s3Err *services.S3Error
-	if errors.As(err, &s3Err) {
-		return s3Err.ErrorType
-	}
-	if lib.IsNetworkError(err) {
-		return models.ErrorTypeTransient
-	}
-	return models.ErrorTypeNonTransient
+// IsRetryable lets SendError satisfy the retryableError seam so the shared
+// classifier handles it alongside FHIRError, S3Error, and the rest.
+func (e *SendError) IsRetryable() bool {
+	return e.ErrorType == models.ErrorTypeTransient
 }

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -1,0 +1,146 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// Step is the seam every pipeline step implements. Run performs only the
+// step-specific work; the shared lifecycle (enabled-check, status transition,
+// timing, error classification) lives once in runStep.
+type Step interface {
+	Name() models.StepName
+	Run(ctx *StepContext) (StepResult, error)
+}
+
+// StepContext carries everything Run needs. The Execute*Step wrappers and the
+// orchestration loop populate it; Run never constructs it.
+type StepContext struct {
+	Job    *models.PipelineJob
+	JobDir string // job root as passed by the caller, not derived from Config.JobsDir
+	Logger *lib.Logger
+
+	// HTTPClient is populated only by the import wrapper (whose signature takes
+	// one); other steps build their own client internally and ignore this.
+	HTTPClient   *services.HTTPClient
+	ShowProgress bool
+}
+
+// StepResult reports what a step produced, for the completion transition.
+type StepResult struct {
+	FilesProcessed int
+	BytesProcessed int64
+}
+
+// ErrPaused is returned by a Step.Run (currently only the wait step) to signal
+// that the pipeline should pause at StepStatusWaiting instead of completing or
+// failing the step.
+var ErrPaused = errors.New("pipeline paused at wait step")
+
+// stopError signals that a step finished its work successfully but the pipeline
+// must halt (e.g. validation found data-quality issues with fail_on_error). The
+// step is marked completed; the wrapped error propagates to stop the loop.
+type stopError struct {
+	result StepResult
+	err    error
+}
+
+func (e *stopError) Error() string { return e.err.Error() }
+func (e *stopError) Unwrap() error { return e.err }
+
+// stopAfterCompletion wraps err so runStep completes the step (recording result)
+// yet still returns err to halt the pipeline.
+func stopAfterCompletion(result StepResult, err error) error {
+	return &stopError{result: result, err: err}
+}
+
+// errorClassifier is the optional hook a Step implements when it needs a
+// classification rule other than the shared classifyServiceError (the import
+// step preserves its step-name-gated rule this way).
+type errorClassifier interface {
+	ClassifyError(error) models.ErrorType
+}
+
+// runStep is the single step lifecycle. It resolves nothing about the step's
+// work — that is Run's job — but owns every status transition, gating each one
+// through models.CanTransitionTo so an illegal transition fails loudly.
+func runStep(step Step, ctx *StepContext) error {
+	name := step.Name()
+
+	if !isStepEnabled(ctx.Job.Config, name) {
+		ctx.Logger.Info(string(name)+" step not enabled, skipping", "job_id", ctx.Job.JobID)
+		return nil
+	}
+
+	current := getOrCreateStep(ctx.Job, name)
+	if err := transitionStep(current, models.StepStatusInProgress); err != nil {
+		return err
+	}
+	// Preserve the original start time across re-entries (a resumed wait step, or
+	// each `pipeline continue` poll, would otherwise lose its first-arrival time).
+	firstStarted := current.StartedAt
+	*current = models.StartStep(*current)
+	if firstStarted != nil {
+		current.StartedAt = firstStarted
+	}
+	lib.LogStepStart(ctx.Logger, string(name), ctx.Job.JobID)
+
+	startTime := time.Now()
+	result, err := step.Run(ctx)
+
+	if errors.Is(err, ErrPaused) {
+		if terr := transitionStep(current, models.StepStatusWaiting); terr != nil {
+			return terr
+		}
+		current.Status = models.StepStatusWaiting
+		return ErrPaused
+	}
+
+	var stop *stopError
+	if errors.As(err, &stop) {
+		if terr := completeStep(current, name, ctx, stop.result, startTime); terr != nil {
+			return terr
+		}
+		return stop.err
+	}
+
+	if err != nil {
+		errType := classifyServiceError(err)
+		if c, ok := step.(errorClassifier); ok {
+			errType = c.ClassifyError(err)
+		}
+		lib.LogStepFailed(ctx.Logger, string(name), ctx.Job.JobID, err, errType == models.ErrorTypeTransient)
+		if terr := transitionStep(current, models.StepStatusFailed); terr != nil {
+			return terr
+		}
+		*current = models.FailStep(*current, errType, err.Error(), 0)
+		return err
+	}
+
+	return completeStep(current, name, ctx, result, startTime)
+}
+
+// completeStep applies the shared completion transition: gate to completed, record
+// the result, and log completion. Both the normal path and the stop-after-completion
+// path funnel through it.
+func completeStep(current *models.PipelineStep, name models.StepName, ctx *StepContext, result StepResult, startTime time.Time) error {
+	if terr := transitionStep(current, models.StepStatusCompleted); terr != nil {
+		return terr
+	}
+	*current = models.CompleteStep(*current, result.FilesProcessed, result.BytesProcessed)
+	lib.LogStepComplete(ctx.Logger, string(name), ctx.Job.JobID, result.FilesProcessed, time.Since(startTime))
+	return nil
+}
+
+// transitionStep rejects an illegal status change before it is applied.
+func transitionStep(step *models.PipelineStep, to models.StepStatus) error {
+	if !models.CanTransitionTo(step.Status, to) {
+		return fmt.Errorf("illegal transition for step %s: %s -> %s", step.Name, step.Status, to)
+	}
+	return nil
+}

--- a/internal/pipeline/step_test.go
+++ b/internal/pipeline/step_test.go
@@ -1,0 +1,183 @@
+package pipeline
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// fakeStep is a Step whose behavior is fully controlled by the test.
+type fakeStep struct {
+	name   models.StepName
+	result StepResult
+	err    error
+	calls  int
+}
+
+func (f *fakeStep) Name() models.StepName { return f.name }
+
+func (f *fakeStep) Run(_ *StepContext) (StepResult, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+// classifyingFakeStep additionally implements the optional ClassifyError hook.
+type classifyingFakeStep struct {
+	fakeStep
+	errType models.ErrorType
+}
+
+func (c *classifyingFakeStep) ClassifyError(error) models.ErrorType { return c.errType }
+
+func runStepTestJob(name models.StepName) *models.PipelineJob {
+	return &models.PipelineJob{
+		JobID:  "runstep-test",
+		Status: models.JobStatusInProgress,
+		Config: models.ProjectConfig{
+			Pipeline: models.PipelineConfig{EnabledSteps: []models.StepName{name}},
+		},
+		Steps: models.InitializeSteps([]models.StepName{name}),
+	}
+}
+
+func runStepTestContext(job *models.PipelineJob) *StepContext {
+	return &StepContext{Job: job, Logger: lib.NewLogger(lib.LogLevelError)}
+}
+
+func TestRunStep_HappyPathCompletes(t *testing.T) {
+	step := &fakeStep{name: models.StepDIMP, result: StepResult{FilesProcessed: 3, BytesProcessed: 42}}
+	job := runStepTestJob(models.StepDIMP)
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, step.calls)
+	s, ok := models.GetStepByName(*job, models.StepDIMP)
+	require.True(t, ok)
+	assert.Equal(t, models.StepStatusCompleted, s.Status)
+	assert.Equal(t, 3, s.FilesProcessed)
+	assert.Equal(t, int64(42), s.BytesProcessed)
+	require.NotNil(t, s.StartedAt)
+	require.NotNil(t, s.CompletedAt)
+}
+
+func TestRunStep_ErrorFails(t *testing.T) {
+	step := &fakeStep{name: models.StepDIMP, err: errors.New("boom")}
+	job := runStepTestJob(models.StepDIMP)
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.Error(t, err)
+	s, _ := models.GetStepByName(*job, models.StepDIMP)
+	assert.Equal(t, models.StepStatusFailed, s.Status)
+	require.NotNil(t, s.LastError)
+	assert.Contains(t, s.LastError.Message, "boom")
+}
+
+func TestRunStep_DisabledStepSkips(t *testing.T) {
+	step := &fakeStep{name: models.StepValidation}
+	job := runStepTestJob(models.StepDIMP) // validation is not enabled
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, step.calls)
+}
+
+func TestRunStep_IllegalTransitionRejected(t *testing.T) {
+	step := &fakeStep{name: models.StepDIMP}
+	job := runStepTestJob(models.StepDIMP)
+	// Pre-complete the step: completed is terminal, so entering in_progress is illegal.
+	completed, _ := models.GetStepByName(*job, models.StepDIMP)
+	*job = models.ReplaceStep(*job, models.CompleteStep(completed, 1, 1))
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transition")
+	assert.Equal(t, 0, step.calls) // Run never invoked
+}
+
+func TestRunStep_PausePropagatesAsWaiting(t *testing.T) {
+	step := &fakeStep{name: models.StepWait, err: ErrPaused}
+	job := runStepTestJob(models.StepWait)
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.ErrorIs(t, err, ErrPaused)
+	s, _ := models.GetStepByName(*job, models.StepWait)
+	assert.Equal(t, models.StepStatusWaiting, s.Status)
+}
+
+func TestRunStep_StopAfterCompletionCompletesButHalts(t *testing.T) {
+	sentinel := errors.New("data quality stop")
+	step := &fakeStep{
+		name: models.StepValidation,
+		err:  stopAfterCompletion(StepResult{FilesProcessed: 2}, sentinel),
+	}
+	job := runStepTestJob(models.StepValidation)
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+	s, _ := models.GetStepByName(*job, models.StepValidation)
+	assert.Equal(t, models.StepStatusCompleted, s.Status)
+	assert.Equal(t, 2, s.FilesProcessed)
+	require.NotNil(t, s.CompletedAt)
+}
+
+func TestRunStep_PreservesStartedAtOnReEntry(t *testing.T) {
+	// A wait step that paused once and is resumed (e.g. each `pipeline continue`
+	// poll) must keep its original StartedAt, not reset it to now on re-entry.
+	step := &fakeStep{name: models.StepWait, err: ErrPaused}
+	job := runStepTestJob(models.StepWait)
+	original := time.Now().Add(-time.Hour)
+	w, _ := models.GetStepByName(*job, models.StepWait)
+	w.Status = models.StepStatusWaiting
+	w.StartedAt = &original
+	*job = models.ReplaceStep(*job, w)
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.ErrorIs(t, err, ErrPaused)
+	s, _ := models.GetStepByName(*job, models.StepWait)
+	require.NotNil(t, s.StartedAt)
+	assert.Equal(t, original.Unix(), s.StartedAt.Unix(), "original pause time must be preserved")
+}
+
+func TestRunStep_LogsStepStart(t *testing.T) {
+	var buf bytes.Buffer
+	logger := lib.NewLoggerWithWriter(lib.LogLevelInfo, &buf)
+	step := &fakeStep{name: models.StepDIMP}
+	job := runStepTestJob(models.StepDIMP)
+
+	err := runStep(step, &StepContext{Job: job, Logger: logger})
+
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Step started")
+	assert.Contains(t, buf.String(), string(models.StepDIMP))
+}
+
+func TestRunStep_UsesClassifyErrorHook(t *testing.T) {
+	step := &classifyingFakeStep{
+		fakeStep: fakeStep{name: models.StepDIMP, err: errors.New("plain")},
+		errType:  models.ErrorTypeTransient,
+	}
+	job := runStepTestJob(models.StepDIMP)
+
+	err := runStep(step, runStepTestContext(job))
+
+	require.Error(t, err)
+	s, _ := models.GetStepByName(*job, models.StepDIMP)
+	require.NotNil(t, s.LastError)
+	// The default classifier would call a plain error non_transient; the hook overrides it.
+	assert.Equal(t, models.ErrorTypeTransient, s.LastError.Type)
+}

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -41,57 +41,49 @@ func ResetResourceValidatorFactory() {
 	resourceValidatorFactory = defaultResourceValidatorFactory
 }
 
-// ExecuteValidationStep validates FHIR resources against a FHIR validation service.
-// Reads from the previous data-producing step's output directory.
-// Writes per-file OperationOutcome reports for all validated chunks to jobs/<job-id>/validation/.
-// Fails the step if any chunk has error-level or fatal-level issues.
+// validationStep validates FHIR resources against a FHIR validation service.
+// Reads from the previous data-producing step's output directory. Writes per-file
+// OperationOutcome reports for all validated chunks to jobs/<job-id>/validation/.
+// With fail_on_error enabled, error-level issues complete the step yet halt the pipeline.
+type validationStep struct{}
+
+func (validationStep) Name() models.StepName { return models.StepValidation }
+
+// ExecuteValidationStep runs the validation step through the shared lifecycle. It
+// is the exported single-step entrypoint used by the black-box tests; it has no
+// production caller yet (the cmd manual path reports validation as not-yet-wired).
+// To be folded into one exported pipeline.RunStep — see issue #516.
 func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	return runStep(validationStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+}
+
+func (validationStep) Run(ctx *StepContext) (StepResult, error) {
+	job := ctx.Job
+	logger := ctx.Logger
 	stepName := models.StepValidation
 
-	if !isStepEnabled(job.Config, stepName) {
-		logger.Info("Validation step not enabled, skipping", "job_id", job.JobID)
-		return nil
-	}
-
-	logger.Debug("Validation step starting", "job_id", job.JobID)
-
-	step := getOrCreateStep(job, stepName)
-	step.Status = models.StepStatusInProgress
-	now := time.Now()
-	step.StartedAt = &now
-
 	if job.Config.Services.Validation.URL == "" {
-		err := fmt.Errorf("validation service URL not configured")
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("validation service URL not configured")
 	}
 
 	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 	validationClient := resourceValidatorFactory(job.Config.Services.Validation.URL, httpClient, logger)
 
-	layout := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps)
+	layout := services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), job.Config.Pipeline.EnabledSteps)
 	inputDir := layout.InputDir(stepName)
 	outputDir := layout.OutputDir(stepName)
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to create output directory: %w", err)
+		return StepResult{}, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	files, err := findFHIRFiles(inputDir)
 	if err != nil {
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return fmt.Errorf("failed to list input files: %w", err)
+		return StepResult{}, fmt.Errorf("failed to list input files: %w", err)
 	}
 
 	if len(files) == 0 {
-		err := fmt.Errorf("no FHIR NDJSON files found in %s", inputDir)
-		lib.LogStepFailed(logger, string(stepName), job.JobID, err, false)
-		recordStepError(step, err, models.ErrorTypeNonTransient)
-		return err
+		return StepResult{}, fmt.Errorf("no FHIR NDJSON files found in %s", inputDir)
 	}
 
 	fmt.Printf("Validating %d FHIR file(s)...\n\n", len(files))
@@ -116,7 +108,6 @@ func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.L
 
 	var totalChunksWithErrors int
 	totalResourcesValidated := 0
-	filesProcessed := 0
 
 	for _, inputFile := range files {
 		baseName := lib.GetUncompressedFilename(filepath.Base(inputFile))
@@ -130,7 +121,6 @@ func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.L
 				"filename", baseName,
 				"report_file", reportFile,
 				"job_id", job.JobID)
-			filesProcessed++
 			continue
 		}
 
@@ -140,9 +130,7 @@ func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.L
 				"filename", baseName,
 				"error", err,
 				"job_id", job.JobID)
-			lib.LogStepFailed(logger, string(stepName), job.JobID, err, isServiceErrorRetryable(err))
-			recordStepError(step, err, classifyServiceError(err))
-			return fmt.Errorf("failed to validate %s: %w", baseName, err)
+			return StepResult{}, fmt.Errorf("failed to validate %s: %w", baseName, err)
 		}
 
 		if chunksWithErrors > 0 {
@@ -153,39 +141,31 @@ func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.L
 
 		totalResourcesValidated += resourceCount
 		totalChunksWithErrors += chunksWithErrors
-		filesProcessed++
 	}
 
-	step.Status = models.StepStatusCompleted
-	step.FilesProcessed = len(files)
-	completedAt := time.Now()
-	step.CompletedAt = &completedAt
-
-	duration := completedAt.Sub(*step.StartedAt)
+	result := StepResult{FilesProcessed: len(files)}
 
 	if totalChunksWithErrors > 0 {
 		logger.Warn("Validation completed with errors in data",
 			"chunks_with_errors", totalChunksWithErrors,
 			"files_processed", len(files),
 			"resources_validated", totalResourcesValidated,
-			"duration", duration,
 			"job_id", job.JobID,
 		)
 		fmt.Printf("\n⚠ Validation completed: found errors in %d chunk(s) across %d file(s). See reports in validation/ directory.\n", totalChunksWithErrors, len(files))
 
 		if job.Config.Services.Validation.FailOnError != nil && *job.Config.Services.Validation.FailOnError {
-			return fmt.Errorf("validation found errors in %d chunk(s) across %d file(s) — stopping pipeline (fail_on_error is enabled)", totalChunksWithErrors, len(files))
+			return StepResult{}, stopAfterCompletion(result, fmt.Errorf("validation found errors in %d chunk(s) across %d file(s) — stopping pipeline (fail_on_error is enabled)", totalChunksWithErrors, len(files)))
 		}
 	} else {
 		logger.Debug("Validation step completed",
 			"files_processed", len(files),
 			"resources_validated", totalResourcesValidated,
-			"duration", duration,
 			"job_id", job.JobID,
 		)
 	}
 
-	return nil
+	return result, nil
 }
 
 // chunkValidationResult holds the result of validating a single Bundle chunk

--- a/internal/pipeline/wait.go
+++ b/internal/pipeline/wait.go
@@ -3,10 +3,50 @@ package pipeline
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
+
+// waitStep pauses the pipeline for manual data inspection. Its Run is idempotent:
+// it ensures the wait directory exists, then pauses while empty and completes
+// once the user has placed files there — so first-arrival and resume are the
+// same code path.
+type waitStep struct{}
+
+func (waitStep) Name() models.StepName { return models.StepWait }
+
+func (waitStep) Run(ctx *StepContext) (StepResult, error) {
+	idx, err := GetCurrentWaitStepIndex(ctx.Job)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	jobsBaseDir := filepath.Dir(ctx.JobDir)
+	if err := ExecuteWaitStep(ctx.Job, jobsBaseDir, idx); err != nil {
+		return StepResult{}, err
+	}
+
+	waitDir, err := services.NewJobLayout(jobsBaseDir, ctx.Job.JobID, ctx.Job.Config.Pipeline.EnabledSteps).WaitDir(idx)
+	if err != nil {
+		return StepResult{}, fmt.Errorf("failed to find previous step: %w", err)
+	}
+
+	count, err := CountFilesInDir(waitDir)
+	if err != nil {
+		return StepResult{}, err
+	}
+	if count == 0 {
+		fmt.Printf("\n⏸ Pipeline paused at wait step\n")
+		fmt.Printf("  Wait directory: %s\n", waitDir)
+		fmt.Printf("  The directory is EMPTY - place your modified data there\n")
+		fmt.Printf("\n  To continue: aether pipeline continue <config> %s\n", ctx.Job.JobID)
+		return StepResult{}, ErrPaused
+	}
+	fmt.Printf("  Found %d file(s) in wait directory\n", count)
+	return StepResult{FilesProcessed: count}, nil
+}
 
 // FileOps interface for file operations, allowing mocking in tests
 type FileOps interface {

--- a/internal/pipeline/wait_step_run_test.go
+++ b/internal/pipeline/wait_step_run_test.go
@@ -1,0 +1,84 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// waitRunTestJob builds a job with a [local_import, wait] pipeline whose wait
+// step starts in the given status, plus its job dir. The import step is marked
+// completed so WaitDir resolves against import/.
+func waitRunTestJob(t *testing.T, waitStatus models.StepStatus) (*models.PipelineJob, string) {
+	t.Helper()
+	jobsBaseDir := t.TempDir()
+	jobID := "wait-run-test"
+	jobDir := filepath.Join(jobsBaseDir, jobID)
+
+	steps := []models.StepName{models.StepLocalImport, models.StepWait}
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(models.StepWait),
+		Steps:       models.InitializeSteps(steps),
+		Config: models.ProjectConfig{
+			JobsDir:  jobsBaseDir,
+			Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		},
+	}
+	imp, _ := models.GetStepByName(*job, models.StepLocalImport)
+	*job = models.ReplaceStep(*job, models.CompleteStep(imp, 1, 1))
+	wait, _ := models.GetStepByName(*job, models.StepWait)
+	wait.Status = waitStatus
+	*job = models.ReplaceStep(*job, wait)
+	return job, jobDir
+}
+
+func waitRunContext(job *models.PipelineJob, jobDir string) *StepContext {
+	return &StepContext{Job: job, JobDir: jobDir, Logger: lib.NewLogger(lib.LogLevelError)}
+}
+
+func TestWaitStepRun_FirstArrivalPausesAndCreatesDir(t *testing.T) {
+	job, jobDir := waitRunTestJob(t, models.StepStatusPending)
+
+	err := runStep(waitStep{}, waitRunContext(job, jobDir))
+
+	require.ErrorIs(t, err, ErrPaused)
+	s, _ := models.GetStepByName(*job, models.StepWait)
+	assert.Equal(t, models.StepStatusWaiting, s.Status)
+	// import_wait directory created, empty
+	info, statErr := os.Stat(filepath.Join(jobDir, "import_wait"))
+	require.NoError(t, statErr)
+	assert.True(t, info.IsDir())
+}
+
+func TestWaitStepRun_ResumeWithFilesCompletes(t *testing.T) {
+	job, jobDir := waitRunTestJob(t, models.StepStatusWaiting)
+	waitDir := filepath.Join(jobDir, "import_wait")
+	require.NoError(t, os.MkdirAll(waitDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(waitDir, "edited.ndjson"), []byte("{}\n"), 0644))
+
+	err := runStep(waitStep{}, waitRunContext(job, jobDir))
+
+	require.NoError(t, err)
+	s, _ := models.GetStepByName(*job, models.StepWait)
+	assert.Equal(t, models.StepStatusCompleted, s.Status)
+	assert.Equal(t, 1, s.FilesProcessed)
+}
+
+func TestWaitStepRun_ResumeStillEmptyPausesAgain(t *testing.T) {
+	job, jobDir := waitRunTestJob(t, models.StepStatusWaiting)
+	require.NoError(t, os.MkdirAll(filepath.Join(jobDir, "import_wait"), 0755))
+
+	err := runStep(waitStep{}, waitRunContext(job, jobDir))
+
+	require.ErrorIs(t, err, ErrPaused)
+	s, _ := models.GetStepByName(*job, models.StepWait)
+	assert.Equal(t, models.StepStatusWaiting, s.Status)
+}

--- a/tests/unit/models/transitions_test.go
+++ b/tests/unit/models/transitions_test.go
@@ -1,0 +1,51 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+func TestCanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name string
+		from models.StepStatus
+		to   models.StepStatus
+		want bool
+	}{
+		// pending may only begin
+		{"pending to in_progress", models.StepStatusPending, models.StepStatusInProgress, true},
+		{"pending to completed", models.StepStatusPending, models.StepStatusCompleted, false},
+		{"pending to failed", models.StepStatusPending, models.StepStatusFailed, false},
+		{"pending to waiting", models.StepStatusPending, models.StepStatusWaiting, false},
+
+		// in_progress may complete, fail, pause, or re-enter (crash resume)
+		{"in_progress to completed", models.StepStatusInProgress, models.StepStatusCompleted, true},
+		{"in_progress to failed", models.StepStatusInProgress, models.StepStatusFailed, true},
+		{"in_progress to waiting", models.StepStatusInProgress, models.StepStatusWaiting, true},
+		{"in_progress to in_progress", models.StepStatusInProgress, models.StepStatusInProgress, true},
+		{"in_progress to pending", models.StepStatusInProgress, models.StepStatusPending, false},
+
+		// failed may only retry
+		{"failed to in_progress", models.StepStatusFailed, models.StepStatusInProgress, true},
+		{"failed to completed", models.StepStatusFailed, models.StepStatusCompleted, false},
+		{"failed to failed", models.StepStatusFailed, models.StepStatusFailed, false},
+
+		// waiting may resume or complete
+		{"waiting to in_progress", models.StepStatusWaiting, models.StepStatusInProgress, true},
+		{"waiting to completed", models.StepStatusWaiting, models.StepStatusCompleted, true},
+		{"waiting to failed", models.StepStatusWaiting, models.StepStatusFailed, false},
+
+		// completed is terminal for a step
+		{"completed to in_progress", models.StepStatusCompleted, models.StepStatusInProgress, false},
+		{"completed to completed", models.StepStatusCompleted, models.StepStatusCompleted, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, models.CanTransitionTo(tt.from, tt.to))
+		})
+	}
+}

--- a/tests/unit/pipeline_error_paths_test.go
+++ b/tests/unit/pipeline_error_paths_test.go
@@ -1,0 +1,64 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+)
+
+// TestExecuteValidationStep_OutputDirCreationError covers the mkdir failure
+// branch: a regular file sits where the validation output directory must go.
+func TestExecuteValidationStep_OutputDirCreationError(t *testing.T) {
+	tempDir := t.TempDir()
+	jobDir := filepath.Join(tempDir, "jobs", "test-validation-job")
+	require.NoError(t, os.MkdirAll(jobDir, 0755))
+
+	// Block output-dir creation with a file where the directory should be.
+	require.NoError(t, os.WriteFile(filepath.Join(jobDir, "validation"), []byte("x"), 0644))
+
+	job := createValidationTestJob("http://localhost:9999")
+	err := pipeline.ExecuteValidationStep(job, jobDir, lib.NewLogger(lib.LogLevelError))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create output directory")
+}
+
+// TestExecuteValidationStep_ListInputFilesError covers the findFHIRFiles error
+// branch: an unbalanced '[' in the path makes the glob pattern invalid.
+func TestExecuteValidationStep_ListInputFilesError(t *testing.T) {
+	baseDir := t.TempDir()
+	jobDir := filepath.Join(baseDir, "test[invalid")
+	require.NoError(t, os.MkdirAll(jobDir, 0755))
+
+	job := createValidationTestJob("http://localhost:9999")
+	err := pipeline.ExecuteValidationStep(job, jobDir, lib.NewLogger(lib.LogLevelError))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list input files")
+}
+
+// TestExecuteFlatteningStep_ListInputFilesError covers the findFHIRFiles error
+// branch: config, CRTDL and lookup tables all validate, but an unbalanced '[' in
+// the job path makes the input-file glob pattern invalid.
+func TestExecuteFlatteningStep_ListInputFilesError(t *testing.T) {
+	baseDir := t.TempDir()
+	jobDir := filepath.Join(baseDir, "test[invalid")
+	require.NoError(t, os.MkdirAll(jobDir, 0755))
+
+	lookupPath := filepath.Join(baseDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, "https://example.com/Patient", "Patient")
+	crtdlPath := filepath.Join(baseDir, "crtdl.json")
+	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
+
+	job := createFlatteningTestJob("http://localhost:9999", lookupPath, crtdlPath)
+	err := pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list input files")
+}

--- a/tests/unit/pipeline_job_test.go
+++ b/tests/unit/pipeline_job_test.go
@@ -232,6 +232,26 @@ func TestAdvanceToNextStep_NoMoreSteps(t *testing.T) {
 	assert.Equal(t, "", updatedJob.CurrentStep, "Current step should be empty")
 }
 
+// TestAdvanceToNextStep_MultipleWaitSteps guards against advancing toward a
+// second, non-consecutive wait step. Steps are tracked by name, so the lookup
+// resolves the first (already completed) wait step; advancing must still not
+// hard-fail for this documented-supported configuration.
+func TestAdvanceToNextStep_MultipleWaitSteps(t *testing.T) {
+	steps := []models.StepName{models.StepLocalImport, models.StepWait, models.StepDIMP, models.StepWait}
+	job := createJobForPipelineTests(steps)
+	job.CurrentStep = string(models.StepDIMP)
+
+	for _, name := range []models.StepName{models.StepLocalImport, models.StepDIMP} {
+		s, _ := models.GetStepByName(job, name)
+		job = models.ReplaceStep(job, models.CompleteStep(s, 1, 1))
+	}
+	firstWait, _ := models.GetStepByName(job, models.StepWait)
+	job = models.ReplaceStep(job, models.CompleteStep(firstWait, 1, 1))
+
+	_, err := pipeline.AdvanceToNextStep(&job)
+	require.NoError(t, err)
+}
+
 // TestStartJob_EmptySteps tests StartJob when there are no steps
 func TestStartJob_EmptySteps(t *testing.T) {
 	job := models.PipelineJob{

--- a/tests/unit/pipeline_seam_test.go
+++ b/tests/unit/pipeline_seam_test.go
@@ -1,0 +1,300 @@
+package unit
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// seamFakeStep is a pipeline.Step whose behavior is fully controlled by the test.
+// It lets the orchestration loop and runStep lifecycle be exercised through the
+// public Step seam, with no real services.
+type seamFakeStep struct {
+	name   models.StepName
+	result pipeline.StepResult
+	err    error
+	calls  int
+}
+
+func (f *seamFakeStep) Name() models.StepName { return f.name }
+
+func (f *seamFakeStep) Run(_ *pipeline.StepContext) (pipeline.StepResult, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+// seamClassifyingStep additionally implements the optional ClassifyError hook so
+// runStep's classifier override branch is exercised.
+type seamClassifyingStep struct {
+	seamFakeStep
+	errType models.ErrorType
+}
+
+func (c *seamClassifyingStep) ClassifyError(error) models.ErrorType { return c.errType }
+
+// seamLoopJob builds a persisted [local_import, dimp] job positioned at its first
+// step and registers the given fake steps for the duration of the test.
+func seamLoopJob(t *testing.T, fakes map[models.StepName]pipeline.Step) *models.PipelineJob {
+	t.Helper()
+	return seamJobWithSteps(t, []models.StepName{models.StepLocalImport, models.StepDIMP}, fakes)
+}
+
+// seamJobWithSteps builds a persisted job over the given enabled steps, positioned
+// at the first, and registers the given fake steps for the duration of the test.
+func seamJobWithSteps(t *testing.T, steps []models.StepName, fakes map[models.StepName]pipeline.Step) *models.PipelineJob {
+	t.Helper()
+	jobsDir := t.TempDir()
+	jobID := "550e8400-e29b-41d4-a716-446655440000"
+	require.NoError(t, os.MkdirAll(filepath.Join(jobsDir, jobID), 0755))
+
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		InputSource: "/tmp/x",
+		InputType:   models.InputTypeLocal,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(steps[0]),
+		Steps:       models.InitializeSteps(steps),
+		Config: models.ProjectConfig{
+			JobsDir:  jobsDir,
+			Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		},
+	}
+
+	pipeline.SetStepRegistryForTesting(func(n models.StepName) (pipeline.Step, bool) {
+		s, ok := fakes[n]
+		return s, ok
+	})
+	t.Cleanup(pipeline.ResetStepRegistry)
+	return job
+}
+
+func seamLogger() *lib.Logger { return lib.NewLogger(lib.LogLevelError) }
+
+func TestRunLoop_CompletesAllSteps(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport, result: pipeline.StepResult{FilesProcessed: 1}}
+	dimp := &seamFakeStep{name: models.StepDIMP, result: pipeline.StepResult{FilesProcessed: 2}}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.JobStatusCompleted, final.Status)
+	assert.Equal(t, "", final.CurrentStep)
+	assert.Equal(t, 1, imp.calls)
+	assert.Equal(t, 1, dimp.calls)
+}
+
+func TestRunLoop_StepFailureFailsJob(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport, err: errors.New("import boom")}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Equal(t, models.JobStatusFailed, final.Status)
+	assert.Equal(t, 0, dimp.calls, "dimp must not run after import fails")
+}
+
+func TestRunLoop_PauseStopsWithoutFailing(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport, err: pipeline.ErrPaused}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.ErrorIs(t, err, pipeline.ErrPaused)
+	assert.Equal(t, models.JobStatusInProgress, final.Status, "pause must not fail the job")
+	s, _ := models.GetStepByName(*final, models.StepLocalImport)
+	assert.Equal(t, models.StepStatusWaiting, s.Status)
+	assert.Equal(t, 0, dimp.calls)
+}
+
+func TestRunLoop_UnknownStepErrors(t *testing.T) {
+	// Registry resolves nothing, so the current step is unknown.
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{})
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown step")
+	assert.Equal(t, models.JobStatusInProgress, final.Status)
+}
+
+func TestRunLoop_UsesClassifyErrorHook(t *testing.T) {
+	imp := &seamClassifyingStep{
+		seamFakeStep: seamFakeStep{name: models.StepLocalImport, err: errors.New("plain")},
+		errType:      models.ErrorTypeTransient,
+	}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Equal(t, models.JobStatusFailed, final.Status)
+	s, _ := models.GetStepByName(*final, models.StepLocalImport)
+	require.NotNil(t, s.LastError)
+	// The default classifier calls a plain error non-transient; the hook overrides it.
+	assert.Equal(t, models.ErrorTypeTransient, s.LastError.Type)
+}
+
+func TestRunLoop_IllegalTransitionSurfacesError(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+	// Pre-complete the current step: completed is terminal, so entering
+	// in_progress is illegal and runStep must reject it before invoking Run.
+	cur, _ := models.GetStepByName(*job, models.StepLocalImport)
+	*job = models.ReplaceStep(*job, models.CompleteStep(cur, 1, 1))
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transition")
+	assert.Equal(t, models.JobStatusFailed, final.Status)
+	assert.Equal(t, 0, imp.calls, "Run must not be invoked when the transition is illegal")
+}
+
+// failSaveOnNth injects a StateFileOpsProvider that lets the first n-1 job saves
+// succeed and fails the nth, so a specific UpdateJob call in RunLoop can be driven
+// to error. The provider is restored on test cleanup.
+func failSaveOnNth(t *testing.T, n int) {
+	t.Helper()
+	original := services.StateFileOpsProvider
+	t.Cleanup(func() { services.StateFileOpsProvider = original })
+	services.StateFileOpsProvider = &countingStateFileOps{
+		failOnNth: n,
+		failErr:   errors.New("simulated write failure"),
+	}
+}
+
+func TestRunLoop_FailedJobSaveErrorIsLogged(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport, err: errors.New("boom")}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+	failSaveOnNth(t, 1) // the failed-job save is the first save attempt
+
+	final, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom", "the original step error still propagates")
+	assert.Equal(t, models.JobStatusFailed, final.Status, "job is failed even if saving that state fails")
+}
+
+func TestRunLoop_PostStepSaveErrorSurfaces(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+	failSaveOnNth(t, 1) // the post-step save is the first save attempt
+
+	_, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save job state")
+}
+
+func TestRunLoop_CompletionSaveErrorSurfaces(t *testing.T) {
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamJobWithSteps(t, []models.StepName{models.StepDIMP},
+		map[models.StepName]pipeline.Step{models.StepDIMP: dimp})
+	failSaveOnNth(t, 2) // post-step save succeeds; the completion save (2nd) fails
+
+	_, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save job state")
+}
+
+func TestRunLoop_PostAdvanceSaveErrorSurfaces(t *testing.T) {
+	imp := &seamFakeStep{name: models.StepLocalImport}
+	dimp := &seamFakeStep{name: models.StepDIMP}
+	job := seamLoopJob(t, map[models.StepName]pipeline.Step{
+		models.StepLocalImport: imp,
+		models.StepDIMP:        dimp,
+	})
+	failSaveOnNth(t, 2) // post-step save succeeds; the post-advance save (2nd) fails
+
+	_, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save job state")
+}
+
+func TestRunLoop_AdvanceErrorSurfaces(t *testing.T) {
+	// A pipeline with no import step: the first step completes, but advancing to
+	// send fails its "import" prerequisite, and RunLoop surfaces that error.
+	first := &seamFakeStep{name: models.StepDIMP}
+	send := &seamFakeStep{name: models.StepSend}
+	job := seamJobWithSteps(t, []models.StepName{models.StepDIMP, models.StepSend},
+		map[models.StepName]pipeline.Step{models.StepDIMP: first, models.StepSend: send})
+
+	_, err := pipeline.RunLoop(job, seamLogger(), pipeline.RunOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to advance to next step")
+	assert.Equal(t, 0, send.calls, "send must not run when the advance fails")
+}
+
+func TestStepFor_ResolvesEveryDefaultStep(t *testing.T) {
+	// Override then reset to exercise both SetStepRegistryForTesting and ResetStepRegistry.
+	pipeline.SetStepRegistryForTesting(func(models.StepName) (pipeline.Step, bool) { return nil, false })
+	pipeline.ResetStepRegistry()
+
+	names := []models.StepName{
+		models.StepTorchImport, models.StepLocalImport, models.StepHttpImport,
+		models.StepDIMP, models.StepValidation, models.StepFlattening,
+		models.StepSend, models.StepWait,
+	}
+	for _, n := range names {
+		s, ok := pipeline.StepFor(n)
+		require.True(t, ok, "expected registry entry for %s", n)
+		assert.Equal(t, n, s.Name(), "registered step should report its own name")
+	}
+}
+
+func TestStepFor_UnknownStep(t *testing.T) {
+	pipeline.ResetStepRegistry()
+	_, ok := pipeline.StepFor(models.StepName("bogus"))
+	assert.False(t, ok)
+}
+
+func TestStepFor_OverrideForTesting(t *testing.T) {
+	fake := &seamFakeStep{name: models.StepDIMP}
+	pipeline.SetStepRegistryForTesting(func(models.StepName) (pipeline.Step, bool) { return fake, true })
+	defer pipeline.ResetStepRegistry()
+
+	s, ok := pipeline.StepFor(models.StepDIMP)
+	require.True(t, ok)
+	assert.Same(t, fake, s)
+}

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -2079,6 +2079,42 @@ func TestExecuteSendStep_FHIR_FileOpenError(t *testing.T) {
 	assert.Equal(t, models.ErrorTypeNonTransient, sendStep.LastError.Type)
 }
 
+func TestExecuteSendStep_FHIR_RetryableServerErrorClassifiedTransient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // 503 - retryable
+		_, _ = w.Write([]byte(`{"issue":"service unavailable"}`))
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	jobID := "test-fhir-retryable-error"
+	jobDir := filepath.Join(tmpDir, jobID)
+	inputDir := filepath.Join(jobDir, "dimp")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "Patient.ndjson"),
+		[]byte(`{"resourceType":"Patient","id":"1"}`+"\n"), 0644))
+
+	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
+	// Keep retries fast; the FHIRError surfaces wrapped once retries are exhausted.
+	job.Config.Retry = models.RetryConfig{MaxAttempts: 2, InitialBackoffMs: 1, MaxBackoffMs: 5}
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	require.Error(t, err)
+
+	var sendStep *models.PipelineStep
+	for i := range job.Steps {
+		if job.Steps[i].Name == models.StepSend {
+			sendStep = &job.Steps[i]
+			break
+		}
+	}
+	require.NotNil(t, sendStep)
+	require.NotNil(t, sendStep.LastError)
+	// A wrapped, transient FHIR server error must be classified transient.
+	assert.Equal(t, models.ErrorTypeTransient, sendStep.LastError.Type)
+}
+
 func TestExecuteSendStep_FHIR_CloseWarning(t *testing.T) {
 	// This test verifies the close error handling path (line 260-262)
 	// by ensuring the upload completes even if close has warnings

--- a/tests/unit/pipeline_wait_run_test.go
+++ b/tests/unit/pipeline_wait_run_test.go
@@ -1,0 +1,133 @@
+package unit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+)
+
+// waitRunJob builds a [local_import, wait] job whose wait step starts in the
+// given status, plus its job dir. The import step is marked completed so
+// WaitDir resolves against import/.
+func waitRunJob(t *testing.T, waitStatus models.StepStatus) (*models.PipelineJob, string) {
+	t.Helper()
+	jobsBaseDir := t.TempDir()
+	jobID := "wait-run-ext-test"
+	jobDir := filepath.Join(jobsBaseDir, jobID)
+
+	steps := []models.StepName{models.StepLocalImport, models.StepWait}
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		Status:      models.JobStatusInProgress,
+		CurrentStep: string(models.StepWait),
+		Steps:       models.InitializeSteps(steps),
+		Config: models.ProjectConfig{
+			JobsDir:  jobsBaseDir,
+			Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		},
+	}
+	imp, _ := models.GetStepByName(*job, models.StepLocalImport)
+	*job = models.ReplaceStep(*job, models.CompleteStep(imp, 1, 1))
+	wait, _ := models.GetStepByName(*job, models.StepWait)
+	wait.Status = waitStatus
+	*job = models.ReplaceStep(*job, wait)
+	return job, jobDir
+}
+
+func waitRunContext(job *models.PipelineJob, jobDir string) *pipeline.StepContext {
+	return &pipeline.StepContext{Job: job, JobDir: jobDir, Logger: lib.NewLogger(lib.LogLevelError)}
+}
+
+// waitStepFromRegistry returns the real wait Step through the public seam.
+func waitStepFromRegistry(t *testing.T) pipeline.Step {
+	t.Helper()
+	pipeline.ResetStepRegistry()
+	step, ok := pipeline.StepFor(models.StepWait)
+	require.True(t, ok)
+	return step
+}
+
+func TestWaitStepRun_ReportsName(t *testing.T) {
+	assert.Equal(t, models.StepWait, waitStepFromRegistry(t).Name())
+}
+
+func TestWaitStepRun_FirstArrivalPausesAndCreatesDir(t *testing.T) {
+	job, jobDir := waitRunJob(t, models.StepStatusInProgress)
+
+	_, err := waitStepFromRegistry(t).Run(waitRunContext(job, jobDir))
+
+	require.ErrorIs(t, err, pipeline.ErrPaused)
+	info, statErr := os.Stat(filepath.Join(jobDir, "import_wait"))
+	require.NoError(t, statErr)
+	assert.True(t, info.IsDir(), "wait directory must be created")
+}
+
+func TestWaitStepRun_ResumeWithFilesCompletes(t *testing.T) {
+	job, jobDir := waitRunJob(t, models.StepStatusInProgress)
+	waitDir := filepath.Join(jobDir, "import_wait")
+	require.NoError(t, os.MkdirAll(waitDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(waitDir, "edited.ndjson"), []byte("{}\n"), 0644))
+
+	result, err := waitStepFromRegistry(t).Run(waitRunContext(job, jobDir))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FilesProcessed)
+}
+
+func TestWaitStepRun_ResumeStillEmptyPausesAgain(t *testing.T) {
+	job, jobDir := waitRunJob(t, models.StepStatusInProgress)
+	require.NoError(t, os.MkdirAll(filepath.Join(jobDir, "import_wait"), 0755))
+
+	_, err := waitStepFromRegistry(t).Run(waitRunContext(job, jobDir))
+
+	require.ErrorIs(t, err, pipeline.ErrPaused)
+}
+
+func TestWaitStepRun_NoWaitInProgressErrors(t *testing.T) {
+	// Wait step is pending, not in progress: GetCurrentWaitStepIndex fails.
+	job, jobDir := waitRunJob(t, models.StepStatusPending)
+
+	_, err := waitStepFromRegistry(t).Run(waitRunContext(job, jobDir))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no wait step currently in progress")
+}
+
+func TestWaitStepRun_CreateDirErrorSurfaces(t *testing.T) {
+	job, jobDir := waitRunJob(t, models.StepStatusInProgress)
+
+	original := pipeline.FileOpsProvider
+	pipeline.FileOpsProvider = &mockFileOps{
+		mkdirFunc: func(string, os.FileMode) error { return os.ErrPermission },
+	}
+	defer func() { pipeline.FileOpsProvider = original }()
+
+	_, err := waitStepFromRegistry(t).Run(waitRunContext(job, jobDir))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create wait directory")
+}
+
+func TestWaitStepRun_CountFilesErrorSurfaces(t *testing.T) {
+	job, jobDir := waitRunJob(t, models.StepStatusInProgress)
+
+	original := pipeline.FileOpsProvider
+	pipeline.FileOpsProvider = &mockFileOps{
+		// MkdirAll succeeds (nil func -> real os.MkdirAll), but reading the wait
+		// directory fails with a non-NotExist error.
+		readDirFunc: func(string) ([]os.DirEntry, error) { return nil, os.ErrPermission },
+	}
+	defer func() { pipeline.FileOpsProvider = original }()
+
+	_, err := waitStepFromRegistry(t).Run(waitRunContext(job, jobDir))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrPermission)
+}


### PR DESCRIPTION
## Summary

Unifies all pipeline steps behind a single `Step` seam so the per-step lifecycle (timing, status transitions, error classification, directory resolution, persistence) is defined **once** instead of re-implemented per step.

- **One `Step` interface + `runStep` lifecycle** (`internal/pipeline/step.go`): every `Execute*Step` is now a thin shim over `runStep`, which owns the enabled-check, gated status transitions, timing and error classification. The exported `Execute*Step` signatures are preserved, so all existing unit/integration tests run unchanged.
- **Registry replaces the dispatch switch** (`registry.go`): `executeStep`'s `switch` collapses to a `map[StepName]Step` lookup.
- **One orchestration loop** (`orchestrate.go` `RunLoop`): the byte-for-byte-duplicated `start`/`continue` loops and the 80-line wait-resume branch merge into a single loop, now unit-testable with a fake step + fake clients (no real services).
- **Transition-time enforcement** (`models.CanTransitionTo`): illegal step-status transitions are rejected inside `runStep`, not only at save (the complement to #425).
- **One error classifier**: the four forked classifiers collapse into the shared `classifyServiceError`; import keeps its step-name-gated rule via an optional `ClassifyError` hook. This incidentally fixes a real bug — the FHIR send path used a raw type assertion that failed to unwrap `%w`-wrapped `FHIRError`s, misclassifying transient 5xx failures as non-transient.
- **Idempotent wait step** (`waitStep.Run`): first-arrival and resume both funnel through a file-count check, replacing the special-cased handling that lived in `cmd`.

Consumes the merged layout resolver (#424) and client seams (#426).

## Review fixes (folded into this PR)

Addressing review feedback on the seam. Each is TDD (failing test first):

- **Re-running a completed step no longer hard-fails** — the new transition gate made `aether job run --step <X>` on an already-completed step fail with `illegal transition: completed -> in_progress` (and the failure was invisible in saved job state). The manual path (`executeStepManually`) now resets a completed target step to `pending` before re-running, restoring pre-refactor behavior; the gate stays strict for the automatic `RunLoop`, which never re-enters a completed step. Regression test added.
- **Wait step keeps its original pause time** — every `pipeline continue` poll on a still-empty wait dir reset `StartedAt`. `runStep` now preserves the first-arrival `StartedAt` across re-entries. Test added.
- **`LogStepStart` is called again** — it had become dead code, dropping the start log line for import steps. `runStep` now emits it for every step. Test added.
- **De-duplicated the completion block** in `runStep` (shared `completeStep` helper) and removed the duplicate `orchestrate_test.go` (the black-box seam tests are a strict superset).
- **Documented the exported single-step entrypoints** (`ExecuteSend/Flattening/ValidationStep`, `StepFor`): they have no production caller but are the exported seam the black-box test suite drives — clarified in-code to correct the "dead code" read.

## Out of scope / follow-ups

Deferred to keep this PR behavior-preserving; each filed as an issue:

- **#513** — explicit re-run gate + `--force` flag for `job run --step` on completed steps (the safer long-term semantics; this PR only restores the old permissive behavior).
- **#514** — centralize the job layout on `StepContext` (steps currently rebuild it from `filepath.Dir/Base(ctx.JobDir)`).
- **#515** — import step / input-type parity guard on the `RunLoop`/`continue` resume path (a behavior change guarding a case that can't occur there today).
- **#516** — unify the per-step `Execute*Step` wrappers behind one exported `pipeline.RunStep`, and fold `executeStepManually`'s separate dispatch switch into it.
- **#504** — the missing `StepFlattening` prerequisite (a behavior change unrelated to the seam).

## Verification

Full `go test ./...` green (unit + integration), `go vet` clean, `gofmt` clean. Manual CLI smoke of `pipeline start` -> pause at wait -> `continue` (empty stays paused; with files completes).

Closes #427
