### PR TITLE
feat(pipeline): guard import steps against mismatched input types

### DIFF
--- a/cmd/import_step_parity_test.go
+++ b/cmd/import_step_parity_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+	"github.com/medizininformatik-initiative/aether/internal/services/servicestest"
+)
+
+// TestValidateImportStepMatchesInput_TorchAcceptsLocalDefault verifies that a
+// standard torch-via-CRTDL job (InputType=Local, no external source) is accepted
+// by `aether job run --step torch`, not rejected as a mismatch.
+func TestValidateImportStepMatchesInput_TorchAcceptsLocalDefault(t *testing.T) {
+	job := &models.PipelineJob{InputType: models.InputTypeLocal}
+	assert.NoError(t, validateImportStepMatchesInput(job, models.StepTorchImport))
+}
+
+// TestValidateImportStepMatchesInput_RejectsUnacceptedType covers the manual
+// --step guard for a step that cannot handle the job's input type.
+func TestValidateImportStepMatchesInput_RejectsUnacceptedType(t *testing.T) {
+	job := &models.PipelineJob{InputType: models.InputTypeLocal}
+	err := validateImportStepMatchesInput(job, models.StepHttpImport)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not accept input type")
+}
+
+// TestExecuteStepManually_RejectsMismatchedImportStep proves the manual
+// `job run --step http_import` path rejects an input type the step cannot handle
+// before any service call, returning the shared parity error.
+func TestExecuteStepManually_RejectsMismatchedImportStep(t *testing.T) {
+	jobsDir := t.TempDir()
+	steps := []models.StepName{models.StepHttpImport, models.StepDIMP}
+	config := &models.ProjectConfig{
+		JobsDir:  jobsDir,
+		Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100},
+	}
+	job := &models.PipelineJob{
+		JobID:       "550e8400-e29b-41d4-a716-446655440000",
+		Status:      models.JobStatusInProgress,
+		InputSource: "/local/path",
+		InputType:   models.InputTypeLocal,
+		CurrentStep: string(models.StepHttpImport),
+		Steps:       models.InitializeSteps(steps),
+		Config:      *config,
+	}
+
+	err := executeStepManually(job, models.StepHttpImport, config, lib.NewLogger(lib.LogLevelError))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not accept input type")
+}
+
+// TestExecuteStepManually_TorchStepRunsOnLocalDefaultJob drives the manual path:
+// `aether job run --step torch` on a standard torch job (InputType=Local, CRTDL
+// attached, no external source) clears the parity guard and runs the TORCH
+// import through to completion.
+func TestExecuteStepManually_TorchStepRunsOnLocalDefaultJob(t *testing.T) {
+	jobsDir := t.TempDir()
+	jobID := "550e8400-e29b-41d4-a716-446655440000"
+	require.NoError(t, os.MkdirAll(filepath.Join(jobsDir, jobID), 0o755))
+
+	crtdlPath := filepath.Join(jobsDir, jobID, "crtdl.json")
+	require.NoError(t, os.WriteFile(crtdlPath, []byte(`{"resourceType":"Parameters"}`), 0o644))
+
+	fake := &servicestest.MockExtractor{
+		SubmitFunc: func(string) (string, error) { return "http://torch/fhir/__status/job-1", nil },
+		PollFunc:   func(string, bool) ([]string, error) { return []string{"http://torch/out-1.ndjson"}, nil },
+		DownloadFunc: func([]string, string, bool, bool, string) ([]models.FHIRDataFile, error) {
+			return []models.FHIRDataFile{{FileName: "out-1.ndjson", FileSize: 42}}, nil
+		},
+	}
+	pipeline.SetExtractorFactoryForTesting(func(models.TORCHConfig, *services.HTTPClient, *lib.Logger) services.Extractor {
+		return fake
+	})
+	defer pipeline.ResetExtractorFactory()
+
+	steps := []models.StepName{models.StepTorchImport}
+	config := &models.ProjectConfig{
+		JobsDir:  jobsDir,
+		Pipeline: models.PipelineConfig{EnabledSteps: steps},
+		Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100},
+	}
+	job := &models.PipelineJob{
+		JobID:       jobID,
+		Status:      models.JobStatusInProgress,
+		InputType:   models.InputTypeLocal,
+		CRTDLPath:   crtdlPath,
+		CurrentStep: string(models.StepTorchImport),
+		Steps:       models.InitializeSteps(steps),
+		Config:      *config,
+	}
+
+	err := executeStepManually(job, models.StepTorchImport, config, lib.NewLogger(lib.LogLevelError))
+
+	require.NoError(t, err)
+	s, ok := models.GetStepByName(*job, models.StepTorchImport)
+	require.True(t, ok)
+	assert.Equal(t, models.StepStatusCompleted, s.Status)
+}

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -387,23 +387,13 @@ func isImportStep(stepName models.StepName) bool {
 	}
 }
 
-// validateImportStepMatchesInput rejects an import step name that does not match
-// the job's input type (e.g. requesting torch import for a local-directory job).
+// validateImportStepMatchesInput rejects a manual --step import request whose
+// step cannot handle the job's input type (e.g. http_import for a local job). It
+// shares models.ImportStepAcceptsInputType with the RunLoop guard and job
+// creation so all three paths agree on the mapping.
 func validateImportStepMatchesInput(job *models.PipelineJob, stepName models.StepName) error {
-	var expectedStep models.StepName
-	switch job.InputType {
-	case models.InputTypeCRTDL, models.InputTypeTORCHURL:
-		expectedStep = models.StepTorchImport
-	case models.InputTypeLocal:
-		expectedStep = models.StepLocalImport
-	case models.InputTypeHTTP:
-		expectedStep = models.StepHttpImport
-	default:
-		return fmt.Errorf("unknown input type: %s", job.InputType)
-	}
-
-	if stepName != expectedStep {
-		return fmt.Errorf("step '%s' does not match input type %s (expected '%s')", stepName, job.InputType, expectedStep)
+	if !models.ImportStepAcceptsInputType(stepName, job.InputType) {
+		return fmt.Errorf("import step %q does not accept input type %q (accepts %v)", stepName, job.InputType, models.AcceptedInputTypes(stepName))
 	}
 	return nil
 }

--- a/internal/models/step.go
+++ b/internal/models/step.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -73,6 +74,31 @@ func IsValidStepName(name StepName) bool {
 	default:
 		return false
 	}
+}
+
+// AcceptedInputTypes returns the input types an import step can handle, or nil
+// when the step is not an import step. The import method is selected by step
+// name, so this expresses which sources each method understands. InputTypeLocal
+// is the CRTDL-submission default for torch, hence it is accepted by both torch
+// and local_import.
+func AcceptedInputTypes(step StepName) []InputType {
+	switch step {
+	case StepTorchImport:
+		return []InputType{InputTypeLocal, InputTypeCRTDL, InputTypeTORCHURL}
+	case StepLocalImport:
+		return []InputType{InputTypeLocal}
+	case StepHttpImport:
+		return []InputType{InputTypeHTTP}
+	default:
+		return nil
+	}
+}
+
+// ImportStepAcceptsInputType reports whether the import step can handle the
+// given input type. It is the single parity check shared by the RunLoop/continue
+// resume path, the manual --step path, and job creation.
+func ImportStepAcceptsInputType(step StepName, inputType InputType) bool {
+	return slices.Contains(AcceptedInputTypes(step), inputType)
 }
 
 // IsValidStepStatus checks if the step status is recognized

--- a/internal/pipeline/import.go
+++ b/internal/pipeline/import.go
@@ -51,6 +51,18 @@ func (s importStep) Run(ctx *StepContext) (StepResult, error) {
 	logger := ctx.Logger
 	currentStep := s.name
 
+	// The import method is chosen by step name; the job's input type must be one
+	// the method can handle. Nothing on the RunLoop/continue path cross-checks the
+	// two (CreateJob picks the step from config, the input type from the source),
+	// so without this guard a mismatch surfaces as a confusing downstream error.
+	accepted := models.AcceptedInputTypes(currentStep)
+	if len(accepted) == 0 {
+		return StepResult{}, fmt.Errorf("unsupported import step: %s", currentStep)
+	}
+	if !models.ImportStepAcceptsInputType(currentStep, job.InputType) {
+		return StepResult{}, fmt.Errorf("import step %q does not accept input type %q (accepts %v)", currentStep, job.InputType, accepted)
+	}
+
 	httpClient := ctx.HTTPClient
 	if httpClient == nil {
 		httpClient = services.NewHTTPClient(
@@ -104,9 +116,6 @@ func (s importStep) Run(ctx *StepContext) (StepResult, error) {
 			logger.Info("Extracting data from TORCH using CRTDL", "crtdl", job.CRTDLPath, "compress", compress)
 			importedFiles, err = executeTORCHExtraction(job, importDir, httpClient, logger, ctx.ShowProgress, compress, compressionLevel)
 		}
-
-	default:
-		return StepResult{}, fmt.Errorf("unsupported import step: %s", currentStep)
 	}
 
 	if err != nil {

--- a/internal/pipeline/job.go
+++ b/internal/pipeline/job.go
@@ -72,6 +72,14 @@ func CreateJob(jobID string, inputSource string, crtdlPath string, config models
 
 	logger.Info("Determined initial step from config", "step", initialStep)
 
+	// Reject a provided source whose detected type the enabled import step cannot
+	// handle, so a mismatched job is never created. An empty source is the torch/
+	// local default placeholder, not a user-chosen type, so it is not cross-checked
+	// here; the import step's own validation reports a missing source clearly.
+	if inputSource != "" && !models.ImportStepAcceptsInputType(initialStep, inputType) {
+		return nil, fmt.Errorf("input %q was detected as %s, which the enabled import step %q does not accept (accepts %v)", inputSource, inputType, initialStep, models.AcceptedInputTypes(initialStep))
+	}
+
 	// Initialize steps from config
 	steps := models.InitializeSteps(config.Pipeline.EnabledSteps)
 

--- a/tests/unit/import_input_type_test.go
+++ b/tests/unit/import_input_type_test.go
@@ -1,0 +1,106 @@
+package unit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/pipeline"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// TestImportStepAcceptsInputType pins the step-centric parity mapping: the
+// import method is chosen by step name, and each method only handles a subset of
+// input types. InputTypeLocal is deliberately accepted by both torch (its
+// CRTDL-submission default) and local_import.
+func TestImportStepAcceptsInputType(t *testing.T) {
+	cases := []struct {
+		step   models.StepName
+		input  models.InputType
+		accept bool
+	}{
+		{models.StepTorchImport, models.InputTypeLocal, true},
+		{models.StepTorchImport, models.InputTypeCRTDL, true},
+		{models.StepTorchImport, models.InputTypeTORCHURL, true},
+		{models.StepTorchImport, models.InputTypeHTTP, false},
+
+		{models.StepLocalImport, models.InputTypeLocal, true},
+		{models.StepLocalImport, models.InputTypeHTTP, false},
+		{models.StepLocalImport, models.InputTypeCRTDL, false},
+		{models.StepLocalImport, models.InputTypeTORCHURL, false},
+
+		{models.StepHttpImport, models.InputTypeHTTP, true},
+		{models.StepHttpImport, models.InputTypeLocal, false},
+		{models.StepHttpImport, models.InputTypeCRTDL, false},
+
+		{models.StepDIMP, models.InputTypeLocal, false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.accept, models.ImportStepAcceptsInputType(tc.step, tc.input),
+			"step %s accepts input type %s", tc.step, tc.input)
+	}
+}
+
+// TestImportStep_RejectsInputTypeStepDoesNotAccept guards the resume/RunLoop
+// path: an http_import step running against a Local job (the mismatch nothing
+// else cross-checks) must fail up front with a clear parity error, not the
+// confusing downstream "unsupported protocol" error from attempting to download
+// a local path.
+func TestImportStep_RejectsInputTypeStepDoesNotAccept(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 500, MaxBackoffMs: 5000}, models.TLSConfig{}, logger)
+
+	job := &models.PipelineJob{
+		JobID:       "test-job-123",
+		InputSource: "/local/path",
+		InputType:   models.InputTypeLocal,
+		CurrentStep: string(models.StepHttpImport),
+		Status:      models.JobStatusPending,
+		Steps:       models.InitializeSteps([]models.StepName{models.StepHttpImport}),
+		Config: models.ProjectConfig{
+			JobsDir:  t.TempDir(),
+			Pipeline: models.PipelineConfig{EnabledSteps: []models.StepName{models.StepHttpImport}},
+			Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 500, MaxBackoffMs: 5000},
+		},
+	}
+
+	_, err := runImportStep(job, logger, httpClient, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not accept input type")
+}
+
+// TestCreateJob_RejectsSourceStepCannotAccept guards creation: a provided source
+// whose detected input type the enabled import step cannot handle (here a local
+// directory with http_import enabled) is rejected up front, so a mismatched job
+// is never created.
+func TestCreateJob_RejectsSourceStepCannotAccept(t *testing.T) {
+	jobsDir := t.TempDir()
+	srcDir := t.TempDir() // a real directory → detected as InputTypeLocal
+
+	config := models.ProjectConfig{
+		JobsDir:  jobsDir,
+		Pipeline: models.PipelineConfig{EnabledSteps: []models.StepName{models.StepHttpImport, models.StepDIMP}},
+		Retry:    models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 10, MaxBackoffMs: 100},
+	}
+
+	_, err := pipeline.CreateJob(models.GenerateJobID(), srcDir, "", config, lib.NewLogger(lib.LogLevelError))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not accept")
+}
+
+// TestAcceptedInputTypes reports nil for a non-import step so callers can detect
+// an unsupported import step name.
+func TestAcceptedInputTypes(t *testing.T) {
+	assert.Equal(t,
+		[]models.InputType{models.InputTypeLocal, models.InputTypeCRTDL, models.InputTypeTORCHURL},
+		models.AcceptedInputTypes(models.StepTorchImport))
+	assert.Equal(t, []models.InputType{models.InputTypeLocal}, models.AcceptedInputTypes(models.StepLocalImport))
+	assert.Equal(t, []models.InputType{models.InputTypeHTTP}, models.AcceptedInputTypes(models.StepHttpImport))
+	assert.Nil(t, models.AcceptedInputTypes(models.StepDIMP))
+}

--- a/tests/unit/import_step_test.go
+++ b/tests/unit/import_step_test.go
@@ -66,8 +66,9 @@ func TestClassifyImportError_NilError(t *testing.T) {
 	t.Skip("classifyImportError is not exported - covered by integration tests")
 }
 
-// TestExecuteImportStep_HttpImportValidationFailure tests error handling when HTTP import has invalid URL
-// Covers import.go lines 55-59 (validation path) and download error handling
+// TestExecuteImportStep_HttpImportValidationFailure tests download error handling
+// when http_import is given a source that is not a real HTTP URL. The input type
+// matches the step (so it clears the parity guard); the download itself fails.
 func TestExecuteImportStep_HttpImportValidationFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	logger := lib.NewLogger(lib.LogLevelInfo)
@@ -79,11 +80,12 @@ func TestExecuteImportStep_HttpImportValidationFailure(t *testing.T) {
 	}
 	httpClient := services.NewHTTPClient(5*time.Second, retryConfig, models.TLSConfig{}, logger)
 
-	// Create a job with http_import step but invalid (non-HTTP) input source
+	// http_import job whose source is not a real URL. ValidateImportSource only
+	// rejects an empty URL, so this reaches the download and fails there.
 	job := &models.PipelineJob{
 		JobID:       "test-job-123",
 		InputSource: "/local/path", // Not an HTTP URL
-		InputType:   models.InputTypeLocal,
+		InputType:   models.InputTypeHTTP,
 		CurrentStep: string(models.StepHttpImport),
 		Status:      models.JobStatusPending,
 		Steps:       models.InitializeSteps([]models.StepName{models.StepHttpImport}),
@@ -224,9 +226,10 @@ func TestExecuteImportStep_TorchImportTORCHURLValidationFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "must start with http", "Error should mention HTTP requirement")
 }
 
-// TestExecuteImportStep_TorchImportInvalidInputType tests error handling when torch import has invalid input type
-// Covers import.go lines 93-94
-func TestExecuteImportStep_TorchImportInvalidInputType(t *testing.T) {
+// TestExecuteImportStep_TorchImportEmptyCRTDL covers the inner CRTDL validation
+// branch: torch accepts InputType=Local (its CRTDL-submission default), so the
+// step clears the parity guard and then rejects the empty CRTDL path.
+func TestExecuteImportStep_TorchImportEmptyCRTDL(t *testing.T) {
 	tmpDir := t.TempDir()
 	logger := lib.NewLogger(lib.LogLevelInfo)
 


### PR DESCRIPTION
## Summary

Adds a step-centric import-step / input-type parity guard.

The import method is chosen by pipeline **step name**; each method only handles a subset of `InputType`s. Nothing cross-checked the two on the RunLoop / `pipeline continue` resume path, so a mismatch surfaced as a confusing downstream error rather than a clear one.

## Key finding

The issue's original blueprint assumed `InputType → import-step` is a function. It isn't: `InputTypeLocal` is the CRTDL-submission **default** for standard torch jobs (`pipeline start cfg query.crtdl` with no source → `InputType=Local`), so `Local` is legitimately accepted by **both** `torch` and `local_import`. A naive `Local → local_import` guard would have broken every standard torch job — and the pre-existing manual `--step` check already carried that latent bug (it would wrongly reject `--step torch` on a torch job). The guard is therefore modelled step-centrically: each import step accepts a set of input types (strict sets: `torch = {local, crtdl, torch_url}`, `local_import = {local}`, `http_import = {http}`).

## Change

A single mapping (`models.AcceptedInputTypes` / `models.ImportStepAcceptsInputType`) enforced by three sites that now share it:

- `importStep.Run` — RunLoop start **and** `pipeline continue` resume.
- `executeStepManually` — manual `--step`, fixing the latent torch rejection.
- `CreateJob` — rejects a provided source whose detected type the enabled import step cannot accept; an empty source is the torch/local default and is left to the step's own validation.

## Tests

- `models` mapping matrix across the step/input-type combinations.
- `importStep.Run` rejects `http_import` + Local; torch + Local still runs to completion.
- Manual `--step`: torch accepts the Local default (end-to-end via a fake extractor); a mismatched step is rejected before any service call.
- `CreateJob` rejects a local-directory source with `http_import` enabled.

Closes #515
