### PR TITLE
fix(torch): stall-bounded download client for large extractions

### DIFF
--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -36,6 +36,14 @@ services:
     # Default: PT10S
     # file_ready_interval: PT10S
 
+    # Inactivity window when streaming an extraction file to disk. The download
+    # aborts only if NO bytes arrive for this long, so a large but steadily
+    # progressing NDJSON completes regardless of total size, while a hung
+    # connection fails fast. Unlike a whole-request deadline, it never needs to
+    # be sized to the largest expected download.
+    # Default: PT1M
+    # download_stall_timeout: PT1M
+
   # DIMP Pseudonymization Service (optional)
   # Leave empty to skip pseudonymization step
   # URL must be the server root; aether appends /fhir internally.

--- a/docs/adr/0001-extraction-timeout-liveness.md
+++ b/docs/adr/0001-extraction-timeout-liveness.md
@@ -25,3 +25,22 @@ contact with TORCH**, reset on every `202`/`200` poll response. A healthy job (p
 
 - A TORCH job that stays responsive (`202`) but never completes will be polled indefinitely until
   manually interrupted. Accepted as a TORCH-side fault, not aether's to bound.
+
+## Applied again: `download_stall_timeout` (#530)
+
+The same liveness principle governs the NDJSON *download*, for the same reason. Downloads shared
+the HTTP client's 30 s whole-request timeout, which capped the entire body read — so any extraction
+that could not stream within 30 s was impossible to import. A healthy but large download was killed
+for being large: exactly the failure this ADR rejects for polling, one layer down at the byte
+stream.
+
+Downloads now use a dedicated client with no whole-request deadline (`Timeout: 0`); a
+`download_stall_timeout` (default `PT1M`) bounds *inactivity* instead, re-armed on every read of the
+response body. A large but progressing download completes regardless of size, while a connection
+that goes silent fails fast with a clear "download stalled" error. This mirrors the polling liveness
+window (reset on each `202`/`200`) at the download stream.
+
+- The stall window spans each body read together with the write of the chunk that read returned, so
+  it bounds read+write inactivity, not a pure network stall. At the default 60 s the distinction is
+  academic (a 32 KiB chunk write never approaches it); keeping the write inside the window also means
+  a wedged local disk cannot hang the download forever, which narrowing to read-only would give up.

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -81,6 +81,12 @@ type TORCHConfig struct {
 	MaxPollingInterval time.Duration `yaml:"max_polling_interval" json:"max_polling_interval" mapstructure:"max_polling_interval"`
 	FileReadyRetries   int           `yaml:"file_ready_retries" json:"file_ready_retries" mapstructure:"file_ready_retries"`
 	FileReadyInterval  time.Duration `yaml:"file_ready_interval" json:"file_ready_interval" mapstructure:"file_ready_interval"`
+	// DownloadStallTimeout bounds inactivity while streaming an extraction file:
+	// the download aborts only when no bytes arrive for this long, so a large but
+	// steadily-progressing NDJSON finishes regardless of total size, while a hung
+	// connection fails fast. Unlike a whole-request deadline, it never has to be
+	// sized to the largest expected download.
+	DownloadStallTimeout time.Duration `yaml:"download_stall_timeout" json:"download_stall_timeout" mapstructure:"download_stall_timeout"`
 }
 
 // SendMode defines the mode for sending data
@@ -339,14 +345,15 @@ func DefaultConfig() ProjectConfig {
 				BundleSplitThresholdMB: 10, // 10MB default threshold for Bundle splitting
 			},
 			TORCH: TORCHConfig{
-				BaseURL:            "",
-				Username:           "",
-				Password:           "",
-				ExtractionTimeout:  30 * time.Minute,
-				PollingInterval:    5 * time.Second,
-				MaxPollingInterval: 30 * time.Second,
-				FileReadyRetries:   10,
-				FileReadyInterval:  10 * time.Second,
+				BaseURL:              "",
+				Username:             "",
+				Password:             "",
+				ExtractionTimeout:    30 * time.Minute,
+				PollingInterval:      5 * time.Second,
+				MaxPollingInterval:   30 * time.Second,
+				FileReadyRetries:     10,
+				FileReadyInterval:    10 * time.Second,
+				DownloadStallTimeout: 60 * time.Second,
 			},
 			Flattening:         DefaultFlatteningConfig(),
 			CRTDLPreprocessing: DefaultCRTDLPreprocessingConfig(),
@@ -408,6 +415,12 @@ func (c *TORCHConfig) Validate() error {
 
 	if c.FileReadyInterval < 0 {
 		return fmt.Errorf("file_ready_interval must be >= 0, got %s", c.FileReadyInterval)
+	}
+
+	// A negative window is nonsensical; zero means "use the built-in default"
+	// (applied when the TORCH client is constructed), mirroring file_ready_interval.
+	if c.DownloadStallTimeout < 0 {
+		return fmt.Errorf("download_stall_timeout must be >= 0, got %s", c.DownloadStallTimeout)
 	}
 
 	return nil

--- a/internal/services/httpclient.go
+++ b/internal/services/httpclient.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -39,6 +40,37 @@ func NewHTTPClient(timeout time.Duration, retryConfig models.RetryConfig, tlsCon
 		retryConfig: lib.NewRetryConfigFromModel(retryConfig),
 		logger:      logger,
 	}
+}
+
+// newDownloadClient returns an *http.Client tuned for streaming large response
+// bodies. It drops the whole-request deadline (Timeout: 0) so a big but
+// steadily-progressing download is never cut off mid-body, reuses this client's
+// TLS settings by cloning its transport, and bounds the header phase with
+// ResponseHeaderTimeout. Body-phase stall detection is the caller's job, since
+// no transport setting bounds an in-flight body read.
+func (c *HTTPClient) newDownloadClient(stallTimeout time.Duration) *http.Client {
+	var transport *http.Transport
+	if t, ok := c.client.Transport.(*http.Transport); ok && t != nil {
+		transport = t.Clone()
+	} else if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = dt.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.ResponseHeaderTimeout = stallTimeout
+
+	// With Timeout: 0 and the body stall watchdog armed only after headers
+	// arrive, nothing else bounds the connect and TLS-handshake phases. A custom
+	// TLS transport (BuildTLSTransport) ships without a dialer, so a black-holed
+	// connect would hang forever; bound both phases when unset.
+	if transport.DialContext == nil {
+		transport.DialContext = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+	}
+	if transport.TLSHandshakeTimeout == 0 {
+		transport.TLSHandshakeTimeout = 10 * time.Second
+	}
+
+	return &http.Client{Timeout: 0, Transport: transport}
 }
 
 // DefaultHTTPClient creates an HTTP client with sensible defaults (no custom TLS).

--- a/internal/services/torch_client.go
+++ b/internal/services/torch_client.go
@@ -1,8 +1,10 @@
 package services
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,8 +25,17 @@ import (
 type TORCHClient struct {
 	config     models.TORCHConfig
 	httpClient *HTTPClient
-	logger     *lib.Logger
+	// downloadClient streams extraction files without a whole-request deadline;
+	// stallTimeout bounds inactivity during that stream. Submit/poll/availability
+	// keep using httpClient, whose short timeout suits their small payloads.
+	downloadClient *http.Client
+	stallTimeout   time.Duration
+	logger         *lib.Logger
 }
+
+// defaultDownloadStallTimeout applies when TORCHConfig.DownloadStallTimeout is
+// unset (e.g. a client built directly in tests), keeping downloads bounded.
+const defaultDownloadStallTimeout = 60 * time.Second
 
 // TORCHExtractionRequest represents the FHIR Parameters resource for extraction submission
 type TORCHExtractionRequest struct {
@@ -112,10 +123,17 @@ var ErrInvalidCRTDL = fmt.Errorf("invalid CRTDL file")
 
 // NewTORCHClient creates a new TORCH client with the given configuration
 func NewTORCHClient(config models.TORCHConfig, httpClient *HTTPClient, logger *lib.Logger) *TORCHClient {
+	stallTimeout := config.DownloadStallTimeout
+	if stallTimeout <= 0 {
+		stallTimeout = defaultDownloadStallTimeout
+	}
+
 	return &TORCHClient{
-		config:     config,
-		httpClient: httpClient,
-		logger:     logger,
+		config:         config,
+		httpClient:     httpClient,
+		downloadClient: httpClient.newDownloadClient(stallTimeout),
+		stallTimeout:   stallTimeout,
+		logger:         logger,
 	}
 }
 
@@ -516,9 +534,64 @@ func (c *TORCHClient) DownloadExtractionFiles(fileURLs []string, destinationDir 
 	return downloadedFiles, nil
 }
 
-// downloadFile downloads a single file from URL to destination path
+// errDownloadStalled marks a download aborted because no bytes arrived within
+// the stall window, so the failure can be reported clearly rather than as a
+// generic "context canceled".
+var errDownloadStalled = errors.New("download stalled: no data received within stall timeout")
+
+// stallGuardReader arms an inactivity watchdog before each read of the wrapped
+// body. A read that blocks longer than the stall window lets the watchdog fire
+// and cancel the request context, which unblocks the read with an error. This
+// is what bounds a mid-body stall; no http.Transport setting does.
+type stallGuardReader struct {
+	body  io.Reader
+	timer *time.Timer
+	stall time.Duration
+}
+
+func (s *stallGuardReader) Read(p []byte) (int, error) {
+	s.timer.Reset(s.stall)
+	return s.body.Read(p)
+}
+
+// downloadFile downloads a single file, retrying transient failures. The file
+// GET is idempotent, so a fresh attempt is safe; a stall or mid-body write error
+// is not a *TORCHError and so is not retried (retrying from scratch would repeat
+// the stall or waste a full re-transfer). Retry cadence follows the shared
+// client's config.
 func (c *TORCHClient) downloadFile(fileURL, destPath string, compress bool, compressionLevel string) (models.FHIRDataFile, error) {
-	req, err := http.NewRequest("GET", fileURL, nil)
+	retry := c.httpClient.retryConfig
+	attempts := retry.MaxAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		file, err := c.downloadFileOnce(fileURL, destPath, compress, compressionLevel)
+		if err == nil {
+			return file, nil
+		}
+		lastErr = err
+
+		var torchErr *TORCHError
+		if !errors.As(err, &torchErr) || !torchErr.IsRetryable() || attempt == attempts-1 {
+			return models.FHIRDataFile{}, err
+		}
+
+		c.logger.Warn("TORCH download attempt failed, retrying", "url", fileURL, "attempt", attempt+1, "error", err)
+		time.Sleep(lib.CalculateBackoff(attempt, retry.InitialBackoffMs, retry.MaxBackoffMs))
+	}
+	return models.FHIRDataFile{}, lastErr
+}
+
+// downloadFileOnce performs a single download attempt from URL to destination path.
+func (c *TORCHClient) downloadFileOnce(fileURL, destPath string, compress bool, compressionLevel string) (models.FHIRDataFile, error) {
+	// The stall watchdog aborts the download by cancelling this context.
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil)
 	if err != nil {
 		return models.FHIRDataFile{}, fmt.Errorf("failed to create download request: %w", err)
 	}
@@ -528,7 +601,7 @@ func (c *TORCHClient) downloadFile(fileURL, destPath string, compress bool, comp
 	}
 	req.Header.Set("Accept", "application/fhir+ndjson")
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.downloadClient.Do(req)
 	if err != nil {
 		return models.FHIRDataFile{}, &TORCHError{
 			Operation:  "download",
@@ -539,8 +612,16 @@ func (c *TORCHClient) downloadFile(fileURL, destPath string, compress bool, comp
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// Arm the inactivity watchdog before touching the body — downloadClient has
+	// no whole-request deadline, so an error body that stalls mid-stream (a
+	// proxy that flushes 4xx/5xx headers then goes silent) must be bounded too,
+	// not just the success copy. Each read of guardedBody re-arms the timer.
+	timer := time.AfterFunc(c.stallTimeout, func() { cancel(errDownloadStalled) })
+	defer timer.Stop()
+	guardedBody := &stallGuardReader{body: resp.Body, timer: timer, stall: c.stallTimeout}
+
 	if resp.StatusCode >= 400 {
-		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyBytes, _ := io.ReadAll(guardedBody)
 		errorType := lib.ClassifyHTTPError(resp.StatusCode)
 
 		return models.FHIRDataFile{}, &TORCHError{
@@ -566,7 +647,7 @@ func (c *TORCHClient) downloadFile(fileURL, destPath string, compress bool, comp
 		writer = compWriter
 	}
 
-	bytesWritten, err := io.Copy(writer, resp.Body)
+	bytesWritten, err := io.Copy(writer, guardedBody)
 
 	if closeErr := writer.Close(); closeErr != nil && err == nil {
 		err = closeErr
@@ -578,6 +659,11 @@ func (c *TORCHClient) downloadFile(fileURL, destPath string, compress bool, comp
 	}
 
 	if err != nil {
+		// A cancelled context surfaces from io.Copy as a generic error; recover the
+		// stall cause so the caller sees why the download aborted.
+		if cause := context.Cause(ctx); errors.Is(cause, errDownloadStalled) {
+			err = cause
+		}
 		_ = os.Remove(destPath)
 		return models.FHIRDataFile{}, fmt.Errorf("failed to write file: %w", err)
 	}

--- a/internal/services/torch_client_internal_test.go
+++ b/internal/services/torch_client_internal_test.go
@@ -1,12 +1,44 @@
 package services
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
 )
+
+// The streaming download client drops the whole-request deadline, so the
+// connect and TLS-handshake phases (not covered by ResponseHeaderTimeout or the
+// body stall watchdog) must still be bounded — otherwise a black-holed TCP
+// connect on a custom-TLS transport would hang forever. Custom-TLS transports
+// (BuildTLSTransport) ship without a dialer, so this guards that path.
+func TestNewDownloadClient_BoundsConnectAndHandshake(t *testing.T) {
+	logger := lib.NewLogger(lib.LogLevelError)
+
+	cases := map[string]models.TLSConfig{
+		"default transport":    {},
+		"custom TLS transport": {InsecureSkipVerify: true},
+	}
+
+	for name, tlsCfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			shared := NewHTTPClient(30, models.RetryConfig{MaxAttempts: 1}, tlsCfg, logger)
+
+			dl := shared.newDownloadClient(60)
+
+			assert.Zero(t, dl.Timeout, "download client must not carry a whole-request deadline")
+			transport, ok := dl.Transport.(*http.Transport)
+			require.True(t, ok)
+			assert.NotNil(t, transport.DialContext, "connect phase must be bounded")
+			assert.Positive(t, transport.TLSHandshakeTimeout, "TLS handshake must be bounded")
+			assert.Equal(t, 60*1, int(transport.ResponseHeaderTimeout))
+		})
+	}
+}
 
 // Pure unit table for makeAbsoluteURL — all URL shapes and fallback branches,
 // no HTTP server. The integration path stays covered by the

--- a/tests/unit/config_loading_test.go
+++ b/tests/unit/config_loading_test.go
@@ -397,6 +397,43 @@ jobs_dir: "` + jobsDir + `"
 	assert.NoError(t, err, "Valid TORCH config should pass validation")
 }
 
+func TestTORCHConfig_DownloadStallTimeoutLoading(t *testing.T) {
+	writeConfig := func(t *testing.T, torchExtra string) *models.ProjectConfig {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		jobsDir := filepath.Join(tmpDir, "jobs")
+		_ = os.MkdirAll(jobsDir, 0755)
+
+		configContent := `
+services:
+  torch:
+    base_url: "http://localhost:8080"
+    username: "testuser"
+    password: "testpass"
+` + torchExtra + `
+pipeline:
+  enabled_steps:
+    - local_import
+
+jobs_dir: "` + jobsDir + `"
+`
+		require.NoError(t, os.WriteFile(configFile, []byte(configContent), 0644))
+		config, err := services.LoadConfig(configFile)
+		require.NoError(t, err)
+		return config
+	}
+
+	t.Run("explicit value parses", func(t *testing.T) {
+		config := writeConfig(t, "    download_stall_timeout: PT2M\n")
+		assert.Equal(t, 2*time.Minute, config.Services.TORCH.DownloadStallTimeout)
+	})
+
+	t.Run("defaults when omitted", func(t *testing.T) {
+		config := writeConfig(t, "")
+		assert.Equal(t, 60*time.Second, config.Services.TORCH.DownloadStallTimeout)
+	})
+}
+
 func TestTORCHConfig_ValidateMissingBaseURL(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "config.yaml")
@@ -530,6 +567,39 @@ jobs_dir: "` + jobsDir + `"
 	_, err = services.LoadConfig(configFile)
 	assert.Error(t, err, "Zero timeout should fail validation")
 	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestTORCHConfig_ValidateNegativeDownloadStallTimeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	jobsDir := filepath.Join(tmpDir, "jobs")
+	_ = os.MkdirAll(jobsDir, 0755)
+
+	configContent := `
+services:
+  torch:
+    base_url: "http://localhost:8080"
+    username: "testuser"
+    password: "testpass"
+    download_stall_timeout: -1s
+
+pipeline:
+  enabled_steps:
+    - local_import
+
+retry:
+  max_attempts: 5
+  initial_backoff_ms: 1000
+  max_backoff_ms: 30000
+
+jobs_dir: "` + jobsDir + `"
+`
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	_, err = services.LoadConfig(configFile)
+	assert.Error(t, err, "Negative download_stall_timeout should fail validation")
+	assert.Contains(t, err.Error(), "download_stall_timeout")
 }
 
 func TestTORCHConfig_ValidateInvalidPollingInterval(t *testing.T) {

--- a/tests/unit/torch_client_test.go
+++ b/tests/unit/torch_client_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2250,4 +2251,255 @@ func TestTORCHClient_DownloadExtractionFiles_RangeCheckAvailable(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, files, 1)
+}
+
+// A large download that keeps making progress must complete even when the
+// shared HTTP client's whole-request timeout is short: the download uses its
+// own stall-bounded client, not the shared 30s-style deadline. The server
+// trickles data over ~480ms while the shared client is capped at 200ms; only
+// the stall-based download client lets it finish.
+func TestTORCHClient_DownloadExtractionFiles_SlowProgressingSucceeds(t *testing.T) {
+	const chunks = 8
+	line := `{"resourceType":"Patient","id":"1"}` + "\n"
+
+	fileServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		for i := 0; i < chunks; i++ {
+			_, _ = w.Write([]byte(line))
+			if ok {
+				flusher.Flush()
+			}
+			time.Sleep(60 * time.Millisecond)
+		}
+	}))
+	defer fileServer.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	// Short whole-request timeout stands in for the old 30s cap: the download
+	// must not inherit it.
+	httpClient := services.NewHTTPClient(
+		200*time.Millisecond,
+		models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 1, MaxBackoffMs: 1},
+		models.TLSConfig{},
+		logger,
+	)
+	client := services.NewTORCHClient(models.TORCHConfig{
+		BaseURL:              fileServer.URL,
+		Username:             "u",
+		Password:             "p",
+		DownloadStallTimeout: 1 * time.Second,
+	}, httpClient, logger)
+
+	dir := t.TempDir()
+	files, err := client.DownloadExtractionFiles(
+		[]string{fileServer.URL + "/out.ndjson"}, dir, false, false, "")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	content, readErr := os.ReadFile(filepath.Join(dir, files[0].FileName))
+	require.NoError(t, readErr)
+	assert.Equal(t, chunks, strings.Count(string(content), "Patient"))
+}
+
+// A download that sends headers and a few bytes, then goes silent, must abort
+// once the stall window elapses with a clear error — not hang forever waiting on
+// the body read.
+func TestTORCHClient_DownloadExtractionFiles_StalledAborts(t *testing.T) {
+	fileServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"1"}` + "\n"))
+			f.Flush()
+		}
+		// Stall: send nothing more until the client gives up and cancels.
+		<-r.Context().Done()
+	}))
+	defer fileServer.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(
+		5*time.Second,
+		models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 1, MaxBackoffMs: 1},
+		models.TLSConfig{},
+		logger,
+	)
+	client := services.NewTORCHClient(models.TORCHConfig{
+		BaseURL:              fileServer.URL,
+		Username:             "u",
+		Password:             "p",
+		DownloadStallTimeout: 200 * time.Millisecond,
+	}, httpClient, logger)
+
+	dir := t.TempDir()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.DownloadExtractionFiles(
+			[]string{fileServer.URL + "/out.ndjson"}, dir, false, false, "")
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "stall")
+	case <-time.After(2 * time.Second):
+		t.Fatal("download did not abort on stall; it hung")
+	}
+}
+
+// A download whose error response (>=400) emits headers and a few body bytes,
+// then goes silent, must abort once the stall window elapses — the stall
+// watchdog has to guard the error body too, not just the success-copy phase.
+// A proxy in front of TORCH that flushes error headers immediately but then
+// stalls mid error-body would otherwise hang the download forever, since the
+// download client carries no whole-request deadline.
+func TestTORCHClient_DownloadExtractionFiles_StalledErrorBodyAborts(t *testing.T) {
+	fileServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if f, ok := w.(http.Flusher); ok {
+			_, _ = w.Write([]byte(`{"error":"overloaded"`))
+			f.Flush()
+		}
+		// Stall mid error-body: send nothing more until the client cancels.
+		<-r.Context().Done()
+	}))
+	defer fileServer.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(
+		5*time.Second,
+		models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 1, MaxBackoffMs: 1},
+		models.TLSConfig{},
+		logger,
+	)
+	client := services.NewTORCHClient(models.TORCHConfig{
+		BaseURL:              fileServer.URL,
+		Username:             "u",
+		Password:             "p",
+		DownloadStallTimeout: 200 * time.Millisecond,
+	}, httpClient, logger)
+
+	dir := t.TempDir()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.DownloadExtractionFiles(
+			[]string{fileServer.URL + "/out.ndjson"}, dir, false, false, "")
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "503")
+	case <-time.After(2 * time.Second):
+		t.Fatal("download did not abort on stalled error body; it hung")
+	}
+}
+
+// A transient error at the start of the download (e.g. a 503 from a proxy in
+// front of TORCH) must be retried, not fail the whole import on the first
+// attempt. The file GET is idempotent, so retry-from-scratch is safe.
+func TestTORCHClient_DownloadExtractionFiles_RetriesTransientThenSucceeds(t *testing.T) {
+	var calls int32
+	fileServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"1"}` + "\n"))
+	}))
+	defer fileServer.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(
+		5*time.Second,
+		models.RetryConfig{MaxAttempts: 5, InitialBackoffMs: 1, MaxBackoffMs: 5},
+		models.TLSConfig{},
+		logger,
+	)
+	client := services.NewTORCHClient(models.TORCHConfig{
+		BaseURL:              fileServer.URL,
+		Username:             "u",
+		Password:             "p",
+		DownloadStallTimeout: 1 * time.Second,
+	}, httpClient, logger)
+
+	dir := t.TempDir()
+	files, err := client.DownloadExtractionFiles(
+		[]string{fileServer.URL + "/out.ndjson"}, dir, false, false, "")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(3), "server should have been retried")
+}
+
+// A TORCHClient built with a custom TLS config (InsecureSkipVerify) must be able
+// to download over HTTPS: the streaming download client clones the shared
+// client's custom *http.Transport, and that clone has to preserve the TLS
+// settings — otherwise the handshake against the test server's self-signed cert
+// would fail. This exercises newDownloadClient's custom-transport clone branch
+// and its connect/handshake bounding of a dialer-less custom transport.
+func TestTORCHClient_DownloadExtractionFiles_CustomTLSTransport(t *testing.T) {
+	ndjsonContent := `{"resourceType":"Patient","id":"tls-1"}`
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(ndjsonContent))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(
+		5*time.Second,
+		models.RetryConfig{MaxAttempts: 1, InitialBackoffMs: 10, MaxBackoffMs: 100},
+		models.TLSConfig{InsecureSkipVerify: true},
+		logger,
+	)
+	client := services.NewTORCHClient(models.TORCHConfig{BaseURL: server.URL}, httpClient, logger)
+
+	dir := t.TempDir()
+	files, err := client.DownloadExtractionFiles(
+		[]string{server.URL + "/output/tls.ndjson"}, dir, false, false, "")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	content, _ := os.ReadFile(filepath.Join(dir, files[0].FileName))
+	assert.Contains(t, string(content), "tls-1")
+}
+
+// A retry config of zero attempts must not silently skip the download: the
+// per-file loop clamps attempts up to one so exactly one real attempt runs.
+func TestTORCHClient_DownloadExtractionFiles_ZeroRetryAttemptsStillDownloadsOnce(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/fhir+ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"resourceType":"Patient","id":"z-1"}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(
+		5*time.Second,
+		models.RetryConfig{MaxAttempts: 0, InitialBackoffMs: 10, MaxBackoffMs: 100},
+		models.TLSConfig{},
+		logger,
+	)
+	client := services.NewTORCHClient(models.TORCHConfig{BaseURL: server.URL}, httpClient, logger)
+
+	dir := t.TempDir()
+	files, err := client.DownloadExtractionFiles(
+		[]string{server.URL + "/output/z.ndjson"}, dir, false, false, "")
+
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "zero-attempt config must still make exactly one attempt")
 }


### PR DESCRIPTION
## Problem

Large TORCH extractions failed to import with:

```
failed to write file: context deadline exceeded (Client.Timeout or context cancellation while reading body)
```

TORCH completed the extraction, but the shared HTTP client's hard-coded **30s whole-request timeout** (`cmd/job.go`) caps the *entire* request including the body read (`io.Copy` in `torch_client.go`). Any NDJSON that can't stream within 30s was impossible to import, and the retry loop just restarted from scratch into the same wall.

## Fix

The download now gets its own client with **no whole-request deadline** (`Timeout: 0`) and bounds *inactivity* instead:

- **`download_stall_timeout`** (new `TORCHConfig` knob, default `PT1M`, validated `>= 0`): the download aborts only when **no bytes arrive** for this long. A large-but-progressing download completes regardless of size; a genuinely stalled connection fails fast with a clear `download stalled: ...` error. Unlike a whole-request deadline it never needs sizing to the largest expected download.
- A `stallGuardReader` re-arms an inactivity watchdog on every body read and cancels the request context on stall (no `http.Transport` setting bounds an in-flight body read).
- The dedicated client clones the shared TLS transport and also bounds the **connect** and **TLS-handshake** phases, closing a would-be infinite hang on the custom-CA / `insecure_skip_verify` path (whose transport ships without a dialer).
- **Transient** download failures (connect refusal, 5xx) are retried on the idempotent GET, restoring the resilience the shared client previously provided; stalls and mid-body write errors are not retried.

Submit / poll / availability keep using the short-timeout shared client — their payloads are small.

## Acceptance criteria

- [x] A large TORCH NDJSON download that takes longer than 30s completes successfully.
- [x] A genuinely stalled connection (no bytes progressing) fails with a clear error rather than hanging forever.
- [x] Download stall behavior is configurable via `TORCHConfig` (`download_stall_timeout`, default `PT1M`, documented in `aether.example.yaml`).
- [x] Tests cover: (a) slow-but-progressing download succeeds, (b) stalled download aborts, plus transient-retry and connect/handshake bounding.

Closes #530