### PR TITLE
ci(docs): add /aether/stable/ alias for versionless README links

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -17,6 +17,11 @@ on:
         description: 'Git tag to build docs from (e.g. v0.4.0)'
         required: true
         type: string
+      update_stable:
+        description: 'Also overwrite /aether/stable/ with this build (use the latest release tag)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -58,7 +63,11 @@ jobs:
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
           PUSH_REF: ${{ github.ref }}
           PUSH_REF_NAME: ${{ github.ref_name }}
+          DISPATCH_UPDATE_STABLE: ${{ github.event.inputs.update_stable }}
         run: |
+          # build_stable controls whether the version-independent /aether/stable/
+          # copy is rebuilt. It tracks non-prerelease releases (job-level `if` already
+          # filters prereleases), plus an explicit workflow_dispatch opt-in for backfills.
           if [[ "${EVENT_NAME}" == "push" ]]; then
             if [[ "${PUSH_REF}" == refs/tags/* ]]; then
               # Tag push: workflow triggered by release tag (release event is suppressed
@@ -66,19 +75,27 @@ jobs:
               echo "version=${PUSH_REF_NAME}" >> "$GITHUB_OUTPUT"
               echo "ref=${PUSH_REF_NAME}" >> "$GITHUB_OUTPUT"
               echo "is_release=true" >> "$GITHUB_OUTPUT"
+              echo "build_stable=true" >> "$GITHUB_OUTPUT"
             else
               echo "version=dev" >> "$GITHUB_OUTPUT"
               echo "ref=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
               echo "is_release=false" >> "$GITHUB_OUTPUT"
+              echo "build_stable=false" >> "$GITHUB_OUTPUT"
             fi
           elif [[ "${EVENT_NAME}" == "release" ]]; then
             echo "version=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
             echo "ref=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "build_stable=true" >> "$GITHUB_OUTPUT"
           elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "version=${DISPATCH_TAG}" >> "$GITHUB_OUTPUT"
             echo "ref=${DISPATCH_TAG}" >> "$GITHUB_OUTPUT"
             echo "is_release=false" >> "$GITHUB_OUTPUT"
+            if [[ "${DISPATCH_UPDATE_STABLE}" == "true" ]]; then
+              echo "build_stable=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "build_stable=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Checkout repository at target ref
@@ -116,6 +133,19 @@ jobs:
       - name: Save build output
         run: cp -r docs/.vitepress/dist /tmp/docs-build
 
+      # Second build with the version-independent base so /aether/stable/ has its
+      # own correctly-based asset and link URLs (a plain copy would keep /aether/<version>/).
+      - name: Build stable documentation
+        if: steps.vars.outputs.build_stable == 'true'
+        run: npm run docs:build
+        working-directory: docs
+        env:
+          VITE_BASE_PATH: /aether/stable/
+
+      - name: Save stable build output
+        if: steps.vars.outputs.build_stable == 'true'
+        run: cp -r docs/.vitepress/dist /tmp/docs-build-stable
+
       - name: Checkout gh-pages branch
         run: |
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
@@ -144,6 +174,12 @@ jobs:
         run: |
           rm -rf "${VERSION}"
           cp -r /tmp/docs-build "${VERSION}"
+
+      - name: Deploy stable directory
+        if: steps.vars.outputs.build_stable == 'true'
+        run: |
+          rm -rf stable
+          cp -r /tmp/docs-build-stable stable
 
       - name: Update versions.json
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -215,5 +251,8 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           git add "${VERSION}" versions.json index.html .nojekyll
+          if [ -d stable ]; then
+            git add stable
+          fi
           git commit -m "Deploy docs: ${VERSION}" || echo "No changes to commit"
           git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ aether pipeline continue aether.yaml <job-id>
 ## More Information
 
 - [Full Documentation](https://medizininformatik-initiative.github.io/aether/)
-- [Configuration Options](https://medizininformatik-initiative.github.io/aether/v0.10.1/getting-started/configuration.html)
-- [Pipeline Steps](https://medizininformatik-initiative.github.io/aether/v0.10.1/guides/pipeline-steps.html)
+- [Configuration Options](https://medizininformatik-initiative.github.io/aether/stable/getting-started/configuration.html)
+- [Pipeline Steps](https://medizininformatik-initiative.github.io/aether/stable/guides/pipeline-steps.html)
 
 ## License
 

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -14,8 +14,8 @@ const loaded = ref(false)
 
 function detectCurrentVersion(): string {
   if (typeof window === 'undefined') return 'dev'
-  // Path format: /aether/dev/ or /aether/v0.4.0/...
-  const match = window.location.pathname.match(/^\/aether\/(v[\d.]+|dev)/)
+  // Path format: /aether/dev/, /aether/stable/, or /aether/v0.4.0/...
+  const match = window.location.pathname.match(/^\/aether\/(v[\d.]+|dev|stable)/)
   return match ? match[1] : 'dev'
 }
 


### PR DESCRIPTION
## Summary

README deep links carried a hardcoded release segment (`/aether/v0.10.1/...`) that went stale every release and 404'd when dropped (caused #484). This publishes a version-independent `/aether/stable/` copy of the docs and points the README deep links at it, so they never need updating again.

## Changes

- **`.github/workflows/docs-deploy.yml`** — on each non-prerelease release, run a **second** VitePress build with `VITE_BASE_PATH=/aether/stable/` and deploy it to a `stable/` directory on `gh-pages`, overwriting each release. A plain `cp` won't work: VitePress bakes the base path into every asset/link URL at build time, so `stable/` needs its own build. Gated by a new `build_stable` output that mirrors the existing `is_release` logic, plus an opt-in `workflow_dispatch` `update_stable` input for backfilling.
- **`README.md`** — the two versioned deep links now point at `/aether/stable/`.
- **`docs/.vitepress/theme/VersionSwitcher.vue`** — recognize the `/aether/stable/` path so the switcher shows "stable" instead of falling back to "dev" on those pages.

`stable` is intentionally **not** added to `versions.json` / the switcher dropdown — it's an alias, not a discrete version, and a literal `"stable"` would sort to `NaN` in the semver comparator.

## Verification

Built the docs locally with `VITE_BASE_PATH=/aether/stable/` and confirmed every internal link, asset, and favicon in the output resolves to `/aether/stable/...` with zero `/aether/v*` leakage. Both target deep-link pages (`getting-started/configuration`, `guides/pipeline-steps`) build.

## Bootstrap / notes

- `/aether/stable/` won't exist until the next release runs the updated workflow, or a one-off `workflow_dispatch` with `update_stable=true` backfills it. Use the **latest** release tag when backfilling.
- Known limitation: backfilling `stable` from a pre-`VITE_BASE_PATH` historical tag would produce version-based links (the historical-config patch step overrides the env base). The release/tag-push paths are unaffected; only `workflow_dispatch` of an old tag is impacted — hence "use the latest release tag".

Follow-up to #484. Closes #488.