### PR TITLE
refactor(pipeline): unify per-step wrappers behind pipeline.RunStep

### DIFF
--- a/cmd/job.go
+++ b/cmd/job.go
@@ -88,17 +88,22 @@ useful for:
   • Manual recovery after errors
 
 Available Steps:
-  import            - Import FHIR data from local or HTTP source
+  torch             - Import FHIR data from TORCH via CRTDL or TORCH result URL
+  local_import      - Import FHIR data from a local directory
+  http_import       - Import FHIR data from an HTTP URL
   dimp              - Pseudonymize data via DIMP service
-  validation        - Validate FHIR data (placeholder)
+  validation        - Validate FHIR data against a FHIR validation service
+  flattening        - Flatten FHIR data to CSV via fhir-flattener
+  send              - Send data to the configured transfer target
+
 Prerequisites:
   • The step must be enabled in project configuration
   • Prerequisite steps must be completed (e.g., import before dimp)
   • Job must exist and be in a valid state
 
 Examples:
-  # Run import step manually
-  aether job run aether.yaml abc123 --step import
+  # Run local import step manually
+  aether job run aether.yaml abc123 --step local_import
 
   # Run DIMP pseudonymization step
   aether job run aether.yaml abc123 --step dimp
@@ -302,11 +307,13 @@ func validateStepName(step string) (models.StepName, error) {
 		"http_import":  models.StepHttpImport,
 		"dimp":         models.StepDIMP,
 		"validation":   models.StepValidation,
+		"flattening":   models.StepFlattening,
+		"send":         models.StepSend,
 	}
 
 	stepName, ok := validSteps[step]
 	if !ok {
-		return "", fmt.Errorf("invalid step name '%s'. Valid steps: torch, local_import, http_import, dimp, validation", step)
+		return "", fmt.Errorf("invalid step name '%s'. Valid steps: torch, local_import, http_import, dimp, validation, flattening, send", step)
 	}
 
 	return stepName, nil
@@ -322,11 +329,10 @@ func isStepEnabledInConfig(config *models.ProjectConfig, stepName models.StepNam
 	return false
 }
 
-// executeStepManually executes a specific pipeline step manually
-// This is similar to executeStep in pipeline.go but simplified for manual execution
+// executeStepManually runs a single pipeline step through the shared RunStep
+// seam — the same lifecycle the automatic RunLoop uses. It persists job state
+// after the step and, on failure, records job-level failure before returning.
 func executeStepManually(job *models.PipelineJob, stepName models.StepName, config *models.ProjectConfig, logger *lib.Logger) error {
-	jobDir := services.GetJobDir(config.JobsDir, job.JobID)
-
 	// A completed step is terminal for the pipeline's transition gate, so
 	// re-running it manually would otherwise fail with an illegal
 	// completed->in_progress transition. Reset it to pending first so the manual
@@ -341,64 +347,63 @@ func executeStepManually(job *models.PipelineJob, stepName models.StepName, conf
 		*job = models.ReplaceStep(*job, s)
 	}
 
+	ctx := &pipeline.StepContext{
+		Job:          job,
+		Layout:       services.NewJobLayout(config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps),
+		Logger:       logger,
+		ShowProgress: true,
+	}
+
+	// Import steps must match the job's input type and take the manual HTTP client;
+	// other steps build their own client internally and ignore ctx.HTTPClient.
+	if isImportStep(stepName) {
+		if err := validateImportStepMatchesInput(job, stepName); err != nil {
+			return err
+		}
+		ctx.HTTPClient = services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
+	}
+
+	if err := pipeline.RunStep(stepName, ctx); err != nil {
+		failed := pipeline.FailJob(job, err.Error())
+		if saveErr := pipeline.UpdateJob(config.JobsDir, failed); saveErr != nil {
+			logger.Error("Failed to save job state", "error", saveErr)
+		}
+		return fmt.Errorf("%s step failed: %w", stepName, err)
+	}
+
+	if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
+		return fmt.Errorf("failed to save job state: %w", err)
+	}
+	return nil
+}
+
+// isImportStep reports whether the step is one of the three import variants.
+func isImportStep(stepName models.StepName) bool {
 	switch stepName {
 	case models.StepTorchImport, models.StepLocalImport, models.StepHttpImport:
-		// Validate step name matches input type (imported from pipeline.go logic)
-		var expectedStep models.StepName
-		switch job.InputType {
-		case models.InputTypeCRTDL, models.InputTypeTORCHURL:
-			expectedStep = models.StepTorchImport
-		case models.InputTypeLocal:
-			expectedStep = models.StepLocalImport
-		case models.InputTypeHTTP:
-			expectedStep = models.StepHttpImport
-		default:
-			return fmt.Errorf("unknown input type: %s", job.InputType)
-		}
-
-		if stepName != expectedStep {
-			return fmt.Errorf("step '%s' does not match input type %s (expected '%s')", stepName, job.InputType, expectedStep)
-		}
-
-		// Create HTTP client
-		httpClient := services.NewHTTPClient(30*time.Second, job.Config.Retry, job.Config.TLS, logger)
-		showProgress := true
-
-		importedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, showProgress)
-		if err != nil {
-			return fmt.Errorf("%s step failed: %w", stepName, err)
-		}
-
-		if err := pipeline.UpdateJob(config.JobsDir, importedJob); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ %s step completed (%d files)\n", stepName, importedJob.TotalFiles)
-		return nil
-
-	case models.StepDIMP:
-		// Execute DIMP pseudonymization step
-		fmt.Println("Starting DIMP pseudonymization step...")
-		if err := pipeline.ExecuteDIMPStep(job, jobDir, logger); err != nil {
-			// Save failed state
-			if saveErr := pipeline.UpdateJob(config.JobsDir, job); saveErr != nil {
-				logger.Error("Failed to save job state", "error", saveErr)
-			}
-			return fmt.Errorf("DIMP step failed: %w", err)
-		}
-
-		// Save successful state
-		if err := pipeline.UpdateJob(config.JobsDir, job); err != nil {
-			return fmt.Errorf("failed to save job state: %w", err)
-		}
-
-		fmt.Printf("\n✓ DIMP pseudonymization completed\n")
-		return nil
-
-	case models.StepValidation:
-		return fmt.Errorf("validation step not yet implemented")
-
+		return true
 	default:
-		return fmt.Errorf("unknown step: %s", stepName)
+		return false
 	}
+}
+
+// validateImportStepMatchesInput rejects an import step name that does not match
+// the job's input type (e.g. requesting torch import for a local-directory job).
+func validateImportStepMatchesInput(job *models.PipelineJob, stepName models.StepName) error {
+	var expectedStep models.StepName
+	switch job.InputType {
+	case models.InputTypeCRTDL, models.InputTypeTORCHURL:
+		expectedStep = models.StepTorchImport
+	case models.InputTypeLocal:
+		expectedStep = models.StepLocalImport
+	case models.InputTypeHTTP:
+		expectedStep = models.StepHttpImport
+	default:
+		return fmt.Errorf("unknown input type: %s", job.InputType)
+	}
+
+	if stepName != expectedStep {
+		return fmt.Errorf("step '%s' does not match input type %s (expected '%s')", stepName, job.InputType, expectedStep)
+	}
+	return nil
 }

--- a/cmd/job_test.go
+++ b/cmd/job_test.go
@@ -84,3 +84,53 @@ func TestExecuteStepManually_RerunsCompletedDIMPStep(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, models.StepStatusCompleted, s.Status)
 }
+
+// TestExecuteStepManually_RunsValidationStep proves the manual `job run --step
+// validation` path runs the real validation step through the shared seam, rather
+// than the old placeholder that returned "not yet implemented".
+func TestExecuteStepManually_RunsValidationStep(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resourceType": "OperationOutcome",
+			"issue":        []map[string]any{{"severity": "information", "code": "informational"}},
+		})
+	}))
+	defer server.Close()
+
+	jobsDir := t.TempDir()
+	jobID := "550e8400-e29b-41d4-a716-446655440000"
+	importDir := filepath.Join(jobsDir, jobID, "import")
+	require.NoError(t, os.MkdirAll(importDir, 0o755))
+	f, err := os.Create(filepath.Join(importDir, "Patient.ndjson"))
+	require.NoError(t, err)
+	require.NoError(t, json.NewEncoder(f).Encode(map[string]any{"resourceType": "Patient", "id": "p1"}))
+	require.NoError(t, f.Close())
+
+	failOnError := false
+	steps := []models.StepName{models.StepLocalImport, models.StepValidation}
+	config := &models.ProjectConfig{
+		JobsDir:  jobsDir,
+		Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		Services: models.ServiceConfig{Validation: models.ValidationConfig{
+			URL: server.URL, MaxConcurrentRequests: 2, BundleChunkSizeMB: 10, FailOnError: &failOnError,
+		}},
+		Retry: models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 10, MaxBackoffMs: 100},
+	}
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		Status:      models.JobStatusInProgress,
+		InputSource: importDir,
+		InputType:   models.InputTypeLocal,
+		CurrentStep: string(models.StepValidation),
+		Steps:       models.InitializeSteps(steps),
+		Config:      *config,
+	}
+
+	err = executeStepManually(job, models.StepValidation, config, lib.NewLogger(lib.LogLevelError))
+
+	require.NoError(t, err)
+	s, ok := models.GetStepByName(*job, models.StepValidation)
+	require.True(t, ok)
+	assert.Equal(t, models.StepStatusCompleted, s.Status)
+}

--- a/internal/pipeline/dimp.go
+++ b/internal/pipeline/dimp.go
@@ -40,12 +40,6 @@ type dimpStep struct{}
 
 func (dimpStep) Name() models.StepName { return models.StepDIMP }
 
-// ExecuteDIMPStep runs the DIMP pseudonymization step through the shared lifecycle.
-func ExecuteDIMPStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
-	return runStep(dimpStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
-}
-
 func (dimpStep) Run(ctx *StepContext) (StepResult, error) {
 	job := ctx.Job
 	logger := ctx.Logger

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -46,15 +46,6 @@ type flatteningStep struct{}
 
 func (flatteningStep) Name() models.StepName { return models.StepFlattening }
 
-// ExecuteFlatteningStep runs the flattening step through the shared lifecycle. It
-// is the exported single-step entrypoint used by the black-box tests; it has no
-// production caller yet (the cmd manual path wires only import and dimp today).
-// To be folded into one exported pipeline.RunStep — see issue #516.
-func ExecuteFlatteningStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
-	return runStep(flatteningStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
-}
-
 func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 	job := ctx.Job
 	logger := ctx.Logger

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -43,24 +43,6 @@ func (s importStep) ClassifyError(err error) models.ErrorType {
 	return classifyImportError(err, s.name)
 }
 
-// ExecuteImportStep runs the import step through the shared lifecycle. On failure
-// it also marks the job failed (models.AddError), matching import's historical
-// job-level failure behavior, and returns the (mutated) job either way.
-func ExecuteImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *services.HTTPClient, showProgress bool) (*models.PipelineJob, error) {
-	ctx := &StepContext{
-		Job:          job,
-		Layout:       services.NewJobLayout(job.Config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps),
-		Logger:       logger,
-		HTTPClient:   httpClient,
-		ShowProgress: showProgress,
-	}
-	if err := runStep(importStep{name: models.StepName(job.CurrentStep)}, ctx); err != nil {
-		updated := models.AddError(*job, err.Error())
-		return &updated, err
-	}
-	return job, nil
-}
-
 // Run selects the import method from the step name. It builds its own HTTP
 // client when none was injected (the orchestration-loop path), using the
 // longer download-safe timeout.

--- a/internal/pipeline/import_unsupported_test.go
+++ b/internal/pipeline/import_unsupported_test.go
@@ -1,0 +1,35 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// TestImportStep_UnsupportedName covers importStep.Run's defensive default: an
+// importStep carrying a name that is not one of the three import variants is
+// rejected. Registered production dispatch never reaches this branch (the
+// registry binds importStep only to torch/local/http), so it is exercised
+// white-box by constructing the step directly.
+func TestImportStep_UnsupportedName(t *testing.T) {
+	job := &models.PipelineJob{
+		JobID:       "test-job-123",
+		InputType:   models.InputTypeLocal,
+		CurrentStep: string(models.StepDIMP),
+		Config: models.ProjectConfig{
+			JobsDir: t.TempDir(),
+			Retry:   models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 500, MaxBackoffMs: 5000},
+		},
+	}
+	ctx := &StepContext{Job: job, Layout: services.NewJobLayoutForDir(t.TempDir(), nil), Logger: lib.NewLogger(lib.LogLevelInfo)}
+
+	_, err := importStep{name: models.StepDIMP}.Run(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported import step")
+}

--- a/internal/pipeline/registry.go
+++ b/internal/pipeline/registry.go
@@ -25,10 +25,10 @@ func defaultStepLookup(name models.StepName) (Step, bool) {
 // orchestration loop can run against fake steps.
 var stepLookup = defaultStepLookup
 
-// StepFor returns the Step registered for name. It is the exported registry
-// accessor used by the black-box tests; production dispatch (RunLoop) goes through
-// the unexported stepLookup directly, so this has no production caller.
-// To be reconsidered alongside the pipeline.RunStep unification — see issue #516.
+// StepFor returns the raw Step registered for name, without running it. RunStep
+// is the entrypoint for driving a step through the full lifecycle; StepFor exists
+// for tests that need the Step itself (e.g. to call Run in isolation). Production
+// dispatch (RunLoop) resolves via the unexported stepLookup directly.
 func StepFor(name models.StepName) (Step, bool) { return stepLookup(name) }
 
 // SetStepRegistryForTesting replaces the step lookup for tests.

--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -69,15 +69,6 @@ type sendStep struct{}
 
 func (sendStep) Name() models.StepName { return models.StepSend }
 
-// ExecuteSendStep runs the send step through the shared lifecycle. It is the
-// exported single-step entrypoint used by the black-box tests; it has no
-// production caller yet (the cmd manual path wires only import and dimp today).
-// To be folded into one exported pipeline.RunStep — see issue #516.
-func ExecuteSendStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
-	return runStep(sendStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
-}
-
 func (sendStep) Run(ctx *StepContext) (StepResult, error) {
 	job := ctx.Job
 	logger := ctx.Logger

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -68,6 +68,18 @@ type errorClassifier interface {
 	ClassifyError(error) models.ErrorType
 }
 
+// RunStep resolves the step registered for name and drives it through the shared
+// lifecycle. It is the single exported entrypoint for running one pipeline step,
+// used by the manual `job run` path and the black-box tests; the orchestration
+// loop resolves via stepLookup and calls runStep directly.
+func RunStep(name models.StepName, ctx *StepContext) error {
+	step, ok := stepLookup(name)
+	if !ok {
+		return fmt.Errorf("unknown step: %s", name)
+	}
+	return runStep(step, ctx)
+}
+
 // runStep is the single step lifecycle. It resolves nothing about the step's
 // work — that is Run's job — but owns every status transition, gating each one
 // through models.CanTransitionTo so an illegal transition fails loudly.

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -49,15 +49,6 @@ type validationStep struct{}
 
 func (validationStep) Name() models.StepName { return models.StepValidation }
 
-// ExecuteValidationStep runs the validation step through the shared lifecycle. It
-// is the exported single-step entrypoint used by the black-box tests; it has no
-// production caller yet (the cmd manual path reports validation as not-yet-wired).
-// To be folded into one exported pipeline.RunStep — see issue #516.
-func ExecuteValidationStep(job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
-	layout := services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps)
-	return runStep(validationStep{}, &StepContext{Job: job, Layout: layout, Logger: logger})
-}
-
 func (validationStep) Run(ctx *StepContext) (StepResult, error) {
 	job := ctx.Job
 	logger := ctx.Logger

--- a/tests/integration/pipeline_dimp_consistency_test.go
+++ b/tests/integration/pipeline_dimp_consistency_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
 )
 
 // TestDIMPConsistency_SplitVsUnsplit verifies that bundle splitting produces
@@ -67,7 +66,7 @@ func TestDIMPConsistency_SplitVsUnsplit(t *testing.T) {
 		}
 
 		logger := lib.NewLogger(lib.LogLevelDebug)
-		err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 		require.NoError(t, err, "DIMP step should succeed without splitting")
 
 		// Read output
@@ -130,7 +129,7 @@ func TestDIMPConsistency_SplitVsUnsplit(t *testing.T) {
 		}
 
 		logger := lib.NewLogger(lib.LogLevelDebug)
-		err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 		require.NoError(t, err, "DIMP step should succeed with splitting")
 
 		// Read output

--- a/tests/integration/pipeline_dimp_resume_test.go
+++ b/tests/integration/pipeline_dimp_resume_test.go
@@ -107,7 +107,7 @@ func TestDIMPResumeAfterInterrupt(t *testing.T) {
 
 	// Execute DIMP step (this should skip patient.ndjson since it's already processed)
 	jobDir := filepath.Join(jobsDir, job.JobID)
-	err = pipeline.ExecuteDIMPStep(reloadedJob, jobDir, logger)
+	err = runPipelineStep(models.StepDIMP, reloadedJob, jobDir, logger)
 
 	// The bug: ExecuteDIMPStep currently processes ALL files, including patient.ndjson
 	// Expected: Should only process observation.ndjson and condition.ndjson

--- a/tests/integration/pipeline_dimp_split_test.go
+++ b/tests/integration/pipeline_dimp_split_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
 )
 
 // Integration test: End-to-end splitting with mock DIMP
@@ -72,7 +71,7 @@ func TestDIMPStepWithLargeBundle(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Execute DIMP step
-	err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 	require.NoError(t, err, "DIMP step should complete without error")
 
 	// Verify output file exists
@@ -179,7 +178,7 @@ func TestDIMPStepWithLargeBundleAndChunks(t *testing.T) {
 
 	// Execute DIMP step
 	startTime := time.Now()
-	err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 	duration := time.Since(startTime)
 	require.NoError(t, err, "DIMP step should complete without error")
 
@@ -255,7 +254,7 @@ func TestDIMPStepWithSmallBundleNoSplit(t *testing.T) {
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
-	err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 	require.NoError(t, err, "DIMP step should complete without error")
 
 	// Verify output exists
@@ -501,7 +500,7 @@ func TestDIMPStepWithOversizedResource(t *testing.T) {
 
 	// Execute DIMP step - should handle oversized resource gracefully
 	logger := lib.NewLogger(lib.LogLevelInfo)
-	err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 
 	// Expect error due to oversized resource
 	assert.Error(t, err, "Step should error when oversized resource is encountered")
@@ -558,7 +557,7 @@ func TestDIMPStepWithCustomThreshold(t *testing.T) {
 		}
 
 		logger := lib.NewLogger(lib.LogLevelDebug)
-		err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 		require.NoError(t, err, "DIMP step should succeed with valid threshold")
 
 		// Verify output file exists
@@ -609,7 +608,7 @@ func TestDIMPStepWithCustomThreshold(t *testing.T) {
 		}
 
 		logger := lib.NewLogger(lib.LogLevelDebug)
-		err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 		require.NoError(t, err, "DIMP step should succeed with valid threshold")
 
 		// Verify output file exists
@@ -660,7 +659,7 @@ func TestDIMPStepWithCustomThreshold(t *testing.T) {
 		}
 
 		logger := lib.NewLogger(lib.LogLevelDebug)
-		err := pipeline.ExecuteDIMPStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepDIMP, job, jobDir, logger)
 		require.NoError(t, err, "DIMP step should succeed with valid threshold")
 
 		// Verify output file exists

--- a/tests/integration/pipeline_flattening_test.go
+++ b/tests/integration/pipeline_flattening_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
 )
 
 // makeProvenance builds a Provenance resource for integration testing
@@ -182,7 +181,7 @@ func TestExecuteFlatteningStep_FullPipeline(t *testing.T) {
 	logger := lib.NewLogger(lib.LogLevelDebug)
 
 	// Execute flattening step
-	err = pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify output files were created
@@ -214,7 +213,7 @@ func TestExecuteFlatteningStep_NotEnabled(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	assert.NoError(t, err) // Should skip without error
 }
 
@@ -249,7 +248,7 @@ func TestExecuteFlatteningStep_NoCRTDLAttached(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires a CRTDL file")
 	assert.Contains(t, err.Error(), "--crtdl")
@@ -283,7 +282,7 @@ func TestExecuteFlatteningStep_MissingCRTDL(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse CRTDL")
 }
@@ -330,7 +329,7 @@ func TestExecuteFlatteningStep_MissingLookupTables(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load lookup tables")
 }
@@ -383,7 +382,7 @@ func TestExecuteFlatteningStep_NoInputFiles(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no FHIR NDJSON files found")
 }
@@ -464,7 +463,7 @@ func TestExecuteFlatteningStep_FlattenerServiceError(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err = pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flattener failed")
 }
@@ -580,7 +579,7 @@ func TestExecuteFlatteningStep_NonBundleStreamRouting(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err = pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 	assert.True(t, flushed, "flattener service should have been called")
 

--- a/tests/integration/pipeline_import_error_test.go
+++ b/tests/integration/pipeline_import_error_test.go
@@ -50,7 +50,7 @@ func TestPipelineImportError_UnreachableURL(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 
 	// Execute import - should fail
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify error
 	assert.Error(t, err, "Import should fail for unreachable URL")
@@ -109,7 +109,7 @@ func TestPipelineImportError_HTTP404(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/missing.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify error
 	assert.Error(t, err, "Import should fail with 404")
@@ -159,7 +159,7 @@ func TestPipelineImportError_HTTP500WithRetry(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/error.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify error after retries
 	assert.Error(t, err, "Import should fail after max retries")
@@ -205,7 +205,7 @@ func TestPipelineImportError_InvalidLocalPath(t *testing.T) {
 
 	// Start and execute
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify error
 	assert.Error(t, err, "Import should fail for nonexistent directory")
@@ -245,7 +245,7 @@ func TestPipelineImportError_EmptyDirectory(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), emptyDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify error
 	assert.Error(t, err, "Import should fail for empty directory")
@@ -284,7 +284,7 @@ func TestPipelineImportError_PathIsFile(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), filePath, "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify error
 	assert.Error(t, err, "Import should fail when path is a file")
@@ -328,7 +328,7 @@ func TestPipelineImportError_NetworkTimeout(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/slow.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify timeout error
 	assert.Error(t, err, "Import should fail with timeout")
@@ -371,9 +371,13 @@ func TestPipelineImportError_StatePersistence(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/bad.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	assert.Error(t, err)
+
+	// RunStep records only step-level failure; the caller records the job-level
+	// failure that gets persisted, exactly as the automatic RunLoop does via FailJob.
+	importedJob = pipeline.FailJob(importedJob, err.Error())
 
 	// Save failed job state
 	require.NoError(t, pipeline.UpdateJob(jobsDir, importedJob))
@@ -429,7 +433,7 @@ func TestPipelineImportError_PartialDownloadCleanup(t *testing.T) {
 	// we test the cleanup mechanism with a different error scenario
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), "http://localhost:99999/unreachable.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	_, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	_, err := runImportStep(startedJob, logger, httpClient, false)
 
 	assert.Error(t, err)
 

--- a/tests/integration/pipeline_import_local_test.go
+++ b/tests/integration/pipeline_import_local_test.go
@@ -81,7 +81,7 @@ func TestPipelineImportLocal_EndToEnd(t *testing.T) {
 	require.NoError(t, pipeline.UpdateJob(jobsDir, startedJob))
 
 	// Step 3: Execute import step
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err, "Import should succeed")
 	require.NotNil(t, importedJob, "Imported job should be returned")
 
@@ -153,7 +153,7 @@ func TestPipelineImportLocal_InvalidSource(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 
 	// Execute import - should fail
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 	assert.Error(t, err, "Import should fail for nonexistent directory")
 	assert.NotNil(t, importedJob, "Job should be returned even on failure")
 
@@ -199,7 +199,7 @@ func TestPipelineImportLocal_EmptyDirectory(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 
 	// Execute import - should fail
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 	assert.Error(t, err, "Import should fail for directory with no FHIR files")
 
 	// Verify error details
@@ -243,7 +243,7 @@ func TestPipelineImportLocal_ResourceCounting(t *testing.T) {
 	// Execute import
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), sourceDir, "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	require.NoError(t, err)
 
@@ -292,7 +292,7 @@ func TestPipelineImportLocal_JobListAndStatus(t *testing.T) {
 
 	// Execute import for first job
 	startedJob1 := pipeline.StartJob(job1)
-	importedJob1, _ := pipeline.ExecuteImportStep(startedJob1, logger, httpClient, false)
+	importedJob1, _ := runImportStep(startedJob1, logger, httpClient, false)
 	_ = pipeline.UpdateJob(jobsDir, importedJob1)
 
 	// List all jobs

--- a/tests/integration/pipeline_import_url_test.go
+++ b/tests/integration/pipeline_import_url_test.go
@@ -66,7 +66,7 @@ func TestPipelineImportURL_EndToEnd(t *testing.T) {
 	assert.Equal(t, models.JobStatusInProgress, startedJob.Status)
 
 	// Step 3: Execute import with progress display
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, true)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, true)
 	require.NoError(t, err, "Import should succeed")
 
 	// Verify import step completed
@@ -140,7 +140,7 @@ func TestPipelineImportURL_WithRetry(t *testing.T) {
 	// Create and execute job
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/test.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 
 	// Verify retry succeeded
 	require.NoError(t, err, "Import should succeed after retries")
@@ -188,7 +188,7 @@ func TestPipelineImportURL_LargeFile(t *testing.T) {
 	// Execute import with progress
 	job, _ := pipeline.CreateJob(models.GenerateJobID(), server.URL+"/large.ndjson", "", config, logger)
 	startedJob := pipeline.StartJob(job)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, true)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, true)
 
 	require.NoError(t, err, "Import should succeed")
 
@@ -244,7 +244,7 @@ func TestPipelineImportURL_ProgressDisplay(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 
 	// This should use progress bar/spinner internally (progress indicator requirementsc, Progress indicators must update at least every 2 seconds)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, true)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, true)
 
 	require.NoError(t, err, "Import should succeed")
 
@@ -291,7 +291,7 @@ func TestPipelineImportURL_MultipleURLs(t *testing.T) {
 	for _, url := range urls {
 		job, _ := pipeline.CreateJob(models.GenerateJobID(), url, "", config, logger)
 		startedJob := pipeline.StartJob(job)
-		importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+		importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 		require.NoError(t, err, "Import should succeed for URL %s", url)
 		jobs = append(jobs, importedJob)
 	}
@@ -366,7 +366,7 @@ func TestPipelineImportURL_FilenameFromURL(t *testing.T) {
 			url := server.URL + tt.urlPath
 			job, _ := pipeline.CreateJob(models.GenerateJobID(), url, "", config, logger)
 			startedJob := pipeline.StartJob(job)
-			_, _ = pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+			_, _ = runImportStep(startedJob, logger, httpClient, false)
 
 			// Verify filename
 			importDir := services.GetJobOutputDir(jobsDir, job.JobID, models.StepHttpImport)
@@ -413,8 +413,8 @@ func TestPipelineImportURL_ConcurrentDownloads(t *testing.T) {
 	startedJob1 := pipeline.StartJob(job1)
 	startedJob2 := pipeline.StartJob(job2)
 
-	_, err1 := pipeline.ExecuteImportStep(startedJob1, logger, httpClient, false)
-	_, err2 := pipeline.ExecuteImportStep(startedJob2, logger, httpClient, false)
+	_, err1 := runImportStep(startedJob1, logger, httpClient, false)
+	_, err2 := runImportStep(startedJob2, logger, httpClient, false)
 
 	// Verify both succeeded independently
 	require.NoError(t, err1, "Job1 import should succeed")

--- a/tests/integration/pipeline_multistep_test.go
+++ b/tests/integration/pipeline_multistep_test.go
@@ -84,7 +84,7 @@ func TestPipelineMultiStep_AutomaticExecution(t *testing.T) {
 	// Execute import step
 	logger = lib.NewLogger(lib.LogLevelError) // Suppress logs in tests
 	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, models.TLSConfig{}, logger)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err)
 	require.NoError(t, pipeline.UpdateJob(jobsDir, importedJob))
 
@@ -109,7 +109,7 @@ func TestPipelineMultiStep_AutomaticExecution(t *testing.T) {
 
 	// Execute DIMP step
 	jobDir := services.GetJobDir(jobsDir, job.JobID)
-	err = pipeline.ExecuteDIMPStep(advancedJob, jobDir, logger)
+	err = runPipelineStep(models.StepDIMP, advancedJob, jobDir, logger)
 	require.NoError(t, err, "DIMP step should execute successfully")
 
 	// Verify DIMP step completed
@@ -199,7 +199,7 @@ func TestPipelineMultiStep_OnlyImportEnabled(t *testing.T) {
 	// Execute import
 	logger = lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, models.TLSConfig{}, logger)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err)
 
 	// Try to get next step - should be empty
@@ -321,7 +321,7 @@ func TestPipelineMultiStep_JobStatePersistedBetweenSteps(t *testing.T) {
 
 	logger = lib.NewLogger(lib.LogLevelError)
 	httpClient := services.NewHTTPClient(30*time.Second, config.Retry, models.TLSConfig{}, logger)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, httpClient, false)
+	importedJob, err := runImportStep(startedJob, logger, httpClient, false)
 	require.NoError(t, err)
 	require.NoError(t, pipeline.UpdateJob(jobsDir, importedJob))
 
@@ -339,7 +339,7 @@ func TestPipelineMultiStep_JobStatePersistedBetweenSteps(t *testing.T) {
 
 	// Execute DIMP
 	jobDir := services.GetJobDir(jobsDir, jobID)
-	err = pipeline.ExecuteDIMPStep(advancedJob, jobDir, logger)
+	err = runPipelineStep(models.StepDIMP, advancedJob, jobDir, logger)
 	require.NoError(t, err)
 	require.NoError(t, pipeline.UpdateJob(jobsDir, advancedJob))
 

--- a/tests/integration/pipeline_resume_test.go
+++ b/tests/integration/pipeline_resume_test.go
@@ -67,7 +67,7 @@ func TestPipelineResume_AfterImportComplete(t *testing.T) {
 	require.NoError(t, err, "UpdateJob should succeed")
 
 	// Execute import step only
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err, "ExecuteImportStep should succeed")
 	require.Equal(t, 5, importedJob.TotalFiles, "Should import 5 files")
 
@@ -275,7 +275,7 @@ func createCompletedImportJob(t *testing.T, jobsDir string, fileCount int) *mode
 	// Start job and complete import
 	startedJob := pipeline.StartJob(job)
 	logger = lib.NewLogger(lib.LogLevelInfo)
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 
 	// Save completed import state

--- a/tests/integration/pipeline_torch_test.go
+++ b/tests/integration/pipeline_torch_test.go
@@ -165,7 +165,7 @@ func TestPipeline_TORCHExtraction_EndToEnd(t *testing.T) {
 
 	// Execute import step (which should trigger TORCH extraction)
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestPipeline_TORCHExtraction_EmptyResult(t *testing.T) {
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Empty result should be handled gracefully
 	require.NoError(t, err)
@@ -314,7 +314,7 @@ func TestPipeline_TORCHExtraction_ServerUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	_, err = pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	_, err = runImportStep(job, logger, httpClient, false)
 
 	// Should fail with network error
 	assert.Error(t, err)
@@ -414,7 +414,7 @@ func TestPipeline_DirectTORCHURL_Download(t *testing.T) {
 
 	// Execute import step (should download directly without extraction submission)
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
 	require.NoError(t, err)
@@ -501,7 +501,7 @@ func TestPipeline_DirectTORCHURL_EmptyResult(t *testing.T) {
 	require.NoError(t, err)
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Empty result should be handled gracefully
 	require.NoError(t, err)
@@ -765,7 +765,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 
 	// Step 2: Execute TORCH import step
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	importedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	importedJob, err := runImportStep(job, logger, httpClient, false)
 	require.NoError(t, err)
 
 	// Verify import completed
@@ -820,7 +820,7 @@ func TestPipeline_TORCHExtraction_WithWaitStep_DataModification(t *testing.T) {
 	assert.Equal(t, string(models.StepDIMP), dimpReadyJob.CurrentStep)
 
 	// Step 6: Execute DIMP step - should read from import_wait directory
-	err = pipeline.ExecuteDIMPStep(dimpReadyJob, services.GetJobDir(jobsDir, dimpReadyJob.JobID), logger)
+	err = runPipelineStep(models.StepDIMP, dimpReadyJob, services.GetJobDir(jobsDir, dimpReadyJob.JobID), logger)
 	require.NoError(t, err)
 
 	// Step 7: Verify DIMP output contains the MODIFIED data (not the original)
@@ -994,7 +994,7 @@ func TestPipeline_TORCHExtraction_WithPreprocessing(t *testing.T) {
 
 	// Execute import step (triggers TORCH extraction with preprocessing)
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
 	require.NoError(t, err)
@@ -1302,7 +1302,7 @@ func TestPipeline_TORCHExtraction_ReattachViaImportStep(t *testing.T) {
 	job.TORCHExtractionURL = server.URL + "/fhir/extraction/existing-job"
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, submitCount, "re-attach must not POST $extract-data")
@@ -1392,7 +1392,7 @@ func TestPipeline_TORCHExtraction_DeadHandleResubmitsViaImportStep(t *testing.T)
 	job.TORCHExtractionURL = server.URL + "/fhir/extraction/stale-job"
 
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, submitCount, "dead handle must trigger exactly one re-submit")
@@ -1603,7 +1603,7 @@ func TestPipeline_TORCHExtraction_PreprocessingDisabled_UsesOriginalCRTDL(t *tes
 
 	// Execute import step - should use original CRTDL without preprocessing
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
 	require.NoError(t, err)
@@ -1805,7 +1805,7 @@ func TestPipeline_TORCHExtraction_PreprocessingEnabled_EmptyEnrichments(t *testi
 
 	// Execute import step - should use original CRTDL content when no enrichments configured
 	httpClient := services.NewHTTPClient(2*time.Second, config.Retry, models.TLSConfig{}, logger)
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Verify successful execution
 	require.NoError(t, err)

--- a/tests/integration/pipeline_wait_test.go
+++ b/tests/integration/pipeline_wait_test.go
@@ -57,7 +57,7 @@ func TestPipelineWithWaitStep_PausesExecution(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute import step
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 	require.Equal(t, 3, importedJob.TotalFiles)
 
@@ -120,7 +120,7 @@ func TestPipelineWithWaitStep_DirectoryCreated(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 
 	// Advance to wait step
@@ -176,7 +176,7 @@ func TestPipelineWithWaitStep_EmptyDirectory(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 
 	advancedJob, err := pipeline.AdvanceToNextStep(importedJob)
@@ -230,7 +230,7 @@ func TestPipelineWithWaitStep_ContinuesAfterCommand(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 
 	advancedJob, err := pipeline.AdvanceToNextStep(importedJob)
@@ -310,7 +310,7 @@ func TestWaitStep_ContinueWithFilesPresent(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 
 	// Advance to wait step and execute it
@@ -397,7 +397,7 @@ func TestWaitStep_ContinueWithEmptyDirectory(t *testing.T) {
 	startedJob := pipeline.StartJob(job)
 	_ = pipeline.UpdateJob(jobsDir, startedJob)
 
-	importedJob, err := pipeline.ExecuteImportStep(startedJob, logger, nil, false)
+	importedJob, err := runImportStep(startedJob, logger, nil, false)
 	require.NoError(t, err)
 
 	advancedJob, err := pipeline.AdvanceToNextStep(importedJob)

--- a/tests/integration/step_helpers_test.go
+++ b/tests/integration/step_helpers_test.go
@@ -1,0 +1,28 @@
+package integration
+
+import (
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// runPipelineStep drives one pipeline step through the exported RunStep seam for
+// black-box tests that previously called a per-step Execute*Step wrapper.
+func runPipelineStep(name models.StepName, job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	return pipeline.RunStep(name, &pipeline.StepContext{Job: job, Layout: services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps), Logger: logger})
+}
+
+// runImportStep drives the import step through RunStep, selecting the import
+// variant from job.CurrentStep and returning the (in-place mutated) job to match
+// the shape black-box import tests expect.
+func runImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *services.HTTPClient, showProgress bool) (*models.PipelineJob, error) {
+	err := pipeline.RunStep(models.StepName(job.CurrentStep), &pipeline.StepContext{
+		Job:          job,
+		Layout:       services.NewJobLayout(job.Config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps),
+		Logger:       logger,
+		HTTPClient:   httpClient,
+		ShowProgress: showProgress,
+	})
+	return job, err
+}

--- a/tests/unit/client_seam_test.go
+++ b/tests/unit/client_seam_test.go
@@ -41,7 +41,7 @@ func TestDIMPStep_UsesFakeDIMPProcessor(t *testing.T) {
 		{"resourceType": "Patient", "id": "p1"},
 	})
 
-	require.NoError(t, pipeline.ExecuteDIMPStep(job, tmpDir, createDIMPTestLogger()))
+	require.NoError(t, runPipelineStep(models.StepDIMP, job, tmpDir, createDIMPTestLogger()))
 
 	require.NotEmpty(t, mock.Calls, "step must call the injected fake, not a real client")
 	out := readDIMPNDJSON(t, filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson"))
@@ -71,7 +71,7 @@ func TestValidationStep_UsesFakeValidator(t *testing.T) {
 		{"resourceType": "Patient", "id": "p1"},
 	})
 
-	require.NoError(t, pipeline.ExecuteValidationStep(job, tmpDir, createValidationTestLogger()))
+	require.NoError(t, runPipelineStep(models.StepValidation, job, tmpDir, createValidationTestLogger()))
 	assert.NotEmpty(t, mock.Calls, "step must call the injected fake validator")
 }
 
@@ -130,7 +130,7 @@ func TestImportStep_TorchExtraction_UsesFakeExtractor(t *testing.T) {
 		},
 	}
 
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, nil, false)
+	updatedJob, err := runImportStep(job, logger, nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, updatedJob)
 
@@ -201,7 +201,7 @@ func TestFlatteningStep_UsesFakeFlattener(t *testing.T) {
 	// the fake replaces the HTTP round-trip.
 	job := createFlatteningTestJob("http://flattener.invalid", lookupPath, crtdlPath)
 
-	require.NoError(t, pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger()))
+	require.NoError(t, runPipelineStep(models.StepFlattening, job, jobDir, createFlatteningTestLogger()))
 
 	// The provenance-linked Patient was routed to the fake, carrying a
 	// ViewDefinition compiled from the CRTDL group.

--- a/tests/unit/import_step_test.go
+++ b/tests/unit/import_step_test.go
@@ -9,51 +9,8 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
-
-// TestExecuteImportStep_UnsupportedStep tests error handling for unsupported import steps
-// This covers import.go switch statement for currentStep
-func TestExecuteImportStep_UnsupportedStep(t *testing.T) {
-	tmpDir := t.TempDir()
-	logger := lib.NewLogger(lib.LogLevelInfo)
-
-	retryConfig := models.RetryConfig{
-		MaxAttempts:      3,
-		InitialBackoffMs: 500,
-		MaxBackoffMs:     5000,
-	}
-	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
-
-	// Create a job with an unsupported step (not an import step)
-	job := &models.PipelineJob{
-		JobID:       "test-job-123",
-		InputSource: "/some/path",
-		InputType:   models.InputTypeLocal,
-		CurrentStep: string(models.StepDIMP), // Not an import step
-		Status:      models.JobStatusPending,
-		Steps:       models.InitializeSteps([]models.StepName{models.StepDIMP}),
-		Config: models.ProjectConfig{
-			JobsDir: tmpDir,
-			Pipeline: models.PipelineConfig{
-				EnabledSteps: []models.StepName{models.StepDIMP},
-			},
-			Retry: models.RetryConfig{
-				MaxAttempts:      3,
-				InitialBackoffMs: 500,
-				MaxBackoffMs:     5000,
-			},
-		},
-	}
-
-	// Execute import step - should fail with unsupported step
-	_, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
-
-	// Verify error
-	require.Error(t, err, "Should fail with unsupported import step")
-	assert.Contains(t, err.Error(), "unsupported import step", "Error should mention unsupported import step")
-}
 
 // TestExecuteImportStep_LocalImportMissingDir tests error handling when local_import directory doesn't exist
 func TestExecuteImportStep_LocalImportMissingDir(t *testing.T) {
@@ -89,7 +46,7 @@ func TestExecuteImportStep_LocalImportMissingDir(t *testing.T) {
 	}
 
 	// Execute import step - should fail because directory doesn't exist
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	// Verify error
 	require.Error(t, err, "Should fail when directory doesn't exist")
@@ -140,7 +97,7 @@ func TestExecuteImportStep_HttpImportValidationFailure(t *testing.T) {
 	}
 
 	// Execute import step - should fail with unsupported protocol
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.Error(t, err, "Should fail when HTTP import has invalid URL")
 	assert.NotNil(t, updatedJob, "Should return updated job even on error")
@@ -178,7 +135,7 @@ func TestExecuteImportStep_HttpImportEmptyURL(t *testing.T) {
 	}
 
 	// Execute import step - should fail validation
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.Error(t, err, "Should fail when HTTP import URL is empty")
 	assert.NotNil(t, updatedJob, "Should return updated job even on error")
@@ -222,7 +179,7 @@ func TestExecuteImportStep_TorchImportCRTDLValidationFailure(t *testing.T) {
 	}
 
 	// Execute import step - should fail validation
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.Error(t, err, "Should fail when CRTDL validation fails")
 	assert.NotNil(t, updatedJob, "Should return updated job even on error")
@@ -260,7 +217,7 @@ func TestExecuteImportStep_TorchImportTORCHURLValidationFailure(t *testing.T) {
 	}
 
 	// Execute import step - should fail validation
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.Error(t, err, "Should fail when TORCH URL validation fails")
 	assert.NotNil(t, updatedJob, "Should return updated job even on error")
@@ -301,7 +258,7 @@ func TestExecuteImportStep_TorchImportInvalidInputType(t *testing.T) {
 	}
 
 	// Execute import step - should fail because no CRTDL is attached
-	updatedJob, err := pipeline.ExecuteImportStep(job, logger, httpClient, false)
+	updatedJob, err := runImportStep(job, logger, httpClient, false)
 
 	require.Error(t, err, "Should fail when torch import has no CRTDL")
 	assert.NotNil(t, updatedJob, "Should return updated job even on error")

--- a/tests/unit/pipeline_dimp_test.go
+++ b/tests/unit/pipeline_dimp_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
 )
 
 // Helper functions for DIMP pipeline tests
@@ -116,7 +115,7 @@ func TestExecuteDIMPStep_DisabledStep(t *testing.T) {
 	job := createDIMPTestJobDisabled()
 	logger := createDIMPTestLogger()
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 }
 
@@ -126,7 +125,7 @@ func TestExecuteDIMPStep_MissingDIMPURL(t *testing.T) {
 	job := createDIMPTestJob("") // Empty URL
 	logger := createDIMPTestLogger()
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "DIMP service URL not configured")
 }
@@ -146,7 +145,7 @@ func TestExecuteDIMPStep_FailedToCreateOutputDir(t *testing.T) {
 	require.NoError(t, cerr)
 	require.NoError(t, f.Close())
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create output directory")
 }
@@ -164,7 +163,7 @@ func TestExecuteDIMPStep_NoFilesFound(t *testing.T) {
 	importDir := filepath.Join(tmpDir, "import")
 	require.NoError(t, os.MkdirAll(importDir, 0755))
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no FHIR NDJSON files found")
 }
@@ -189,7 +188,7 @@ func TestExecuteDIMPStep_ProcessSimpleResources(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file was created
@@ -232,7 +231,7 @@ func TestExecuteDIMPStep_ResumeProcessing(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, outputFile, existingData)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify file still has original content (wasn't reprocessed)
@@ -261,7 +260,7 @@ func TestExecuteDIMPStep_InvalidJSON(t *testing.T) {
 	require.NoError(t, ferr)
 	require.NoError(t, f.Close())
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse")
 }
@@ -296,7 +295,7 @@ func TestExecuteDIMPStep_ProcessBundleWithoutSplit(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, []map[string]any{bundle})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
@@ -321,7 +320,7 @@ func TestExecuteDIMPStep_ProcessBundleWithSplit(t *testing.T) {
 	bundle := CreateTestBundle(20, 100) // 20 entries, ~100KB each = ~2MB total
 	writeDIMPNDJSON(t, inputFile, []map[string]any{bundle})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
@@ -348,7 +347,7 @@ func TestExecuteDIMPStep_DIMPServiceError(t *testing.T) {
 	patients := []map[string]any{{"resourceType": "Patient", "id": "p1"}}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 }
 
@@ -372,7 +371,7 @@ func TestExecuteDIMPStep_MultipleFiles(t *testing.T) {
 		writeDIMPNDJSON(t, inputFile, data)
 	}
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify all output files were created
@@ -398,7 +397,7 @@ func TestExecuteDIMPStep_StepStateUpdated(t *testing.T) {
 	patients := []map[string]any{{"resourceType": "Patient", "id": "p1"}}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify step was added to job
@@ -435,7 +434,7 @@ func TestExecuteDIMPStep_EmptyLines(t *testing.T) {
 	require.NoError(t, ferr)
 	require.NoError(t, f.Close())
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	outputFile := filepath.Join(tmpDir, "dimp", "dimped_sparse.ndjson")
@@ -475,7 +474,7 @@ func TestExecuteDIMPStep_OversizedNonBundleResource(t *testing.T) {
 	require.NoError(t, ferr)
 	require.NoError(t, f.Close())
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "oversized")
 }
@@ -502,7 +501,7 @@ func TestExecuteDIMPStep_BundleCalcSizeError(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// The test should handle this - it shouldn't crash
-	_ = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	_ = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 }
 
 // TestExecuteDIMPStep_DefaultBundleThreshold tests default threshold when not configured
@@ -534,7 +533,7 @@ func TestExecuteDIMPStep_DefaultBundleThreshold(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, []map[string]any{bundle})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
@@ -567,7 +566,7 @@ func TestExecuteDIMPStep_GetOrCreateStepExisting(t *testing.T) {
 	patients := []map[string]any{{"resourceType": "Patient", "id": "p1"}}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify still only one step
@@ -599,7 +598,7 @@ func TestExecuteDIMPStep_NegativeBundleThreshold(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, []map[string]any{bundle})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 }
 
@@ -630,7 +629,7 @@ func TestExecuteDIMPStep_AlreadyProcessedFileCountError(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, outputFile, existingData)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 	// Step should complete successfully even if counting fails
 	require.Len(t, job.Steps, 1)
@@ -655,7 +654,7 @@ func TestExecuteDIMPStep_StepErrorRecording(t *testing.T) {
 	patients := []map[string]any{{"resourceType": "Patient", "id": "p1"}}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 
 	// Verify step was created and has error recorded
@@ -676,7 +675,7 @@ func TestExecuteDIMPStep_FileListingWithoutImportDir(t *testing.T) {
 	logger := createDIMPTestLogger()
 
 	// Don't create import directory - glob should return empty
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no FHIR NDJSON files found")
 }
@@ -701,7 +700,7 @@ func TestExecuteDIMPStep_VeryLargeBundle(t *testing.T) {
 	largeBundle := CreateTestBundle(500, 50) // 500 entries of ~50KB each = ~25MB
 	writeDIMPNDJSON(t, inputFile, []map[string]any{largeBundle})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file was created
@@ -730,7 +729,7 @@ func TestExecuteDIMPStep_MixedResourceTypes(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, resources)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file exists and has all resources
@@ -777,7 +776,7 @@ func TestExecuteDIMPStep_BundleWithError(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, []map[string]any{bundle})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	outputFile := filepath.Join(tmpDir, "dimp", "dimped_bundles.ndjson")
@@ -810,7 +809,7 @@ func TestExecuteDIMPStep_LargeNumberOfFiles(t *testing.T) {
 		writeDIMPNDJSON(t, inputFile, data)
 	}
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify all files were processed
@@ -838,7 +837,7 @@ func TestExecuteDIMPStep_SpecialCharactersInFilenames(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file exists
@@ -873,7 +872,7 @@ func TestExecuteDIMPStep_WithCompression(t *testing.T) {
 	}
 	writeDIMPNDJSON(t, inputFile, patients)
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file was created with compression extension
@@ -921,7 +920,7 @@ func TestExecuteDIMPStep_CompressedInput(t *testing.T) {
 	}
 	require.NoError(t, writer.Close())
 
-	err = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file was created (uncompressed)
@@ -964,7 +963,7 @@ func TestExecuteDIMPStep_CompressedInputToCompressedOutput(t *testing.T) {
 	}
 	require.NoError(t, writer.Close())
 
-	err = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file was created with compression extension
@@ -1007,7 +1006,7 @@ func TestExecuteDIMPStep_MixedInputFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	err = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify both output files were created with compression
@@ -1038,7 +1037,7 @@ func TestExecuteDIMPStep_CompressionAllLevels(t *testing.T) {
 			patients := []map[string]any{{"resourceType": "Patient", "id": "p1"}}
 			writeDIMPNDJSON(t, inputFile, patients)
 
-			err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+			err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 			assert.NoError(t, err, "DIMP should succeed with compression level: %s", level)
 
 			outputFile := filepath.Join(tmpDir, "dimp", "dimped_patients.ndjson.zst")
@@ -1071,7 +1070,7 @@ func TestExecuteDIMPStep_DuplicateFilesError(t *testing.T) {
 	require.NoError(t, writer.Close())
 
 	// This should fail due to duplicate files
-	err = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "patients.ndjson")
 }
@@ -1105,7 +1104,7 @@ func TestExecuteDIMPStep_ResumeWithCompressedOutput(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	err = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify file still has original content (wasn't reprocessed)
@@ -1162,7 +1161,7 @@ func TestExecuteDIMPStep_StalePartFileRemovalError(t *testing.T) {
 
 	// Processing should still continue (error is logged but not fatal)
 	// However, it will fail to create output file due to read-only directory
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	// We expect an error, but it should be about creating the output file, not removing .part
 	assert.Error(t, err)
 }
@@ -1193,7 +1192,7 @@ func TestExecuteDIMPStep_CountResourcesError(t *testing.T) {
 	require.NoError(t, os.WriteFile(outputFile, []byte{0x00, 0x01, 0x02, 0x03}, 0644))
 
 	// Processing should skip this file (already exists)
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	// Should succeed - file is skipped as "already processed"
 	assert.NoError(t, err)
 }
@@ -1226,7 +1225,7 @@ func TestExecuteDIMPStep_ProcessDIMPFileOpenError(t *testing.T) {
 		_ = os.Chmod(inputFile, 0644)
 	}()
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to open")
 }
@@ -1265,7 +1264,7 @@ func TestExecuteDIMPStep_LongLine(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	err = pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err = runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify output file was created
@@ -1296,7 +1295,7 @@ func TestExecuteDIMPStep_StalePartFileRemoval(t *testing.T) {
 	partFile := filepath.Join(pseudonymizedDir, "dimped_patients.ndjson.part")
 	require.NoError(t, os.WriteFile(partFile, []byte("stale data"), 0644))
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Verify .part file was removed
@@ -1327,7 +1326,7 @@ func TestExecuteDIMPStep_NetworkErrorIsTransient(t *testing.T) {
 		{"resourceType": "Patient", "id": "1"},
 	})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 
 	// Find the DIMP step and verify error type is transient
@@ -1371,7 +1370,7 @@ func TestExecuteDIMPStep_GlobPatternError(t *testing.T) {
 	})
 
 	// Execute with the bad directory path - should fail with glob pattern error
-	err := pipeline.ExecuteDIMPStep(job, badDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, badDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "pattern")
 }
@@ -1397,7 +1396,7 @@ func TestExecuteDIMPStep_400BadRequestIsNonTransient(t *testing.T) {
 		{"resourceType": "Patient", "id": "1"},
 	})
 
-	err := pipeline.ExecuteDIMPStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepDIMP, job, tmpDir, logger)
 	assert.Error(t, err)
 
 	// Find the DIMP step and verify error type is non-transient

--- a/tests/unit/pipeline_error_paths_test.go
+++ b/tests/unit/pipeline_error_paths_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 // TestExecuteValidationStep_OutputDirCreationError covers the mkdir failure
@@ -23,7 +23,7 @@ func TestExecuteValidationStep_OutputDirCreationError(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(jobDir, "validation"), []byte("x"), 0644))
 
 	job := createValidationTestJob("http://localhost:9999")
-	err := pipeline.ExecuteValidationStep(job, jobDir, lib.NewLogger(lib.LogLevelError))
+	err := runPipelineStep(models.StepValidation, job, jobDir, lib.NewLogger(lib.LogLevelError))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create output directory")
@@ -37,7 +37,7 @@ func TestExecuteValidationStep_ListInputFilesError(t *testing.T) {
 	require.NoError(t, os.MkdirAll(jobDir, 0755))
 
 	job := createValidationTestJob("http://localhost:9999")
-	err := pipeline.ExecuteValidationStep(job, jobDir, lib.NewLogger(lib.LogLevelError))
+	err := runPipelineStep(models.StepValidation, job, jobDir, lib.NewLogger(lib.LogLevelError))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list input files")
@@ -57,7 +57,7 @@ func TestExecuteFlatteningStep_ListInputFilesError(t *testing.T) {
 	writeTestCRTDL(t, crtdlPath, "group-1", "Patient", "https://example.com/Patient")
 
 	job := createFlatteningTestJob("http://localhost:9999", lookupPath, crtdlPath)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger())
+	err := runPipelineStep(models.StepFlattening, job, jobDir, createFlatteningTestLogger())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list input files")

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -242,7 +242,7 @@ func TestExecuteFlatteningStep_MissingCRTDLPath(t *testing.T) {
 	job.InputType = models.InputTypeHTTP
 	job.CRTDLPath = ""
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger())
+	err := runPipelineStep(models.StepFlattening, job, jobDir, createFlatteningTestLogger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "CRTDL")
 	assert.Contains(t, err.Error(), "--crtdl")
@@ -277,7 +277,7 @@ func TestExecuteFlatteningStep_AcceptsHTTPInputWithCRTDLPath(t *testing.T) {
 	job.InputType = models.InputTypeHTTP
 	// CRTDLPath is set by createFlatteningTestJob via crtdlPath arg
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, createFlatteningTestLogger())
+	err := runPipelineStep(models.StepFlattening, job, jobDir, createFlatteningTestLogger())
 	require.NoError(t, err, "http_import + CRTDLPath must be accepted (issue #286)")
 }
 
@@ -384,7 +384,7 @@ func TestExecuteFlatteningStep_ConfigValidationError(t *testing.T) {
 	}
 
 	logger := createFlatteningTestLogger()
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "service_url is required")
 }
@@ -419,7 +419,7 @@ func TestExecuteFlatteningStep_LookupValidationError(t *testing.T) {
 	job := createFlatteningTestJob("http://localhost:8080", lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err = pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid lookup tables")
 	assert.Contains(t, err.Error(), "duplicate profile URL")
@@ -450,7 +450,7 @@ func TestExecuteFlatteningStep_ViewDefinitionBuildError(t *testing.T) {
 	logger := createFlatteningTestLogger()
 
 	// This should complete without error (group is skipped)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify no CSV files were created (group was skipped)
@@ -483,7 +483,7 @@ func TestExecuteFlatteningStep_NoMatchingResources(t *testing.T) {
 	logger := createFlatteningTestLogger()
 
 	// Should complete without error (no matching resources, group skipped)
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify no CSV files were created (no matching resources)
@@ -513,7 +513,7 @@ func TestExecuteFlatteningStep_ScanProvenanceError(t *testing.T) {
 	job := createFlatteningTestJob("http://localhost:8080", lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load resources")
 }
@@ -546,7 +546,7 @@ func TestExecuteFlatteningStep_OutputDirCreationError(t *testing.T) {
 	job := createFlatteningTestJob("http://localhost:8080", lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create output directory")
 }
@@ -601,7 +601,7 @@ func TestExecuteFlatteningStep_ViewDefinitionWriteError(t *testing.T) {
 	logger := createFlatteningTestLogger()
 
 	// Should complete successfully even though ViewDefinition write fails
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify CSV file was created despite ViewDefinition write failure
@@ -659,7 +659,7 @@ func TestExecuteFlatteningStep_CSVWriteError(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to write CSV for group")
 }
@@ -717,7 +717,7 @@ func TestExecuteFlatteningStep_MultipleBatches(t *testing.T) {
 
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify CSV file was created
@@ -773,7 +773,7 @@ func TestExecuteFlatteningStep_FlattenerError(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "flattener failed for group")
 }
@@ -817,7 +817,7 @@ func TestExecuteFlatteningStep_BundleExtraction(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify CSV was created
@@ -885,7 +885,7 @@ func TestExecuteFlatteningStep_StreamingEdgeCases(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Flattener should be called once (only the valid Bundle entry with provenance)
@@ -967,7 +967,7 @@ func TestExecuteFlatteningStep_BatchFlushOnThreshold(t *testing.T) {
 
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Flattener should be called at least once
@@ -1021,7 +1021,7 @@ func TestExecuteFlatteningStep_NilViewDefSkipped(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// No CSV should be created — ViewDefinition is nil, resource is skipped
@@ -1060,7 +1060,7 @@ func TestExecuteFlatteningStep_BundleEntryUnmatchedProfile(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	csvFiles, _ := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
@@ -1113,7 +1113,7 @@ func TestExecuteFlatteningStep_FlattenerErrorDuringFlush(t *testing.T) {
 		job.Config.Services.Flattening.BatchSizeMB = 1
 		logger := createFlatteningTestLogger()
 
-		err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "flattener failed for group")
 	})
@@ -1144,7 +1144,7 @@ func TestExecuteFlatteningStep_FlattenerErrorDuringFlush(t *testing.T) {
 		job.Config.Services.Flattening.BatchSizeMB = 1
 		logger := createFlatteningTestLogger()
 
-		err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+		err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "flattener failed for group")
 	})
@@ -1183,7 +1183,7 @@ func TestExecuteFlatteningStep_OpenFileError(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load resources")
 }
@@ -1252,7 +1252,7 @@ func TestExecuteFlatteningStep_ProvenanceInPseudonymizedDir(t *testing.T) {
 
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// CSV output should be produced — provenance is in the pseudonymized input
@@ -1288,7 +1288,7 @@ func TestExecuteFlatteningStep_UnknownProfile(t *testing.T) {
 	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 	logger := createFlatteningTestLogger()
 
-	err := pipeline.ExecuteFlatteningStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// No CSV should be written (no matching resources)

--- a/tests/unit/pipeline_seam_test.go
+++ b/tests/unit/pipeline_seam_test.go
@@ -266,6 +266,34 @@ func TestRunLoop_AdvanceErrorSurfaces(t *testing.T) {
 	assert.Equal(t, 0, send.calls, "send must not run when the advance fails")
 }
 
+func TestRunStep_RunsRegisteredStepThroughLifecycle(t *testing.T) {
+	dimp := &seamFakeStep{name: models.StepDIMP, result: pipeline.StepResult{FilesProcessed: 3}}
+	job := seamJobWithSteps(t, []models.StepName{models.StepDIMP},
+		map[models.StepName]pipeline.Step{models.StepDIMP: dimp})
+
+	err := pipeline.RunStep(models.StepDIMP, &pipeline.StepContext{
+		Job: job, Layout: services.NewJobLayoutForDir(t.TempDir(), nil), Logger: seamLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, dimp.calls, "the registered step must run once")
+	s, ok := models.GetStepByName(*job, models.StepDIMP)
+	require.True(t, ok)
+	assert.Equal(t, models.StepStatusCompleted, s.Status, "RunStep drives the full lifecycle to completion")
+}
+
+func TestRunStep_UnknownStepErrors(t *testing.T) {
+	job := seamJobWithSteps(t, []models.StepName{models.StepDIMP},
+		map[models.StepName]pipeline.Step{models.StepDIMP: &seamFakeStep{name: models.StepDIMP}})
+
+	err := pipeline.RunStep(models.StepName("bogus"), &pipeline.StepContext{
+		Job: job, Layout: services.NewJobLayoutForDir(t.TempDir(), nil), Logger: seamLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown step")
+}
+
 func TestStepFor_ResolvesEveryDefaultStep(t *testing.T) {
 	// Override then reset to exercise both SetStepRegistryForTesting and ResetStepRegistry.
 	pipeline.SetStepRegistryForTesting(func(models.StepName) (pipeline.Step, bool) { return nil, false })

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -68,7 +68,7 @@ func TestExecuteSendStep_Success(t *testing.T) {
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// 2 Binary resources + 1 DocumentReference = 3 PUT requests
@@ -173,7 +173,7 @@ func TestExecuteSendStep_ZipContentVerification(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify the captured Binary resource
@@ -224,7 +224,7 @@ func TestExecuteSendStep_ContentTypeMapping(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// 3 Binaries + 1 DocumentReference = 4 requests
@@ -259,7 +259,7 @@ func TestExecuteSendStep_ServerError(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to upload Binary")
 }
@@ -273,7 +273,7 @@ func TestExecuteSendStep_NoFiles(t *testing.T) {
 
 	job := createSendTestJob("http://unused", jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no files found")
 }
@@ -307,7 +307,7 @@ func TestExecuteSendStep_InvalidConfig(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "url is required")
 }
@@ -346,7 +346,7 @@ func TestExecuteSendStep_NotEnabled(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	// Should succeed by skipping (not an error)
 	assert.NoError(t, err)
 }
@@ -364,7 +364,7 @@ func TestExecuteSendStep_InputDirNotExists(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list input files")
 }
@@ -397,7 +397,7 @@ func TestExecuteSendStep_DocumentReferenceUploadError(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to upload DocumentReference")
 }
@@ -430,7 +430,7 @@ func TestExecuteSendStep_JsonFile(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// All files are now zipped - JSON files get application/zip
@@ -480,7 +480,7 @@ func TestExecuteSendStep_AllJsonFilesZipped(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Count Binary resources with application/zip
@@ -518,7 +518,7 @@ func TestExecuteSendStep_SubdirectoryFiles(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Should process 2 files (root.csv + nested.csv) -> 2 Binaries + 1 DocumentReference
@@ -548,7 +548,7 @@ func TestExecuteSendStep_ServerNonRetryableError(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to upload Binary")
 
@@ -587,7 +587,7 @@ func TestExecuteSendStep_UnknownFileExtension(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	var binaryResource map[string]any
@@ -627,7 +627,7 @@ func TestExecuteSendStep_FileReadError(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to process")
 }
@@ -663,7 +663,7 @@ func TestExecuteSendStep_CompressedNdjsonFile(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err = pipeline.ExecuteSendStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify the Binary was created with zip content type
@@ -729,7 +729,7 @@ func TestExecuteSendStep_CompressedJsonFile(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err = pipeline.ExecuteSendStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify the Binary was created
@@ -767,7 +767,7 @@ func TestExecuteSendStep_UnreadableFile(t *testing.T) {
 
 	job := createSendTestJob(server.URL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	// Should fail when trying to read the file to process it
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to process")
@@ -791,7 +791,7 @@ func TestExecuteSendStep_ConnectionRefused(t *testing.T) {
 
 	job := createSendTestJob(unreachableURL, jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to upload Binary")
 
@@ -906,7 +906,7 @@ func TestExecuteSendStep_BasicAuth(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify Basic Auth header was sent
@@ -965,7 +965,7 @@ func TestExecuteSendStep_OAuth2(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify Bearer token was sent
@@ -995,7 +995,7 @@ func TestExecuteSendStep_NoAuth(t *testing.T) {
 	job := createSendTestJobWithAuth(server.URL, jobID, tmpDir, models.AuthConfig{})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// No Authorization header should be sent
@@ -1034,7 +1034,7 @@ func TestExecuteSendStep_OAuth2TokenError(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get OAuth2 token")
 }
@@ -1076,7 +1076,7 @@ func TestExecuteSendStep_OAuth2TokenCaching(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job1, jobDir1, logger)
+	err := runPipelineStep(models.StepSend, job1, jobDir1, logger)
 	require.NoError(t, err)
 
 	firstRequestCount := tokenRequestCount
@@ -1094,7 +1094,7 @@ func TestExecuteSendStep_OAuth2TokenCaching(t *testing.T) {
 		OAuthClientSecret: "test-secret",
 	})
 
-	err = pipeline.ExecuteSendStep(job2, jobDir2, logger)
+	err = runPipelineStep(models.StepSend, job2, jobDir2, logger)
 	require.NoError(t, err)
 
 	// The second execution should not have requested a new token (cached)
@@ -1137,7 +1137,7 @@ func TestExecuteSendStep_OAuth2TokenInvalidJSON(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get OAuth2 token")
 }
@@ -1176,7 +1176,7 @@ func TestExecuteSendStep_OAuth2TokenMissingAccessToken(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get OAuth2 token")
 }
@@ -1216,7 +1216,7 @@ func TestExecuteSendStep_OAuth2TokenShortExpiry(t *testing.T) {
 	})
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// With short-lived token, each PUT request may need a new token
@@ -1270,7 +1270,7 @@ func TestExecuteSendStep_FHIR_Success(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify transaction bundles were sent
@@ -1339,7 +1339,7 @@ func TestExecuteSendStep_FHIR_CoreFilesFirst(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// core file should be processed first
@@ -1385,7 +1385,7 @@ func TestExecuteSendStep_FHIR_CompressedFiles(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err = pipeline.ExecuteSendStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Should have received 2 resources
@@ -1411,7 +1411,7 @@ func TestExecuteSendStep_FHIR_NoFiles(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no NDJSON files found")
 }
@@ -1436,7 +1436,7 @@ func TestExecuteSendStep_FHIR_ServerError(t *testing.T) {
 	job.Config.Retry.MaxAttempts = 1
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to upload")
 
@@ -1471,7 +1471,7 @@ func TestExecuteSendStep_FHIR_BadRequest(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 
 	// Check that step has non-transient error type for 400 errors
@@ -1507,7 +1507,7 @@ func TestExecuteSendStep_FHIR_WithAuth(t *testing.T) {
 	job := createFHIRSendTestJobWithAuth(server.URL, jobID, tmpDir, "fhiruser", "fhirpass")
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify Basic Auth header was sent
@@ -1549,7 +1549,7 @@ func TestExecuteSendStep_FHIR_InvalidConfig(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must use http or https scheme")
 }
@@ -1568,7 +1568,7 @@ func TestExecuteSendStep_FHIR_InputDirNotExists(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list NDJSON files")
 }
@@ -1616,7 +1616,7 @@ func TestExecuteSendStep_FHIR_CoreAndCompressed(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err = pipeline.ExecuteSendStep(job, jobDir, logger)
+	err = runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Core file (even compressed) should be processed first
@@ -1644,7 +1644,7 @@ func TestExecuteSendStep_S3_Success(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Verify files were uploaded
@@ -1692,7 +1692,7 @@ func TestExecuteSendStep_S3_NoFiles(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no files found")
 }
@@ -1716,7 +1716,7 @@ func TestExecuteSendStep_S3_UploadError(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to upload")
 
@@ -1761,7 +1761,7 @@ func TestExecuteSendStep_S3_ManifestRetry(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	// Only the second file should have been uploaded
@@ -1800,7 +1800,7 @@ func TestExecuteSendStep_S3_SubdirectoryFiles(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 
 	assert.Len(t, mock.UploadedKeys, 2)
@@ -1845,7 +1845,7 @@ func TestExecuteSendStep_S3_InvalidConfig(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "bucket is required")
 }
@@ -1869,7 +1869,7 @@ func TestExecuteSendStep_S3_TransientError(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 
 	// Error should be classified as transient
@@ -2024,7 +2024,7 @@ func TestExecuteSendStep_UnknownSendMode(t *testing.T) {
 	}
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	// The validation rejects unknown modes with this message
 	assert.Contains(t, err.Error(), "invalid send send_as")
@@ -2063,7 +2063,7 @@ func TestExecuteSendStep_FHIR_FileOpenError(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to open")
 
@@ -2099,7 +2099,7 @@ func TestExecuteSendStep_FHIR_RetryableServerErrorClassifiedTransient(t *testing
 	job.Config.Retry = models.RetryConfig{MaxAttempts: 2, InitialBackoffMs: 1, MaxBackoffMs: 5}
 
 	logger := lib.NewLogger(lib.LogLevelError)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 
 	var sendStep *models.PipelineStep
@@ -2147,7 +2147,7 @@ func TestExecuteSendStep_FHIR_CloseWarning(t *testing.T) {
 	job := createFHIRSendTestJob(server.URL, jobID, tmpDir)
 
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.NoError(t, err)
 	assert.Equal(t, 1, receivedResources)
 }
@@ -2191,7 +2191,7 @@ func TestExecuteSendStep_S3_UploaderFactoryError(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create S3 uploader")
 }
@@ -2217,7 +2217,7 @@ func TestExecuteSendStep_S3_CorruptedManifest(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	// Should succeed despite the corrupted manifest (starts fresh)
 	require.NoError(t, err)
 	assert.Len(t, mock.UploadedKeys, 1)
@@ -2237,7 +2237,7 @@ func TestExecuteSendStep_S3_NonExistentInputDir(t *testing.T) {
 
 	job := createS3SendTestJob(jobID, tmpDir)
 	logger := lib.NewLogger(lib.LogLevelDebug)
-	err := pipeline.ExecuteSendStep(job, jobDir, logger)
+	err := runPipelineStep(models.StepSend, job, jobDir, logger)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list input files")
 }

--- a/tests/unit/pipeline_validation_test.go
+++ b/tests/unit/pipeline_validation_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
-	"github.com/medizininformatik-initiative/aether/internal/pipeline"
 )
 
 func createValidationTestLogger() *lib.Logger {
@@ -144,7 +143,7 @@ func TestExecuteValidationStep_DisabledStep(t *testing.T) {
 	job.Config.Pipeline.EnabledSteps = []models.StepName{} // not enabled
 	logger := createValidationTestLogger()
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 }
 
@@ -154,7 +153,7 @@ func TestExecuteValidationStep_MissingURL(t *testing.T) {
 	job := createValidationTestJob("") // empty URL
 	logger := createValidationTestLogger()
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "validation service URL not configured")
 }
@@ -170,7 +169,7 @@ func TestExecuteValidationStep_NoFilesFound(t *testing.T) {
 
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "import"), 0755))
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no FHIR NDJSON files found")
 }
@@ -194,7 +193,7 @@ func TestExecuteValidationStep_AllValid(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), patients)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Report file should contain informational OperationOutcome (1 chunk)
@@ -224,7 +223,7 @@ func TestExecuteValidationStep_SomeInvalid(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Condition.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err, "validation findings should not fail the pipeline")
 
 	// Step should be completed, not failed
@@ -291,7 +290,7 @@ func TestExecuteValidationStep_BundleChunking(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// With default 10MB chunk size all 20 tiny resources fit in 1 chunk
@@ -321,7 +320,7 @@ func TestExecuteValidationStep_ResumesProcessing(t *testing.T) {
 	require.NoError(t, os.MkdirAll(validationDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(validationDir, "Patient.validation.ndjson"), []byte{}, 0644))
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Both reports should exist
@@ -373,7 +372,7 @@ func TestExecuteValidationStep_ConcurrencyRespected(t *testing.T) {
 		writeValidationNDJSON(t, filepath.Join(importDir, fmt.Sprintf("Patient%d.ndjson", i)), resources)
 	}
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	assert.LessOrEqual(t, maxConcurrent.Load(), int32(2), "concurrent requests should not exceed MaxConcurrentRequests")
@@ -397,7 +396,7 @@ func TestExecuteValidationStep_HTTPError(t *testing.T) {
 	resources := []map[string]any{{"resourceType": "Patient", "id": "p1"}}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to validate")
 }
@@ -421,7 +420,7 @@ func TestExecuteValidationStep_MultipleFiles(t *testing.T) {
 		{"resourceType": "Condition", "id": "c1"},
 	})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(tmpDir, "validation", "Patient.validation.ndjson"))
@@ -444,7 +443,7 @@ func TestExecuteValidationStep_StepStatusTracking(t *testing.T) {
 		{"resourceType": "Patient", "id": "p1"},
 	})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	require.NoError(t, err)
 
 	var validationStep *models.PipelineStep
@@ -483,7 +482,7 @@ func TestExecuteValidationStep_EmptyLinesInNDJSON(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(filepath.Join(importDir, "Patient.ndjson"), []byte(content), 0644))
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 }
 
@@ -504,7 +503,7 @@ not-valid-json{{{
 `
 	require.NoError(t, os.WriteFile(filepath.Join(importDir, "Patient.ndjson"), []byte(content), 0644))
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to validate")
 }
@@ -524,7 +523,7 @@ func TestExecuteValidationStep_EmptyFile(t *testing.T) {
 	// Write an empty NDJSON file
 	require.NoError(t, os.WriteFile(filepath.Join(importDir, "Empty.ndjson"), []byte(""), 0644))
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Report should exist (empty — created for resumption tracking)
@@ -548,7 +547,7 @@ func TestExecuteValidationStep_DefaultConcurrency(t *testing.T) {
 		{"resourceType": "Patient", "id": "p1"},
 	})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 }
 
@@ -573,7 +572,7 @@ func TestExecuteValidationStep_StalePartFileCleanup(t *testing.T) {
 	stalePartFile := filepath.Join(validationDir, "OldFile.validation.ndjson.part")
 	require.NoError(t, os.WriteFile(stalePartFile, []byte("stale"), 0644))
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// Stale .part file should be removed
@@ -600,7 +599,7 @@ func TestExecuteValidationStep_ErrorOutcomesHaveExpression(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err, "validation findings should not fail the pipeline")
 
 	reportFile := filepath.Join(tmpDir, "validation", "Patient.validation.ndjson")
@@ -657,7 +656,7 @@ func TestExecuteValidationStep_FirstErrBailsEarlyFromChunkLoop(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 
 	// Not all chunks should be dispatched — firstErr should bail early
@@ -700,7 +699,7 @@ func TestExecuteValidationStep_OversizedResource(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err)
 
 	// At least 2 bundles: one for the oversized resource, one for the normal resources
@@ -722,7 +721,7 @@ func TestExecuteValidationStep_ConnectionRefused(t *testing.T) {
 		{"resourceType": "Patient", "id": "p1"},
 	})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to validate")
 }
@@ -748,7 +747,7 @@ func TestExecuteValidationStep_ValidationServiceReturns400(t *testing.T) {
 		{"resourceType": "Patient", "id": "p1"},
 	})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to validate")
 }
@@ -784,7 +783,7 @@ func TestExecuteValidationStep_BundleEntriesHaveFullURL(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Test.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	require.NoError(t, err)
 
 	// Verify the Bundle sent to the validator has fullUrl on all entries
@@ -819,7 +818,7 @@ func TestExecuteValidationStep_FailOnError_StopsPipeline(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Condition.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	require.Error(t, err, "should return error when FailOnError is true and validation finds errors")
 	assert.Contains(t, err.Error(), "fail_on_error")
 
@@ -856,7 +855,7 @@ func TestExecuteValidationStep_FailOnError_ContinuesWhenNoErrors(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.NoError(t, err, "should not error when FailOnError is true but no validation errors found")
 }
 
@@ -902,7 +901,7 @@ func TestExecuteValidationStep_ChunkValidationHTTPError(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Patient.ndjson"), resources)
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to validate")
 }
@@ -955,7 +954,7 @@ func TestExecuteValidationStep_InnerBundleEntriesGetFullURL(t *testing.T) {
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Bundles.ndjson"), []map[string]any{transactionBundle})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	require.NoError(t, err)
 
 	// The outer collection Bundle wraps the transaction Bundle as a single entry
@@ -1026,7 +1025,7 @@ func TestExecuteValidationStep_InnerBundlePreservesExistingFullURL(t *testing.T)
 	}
 	writeValidationNDJSON(t, filepath.Join(importDir, "Bundles.ndjson"), []map[string]any{bundleWithFullURLs})
 
-	err := pipeline.ExecuteValidationStep(job, tmpDir, logger)
+	err := runPipelineStep(models.StepValidation, job, tmpDir, logger)
 	require.NoError(t, err)
 
 	outerEntries := receivedBundle["entry"].([]any)

--- a/tests/unit/step_helpers_test.go
+++ b/tests/unit/step_helpers_test.go
@@ -1,0 +1,28 @@
+package unit
+
+import (
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// runPipelineStep drives one pipeline step through the exported RunStep seam for
+// black-box tests that previously called a per-step Execute*Step wrapper.
+func runPipelineStep(name models.StepName, job *models.PipelineJob, jobDir string, logger *lib.Logger) error {
+	return pipeline.RunStep(name, &pipeline.StepContext{Job: job, Layout: services.NewJobLayoutForDir(jobDir, job.Config.Pipeline.EnabledSteps), Logger: logger})
+}
+
+// runImportStep drives the import step through RunStep, selecting the import
+// variant from job.CurrentStep and returning the (in-place mutated) job to match
+// the shape black-box import tests expect.
+func runImportStep(job *models.PipelineJob, logger *lib.Logger, httpClient *services.HTTPClient, showProgress bool) (*models.PipelineJob, error) {
+	err := pipeline.RunStep(models.StepName(job.CurrentStep), &pipeline.StepContext{
+		Job:          job,
+		Layout:       services.NewJobLayout(job.Config.JobsDir, job.JobID, job.Config.Pipeline.EnabledSteps),
+		Logger:       logger,
+		HTTPClient:   httpClient,
+		ShowProgress: showProgress,
+	})
+	return job, err
+}


### PR DESCRIPTION
## What

Follow-up to #427. Replaces the five per-step `Execute*Step` wrappers with one exported `pipeline.RunStep(name, ctx) error` that resolves the step via the registry and drives it through the shared `runStep` lifecycle.

## Changes

- **New seam**: `pipeline.RunStep` (`internal/pipeline/step.go`) — the single exported entrypoint for running one step.
- **Deleted** `ExecuteImportStep`, `ExecuteDIMPStep`, `ExecuteSendStep`, `ExecuteFlatteningStep`, `ExecuteValidationStep`.
- **Folded** the manual `aether job run --step` path (`executeStepManually`) into `RunStep`, removing its divergence from `RunLoop`: `validation` is no longer stubbed as "not yet implemented", and `send`/`flattening` are now runnable manually. `validateStepName` and the command help were updated accordingly (`wait` deliberately stays out — single-step manual wait is nonsensical). Job-level failure is recorded via `FailJob`, matching `RunLoop`.
- **Kept** `StepFor` as the raw-`Step` registry accessor (used by tests that call `Run` in isolation); re-documented alongside `RunStep`.
- **Migrated** ~230 black-box test call sites to `runPipelineStep` / `runImportStep` helpers.
- The import wrapper's `models.AddError`-on-failure was a test-only artifact (production `cmd` discarded it before saving); the one test that relied on persisted job-level error state (`TestPipelineImportError_StatePersistence`) now records it via `FailJob`, matching production. The defensive `importStep.Run` name-mismatch branch, previously reachable only through the wrapper, is now covered by a white-box test (`import_unsupported_test.go`).

## Behavior

No change to the automatic pipeline (`RunLoop`). The only behavior change is the approved CLI fold: `job run --step {validation,flattening,send}` now works.

Closes #516
