### PR TITLE
fix(models): gate flattening step on import prerequisite

### DIFF
--- a/internal/models/prerequisites.go
+++ b/internal/models/prerequisites.go
@@ -8,6 +8,7 @@ var StepPrerequisites = map[StepName][]StepName{
 	StepHttpImport:  {},         // No prerequisites - can always run
 	StepDIMP:        {"import"}, // Requires any import step to complete
 	StepValidation:  {"import"}, // Can validate after import (regardless of DIMP)
+	StepFlattening:  {"import"}, // Flattening needs imported FHIR input to transform
 	StepWait:        {"import"}, // Wait requires at least one step to have run
 	StepSend:        {"import"}, // Send requires at least import to have run
 }

--- a/tests/unit/models/prerequisites_test.go
+++ b/tests/unit/models/prerequisites_test.go
@@ -54,6 +54,30 @@ func TestValidateStepPrerequisites_ValidationRequiresImport(t *testing.T) {
 	assert.Equal(t, models.StepName("import"), prerequisite) // Returns "import" placeholder
 }
 
+func TestValidateStepPrerequisites_FlatteningRequiresImport(t *testing.T) {
+	job := createTestJob([]models.StepName{models.StepLocalImport, models.StepFlattening})
+
+	// Import not completed yet
+	prerequisite, canRun := models.ValidateStepPrerequisites(job, models.StepFlattening)
+
+	assert.False(t, canRun)
+	assert.Equal(t, models.StepName("import"), prerequisite)
+}
+
+func TestValidateStepPrerequisites_FlatteningAllowedAfterImport(t *testing.T) {
+	job := createTestJob([]models.StepName{models.StepLocalImport, models.StepFlattening})
+
+	// Mark import as completed
+	importStep, _ := models.GetStepByName(job, models.StepLocalImport)
+	importStep = models.CompleteStep(importStep, 10, 1000)
+	job = models.ReplaceStep(job, importStep)
+
+	prerequisite, canRun := models.ValidateStepPrerequisites(job, models.StepFlattening)
+
+	assert.True(t, canRun)
+	assert.Equal(t, models.StepName(""), prerequisite)
+}
+
 func TestValidateStepPrerequisites_PrerequisiteNotEnabled(t *testing.T) {
 	// Job without import step (unusual but possible)
 	job := createTestJob([]models.StepName{models.StepDIMP})


### PR DESCRIPTION
## Summary

`StepFlattening` had no entry in the `StepPrerequisites` map (`internal/models/prerequisites.go`), so `ValidateStepPrerequisites` returned `("", true)` for it — the flattening step was **never gated on a completed import**, unlike dimp/validation/wait/send which all require `{"import"}`.

This adds `StepFlattening: {"import"}` so flattening cannot advance before an import step completes.

## Why it matters

Latent safety-net gap. In normal operation flattening sits after import in configured order, so import has completed before the guard runs. The gap only surfaces for a misconfigured `enabled_steps`, an out-of-order advance, or hand-edited job state. Deliberately kept out of the #427 seam refactor (no-behavior-change) and filed separately.

## Tests

- `TestValidateStepPrerequisites_FlatteningRequiresImport` — blocked without completed import
- `TestValidateStepPrerequisites_FlatteningAllowedAfterImport` — allowed once import completes

Full suite green (`go test ./...`).

Closes #504