### PR TITLE
refactor(pipeline): centralize job layout on StepContext

### DIFF
--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -42,7 +42,8 @@ func (dimpStep) Name() models.StepName { return models.StepDIMP }
 
 // ExecuteDIMPStep runs the DIMP pseudonymization step through the shared lifecycle.
 func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	return runStep(dimpStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
+	return runStep(dimpStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
 }
 
 func (dimpStep) Run(ctx *StepContext) (StepResult, error) {
@@ -57,9 +58,8 @@ func (dimpStep) Run(ctx *StepContext) (StepResult, error) {
 	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 	dimpClient := dimpFactory(job.Config.Services.DIMP.URL, httpClient, logger)
 
-	layout := services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), job.Config.Pipeline.EnabledSteps)
-	importDir := layout.InputDir(stepName)
-	outputDir := layout.OutputDir(stepName)
+	importDir := ctx.Layout.InputDir(stepName)
+	outputDir := ctx.Layout.OutputDir(stepName)
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return StepResult{}, fmt.Errorf("failed to create output directory: %w", err)

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -51,7 +51,8 @@ func (flatteningStep) Name() models.StepName { return models.StepFlattening }
 // production caller yet (the cmd manual path wires only import and dimp today).
 // To be folded into one exported pipeline.RunStep — see issue #516.
 func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	return runStep(flatteningStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
+	return runStep(flatteningStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
 }
 
 func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
@@ -91,10 +92,9 @@ func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 		return StepResult{}, fmt.Errorf("invalid lookup tables: %w", err)
 	}
 
-	layout := services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), job.Config.Pipeline.EnabledSteps)
-	inputDir := layout.InputDir(stepName)
-	outputDir := layout.OutputDir(stepName)
-	viewDefDir := layout.ViewDefinitionsDir()
+	inputDir := ctx.Layout.InputDir(stepName)
+	outputDir := ctx.Layout.OutputDir(stepName)
+	viewDefDir := ctx.Layout.ViewDefinitionsDir()
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return StepResult{}, fmt.Errorf("failed to create output directory: %w", err)

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -49,7 +49,7 @@ func (s importStep) ClassifyError(err error) models.ErrorType {
 func ExecuteImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *services.HTTPClient, showProgress bool) (*models.PipelineJob, error) {
 	ctx := &StepContext{
 		Job:          job,
-		JobDir:       services.GetJobDir(job.Config.JobsDir, job.JobID),
+		Layout:       services.NewJobLayout(job.Config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps),
 		Logger:       logger,
 		HTTPClient:   httpClient,
 		ShowProgress: showProgress,
@@ -76,7 +76,7 @@ func (s importStep) Run(ctx *StepContext) (StepResult, error) {
 			job.Config.Retry, job.Config.TLS, logger)
 	}
 
-	importDir := services.GetJobOutputDir(job.Config.JobsDir, job.JobID, currentStep)
+	importDir := ctx.Layout.OutputDir(currentStep)
 	compress := job.Config.Compression.Enabled
 	compressionLevel := job.Config.Compression.Level
 

--- a/internal/pipeline/orchestrate.go
+++ b/internal/pipeline/orchestrate.go
@@ -33,7 +33,7 @@ func RunLoop(job *models.PipelineJob, logger *lib.Logger, opts RunOptions) (*mod
 
 		ctx := &StepContext{
 			Job:          job,
-			JobDir:       services.GetJobDir(job.Config.JobsDir, job.JobID),
+			Layout:       services.NewJobLayout(job.Config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps),
 			Logger:       logger,
 			ShowProgress: !opts.NoProgress,
 		}

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -74,7 +74,8 @@ func (sendStep) Name() models.StepName { return models.StepSend }
 // production caller yet (the cmd manual path wires only import and dimp today).
 // To be folded into one exported pipeline.RunStep — see issue #516.
 func ExecuteSendStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	return runStep(sendStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
+	return runStep(sendStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
 }
 
 func (sendStep) Run(ctx *StepContext) (StepResult, error) {
@@ -88,11 +89,11 @@ func (sendStep) Run(ctx *StepContext) (StepResult, error) {
 	sendMode := job.Config.Services.Send.SendAs
 	switch sendMode {
 	case models.SendModeDirectResourceLoad:
-		return executeDirectResourceLoadSend(job, ctx.JobDir, logger)
+		return executeDirectResourceLoadSend(job, ctx.Layout, logger)
 	case models.SendModeTransferLoad:
-		return executeTransferLoadSend(job, ctx.JobDir, logger)
+		return executeTransferLoadSend(job, ctx.Layout, logger)
 	case models.SendModeS3Upload:
-		return executeS3UploadSend(job, ctx.JobDir, logger)
+		return executeS3UploadSend(job, ctx.Layout, logger)
 	default:
 		return StepResult{}, fmt.Errorf("unknown send mode: %s", sendMode)
 	}
@@ -101,10 +102,10 @@ func (sendStep) Run(ctx *StepContext) (StepResult, error) {
 // executeTransferLoadSend sends files to a transfer FHIR server.
 // For each file: zips it, base64-encodes it, and wraps it in a FHIR Binary resource.
 // Then creates a DocumentReference linking all Binaries and uploads them.
-func executeTransferLoadSend(job *models.PipelineJob, jobDir string, logger *lib.Logger) (StepResult, error) {
+func executeTransferLoadSend(job *models.PipelineJob, layout services.JobLayout, logger *lib.Logger) (StepResult, error) {
 	stepName := models.StepSend
 
-	inputDir := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps).InputDir(stepName)
+	inputDir := layout.InputDir(stepName)
 
 	files, err := findAllFilesRecursive(inputDir)
 	if err != nil {
@@ -170,10 +171,10 @@ func executeTransferLoadSend(job *models.PipelineJob, jobDir string, logger *lib
 // executeDirectResourceLoadSend uploads NDJSON files to a FHIR server using transaction bundles.
 // Core files (core.ndjson) are loaded first before other NDJSON files to ensure
 // base resources are created before dependent resources.
-func executeDirectResourceLoadSend(job *models.PipelineJob, jobDir string, logger *lib.Logger) (StepResult, error) {
+func executeDirectResourceLoadSend(job *models.PipelineJob, layout services.JobLayout, logger *lib.Logger) (StepResult, error) {
 	stepName := models.StepSend
 
-	inputDir := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps).InputDir(stepName)
+	inputDir := layout.InputDir(stepName)
 
 	// Find NDJSON files
 	files, err := findNDJSONFiles(inputDir)
@@ -490,11 +491,11 @@ func findAllFilesRecursive(dir string) ([]string, error) {
 
 // executeS3UploadSend uploads files from the input directory to an S3 bucket.
 // Uses an upload manifest for retry resilience — previously uploaded files are skipped.
-func executeS3UploadSend(job *models.PipelineJob, jobDir string, logger *lib.Logger) (StepResult, error) {
+func executeS3UploadSend(job *models.PipelineJob, layout services.JobLayout, logger *lib.Logger) (StepResult, error) {
 	stepName := models.StepSend
 	startTime := time.Now()
 
-	inputDir := services.NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), job.Config.Pipeline.EnabledSteps).InputDir(stepName)
+	inputDir := layout.InputDir(stepName)
 
 	files, err := findAllFilesRecursive(inputDir)
 	if err != nil {
@@ -514,7 +515,7 @@ func executeS3UploadSend(job *models.PipelineJob, jobDir string, logger *lib.Log
 	}
 
 	// Load or create upload manifest for retry resilience
-	manifestPath := models.GetUploadManifestPath(jobDir)
+	manifestPath := models.GetUploadManifestPath(layout.JobDir())
 	manifest, err := models.LoadUploadManifest(manifestPath)
 	if err != nil {
 		logger.Warn("Failed to load upload manifest, starting fresh", "error", err)

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -18,11 +18,13 @@ type Step interface {
 	Run(ctx *StepContext) (StepResult, error)
 }
 
-// StepContext carries everything Run needs. The Execute*Step wrappers and the
-// orchestration loop populate it; Run never constructs it.
+// StepContext is the parameter block passed to a Step's Run. The Execute*Step
+// wrappers and the orchestration loop build it — resolving the JobLayout once so
+// no Run re-derives the job's directory layout — and Run never constructs it. Not
+// every field applies to every step (HTTPClient and ShowProgress are import-only).
 type StepContext struct {
 	Job    *models.PipelineJob
-	JobDir string // job root as passed by the caller, not derived from Config.JobsDir
+	Layout services.JobLayout // resolved once by the caller; the single source for a step's directories
 	Logger *lib.Logger
 
 	// HTTPClient is populated only by the import wrapper (whose signature takes

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -54,7 +54,8 @@ func (validationStep) Name() models.StepName { return models.StepValidation }
 // production caller yet (the cmd manual path reports validation as not-yet-wired).
 // To be folded into one exported pipeline.RunStep — see issue #516.
 func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	return runStep(validationStep{}, &StepContext{Job: job, JobDir: jobDir, Logger: logger})
+	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
+	return runStep(validationStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
 }
 
 func (validationStep) Run(ctx *StepContext) (StepResult, error) {
@@ -69,9 +70,8 @@ func (validationStep) Run(ctx *StepContext) (StepResult, error) {
 	httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
 	validationClient := resourceValidatorFactory(job.Config.Services.Validation.URL, httpClient, logger)
 
-	layout := services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), job.Config.Pipeline.EnabledSteps)
-	inputDir := layout.InputDir(stepName)
-	outputDir := layout.OutputDir(stepName)
+	inputDir := ctx.Layout.InputDir(stepName)
+	outputDir := ctx.Layout.OutputDir(stepName)
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return StepResult{}, fmt.Errorf("failed to create output directory: %w", err)

--- a/internal/pipeline/wait.go
+++ b/internal/pipeline/wait.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/services"
@@ -23,14 +22,9 @@ func (waitStep) Run(ctx *StepContext) (StepResult, error) {
 		return StepResult{}, err
 	}
 
-	jobsBaseDir := filepath.Dir(ctx.JobDir)
-	if err := ExecuteWaitStep(ctx.Job, jobsBaseDir, idx); err != nil {
-		return StepResult{}, err
-	}
-
-	waitDir, err := services.NewJobLayout(jobsBaseDir, ctx.Job.JobID, ctx.Job.Config.Pipeline.EnabledSteps).WaitDir(idx)
+	waitDir, err := resolveWaitDir(ctx.Layout, idx)
 	if err != nil {
-		return StepResult{}, fmt.Errorf("failed to find previous step: %w", err)
+		return StepResult{}, err
 	}
 
 	count, err := CountFilesInDir(waitDir)
@@ -94,16 +88,22 @@ func GetCurrentWaitStepIndex(job *models.PipelineJob) (int, error) {
 // Returns nil on success, the job should then be saved with status "waiting"
 func ExecuteWaitStep(job *models.PipelineJob, jobsBaseDir string, waitStepIndex int) error {
 	layout := services.NewJobLayout(jobsBaseDir, job.JobID, job.Config.Pipeline.EnabledSteps)
+	_, err := resolveWaitDir(layout, waitStepIndex)
+	return err
+}
+
+// resolveWaitDir resolves the wait override directory for the wait step at
+// waitStepIndex and ensures it exists. waitStep.Run and the exported
+// ExecuteWaitStep share it so both report the same errors from one place.
+func resolveWaitDir(layout services.JobLayout, waitStepIndex int) (string, error) {
 	waitDir, err := layout.WaitDir(waitStepIndex)
 	if err != nil {
-		return fmt.Errorf("failed to find previous step: %w", err)
+		return "", fmt.Errorf("failed to find previous step: %w", err)
 	}
-
 	if err := CreateWaitDirectory(waitDir); err != nil {
-		return fmt.Errorf("failed to create wait directory: %w", err)
+		return "", fmt.Errorf("failed to create wait directory: %w", err)
 	}
-
-	return nil
+	return waitDir, nil
 }
 
 // CreateWaitDirectory creates an empty wait directory for manual data inspection.

--- a/internal/pipeline/wait_step_run_test.go
+++ b/internal/pipeline/wait_step_run_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
 // waitRunTestJob builds a job with a [local_import, wait] pipeline whose wait
@@ -41,7 +42,8 @@ func waitRunTestJob(t *testing.T, waitStatus models.StepStatus) (*models.Pipelin
 }
 
 func waitRunContext(job *models.PipelineJob, jobDir string) *StepContext {
-	return &StepContext{Job: job, JobDir: jobDir, Logger: lib.NewLogger(lib.LogLevelError)}
+	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
+	return &StepContext{Job: job, Layout: layout, Logger: lib.NewLogger(lib.LogLevelError)}
 }
 
 func TestWaitStepRun_FirstArrivalPausesAndCreatesDir(t *testing.T) {

--- a/internal/services/layout.go
+++ b/internal/services/layout.go
@@ -40,6 +40,13 @@ func NewJobLayout(jobsBaseDir, jobID string, enabledSteps []models.StepName) Job
 	return JobLayout{jobsBaseDir: jobsBaseDir, jobID: jobID, enabledSteps: enabledSteps}
 }
 
+// NewJobLayoutForDir builds a resolver from a job's root directory, splitting it
+// into its base directory and job ID. Use when the caller holds the job root path
+// rather than the base dir and ID separately.
+func NewJobLayoutForDir(jobDir string, enabledSteps []models.StepName) JobLayout {
+	return NewJobLayout(filepath.Dir(jobDir), filepath.Base(jobDir), enabledSteps)
+}
+
 // JobDir returns the root directory for the job.
 func (l JobLayout) JobDir() string {
 	return GetJobDir(l.jobsBaseDir, l.jobID)

--- a/tests/unit/pipeline_wait_run_test.go
+++ b/tests/unit/pipeline_wait_run_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
 // waitRunJob builds a [local_import, wait] job whose wait step starts in the
@@ -42,7 +43,8 @@ func waitRunJob(t *testing.T, waitStatus models.StepStatus) (*models.PipelineJob
 }
 
 func waitRunContext(job *models.PipelineJob, jobDir string) *pipeline.StepContext {
-	return &pipeline.StepContext{Job: job, JobDir: jobDir, Logger: lib.NewLogger(lib.LogLevelError)}
+	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
+	return &pipeline.StepContext{Job: job, Layout: layout, Logger: lib.NewLogger(lib.LogLevelError)}
 }
 
 // waitStepFromRegistry returns the real wait Step through the public seam.


### PR DESCRIPTION
## Summary

Follow-up from the review of #427. `StepContext` carried a raw `JobDir string` and its doc comment claimed it "carries everything Run needs", but every data step reconstructed the job layout itself with `services.NewJobLayout(filepath.Dir(ctx.JobDir), filepath.Base(ctx.JobDir), ...)` gymnastics — so the layout was not actually centralized.

This change resolves the `JobLayout` once, in the caller, and carries it on `StepContext`:

- Replace `StepContext.JobDir` with a resolved `Layout services.JobLayout`, built by `RunLoop` and the `Execute*Step` wrappers.
- Remove the per-step `filepath.Dir`/`filepath.Base` reconstruction from the dimp, validation, flattening, send, and wait steps — each now reads directories straight from `ctx.Layout`.
- Add `services.NewJobLayoutForDir(jobDir, enabledSteps)` to split a job-root path into base dir + job ID in one place (used by the wrappers and their tests).
- Share `resolveWaitDir` between `waitStep.Run` and the exported `ExecuteWaitStep` so both report the same errors from one place.
- Correct the `StepContext` doc comment (it no longer oversells).

Pure structural deepening — no behavior change. Full unit and integration suites stay green.

Closes #514