### PR TITLE
fix(send): use application/zip for csv/parquet Binary contentType

### DIFF
--- a/internal/pipeline/send.go
+++ b/internal/pipeline/send.go
@@ -289,9 +289,10 @@ type binaryEntry struct {
 // createBinaryFromFile reads a file, zips it, base64-encodes the content,
 // and returns a FHIR Binary resource.
 func createBinaryFromFile(filePath string) (binaryEntry, error) {
-	contentType := detectContentType(filePath)
+	// Every file is zipped for transfer, so the Binary describes a zip archive.
+	// application/zip is the IANA-registered type for zip archives.
+	const contentType = "application/zip"
 
-	// All files are zipped for transfer
 	data, err := zipSingleFile(filePath)
 	if err != nil {
 		return binaryEntry{}, fmt.Errorf("failed to zip %s: %w", filepath.Base(filePath), err)
@@ -312,23 +313,6 @@ func createBinaryFromFile(filePath string) (binaryEntry, error) {
 		contentType: contentType,
 		resource:    resource,
 	}, nil
-}
-
-// detectContentType determines the FHIR contentType for a file based on its extension.
-// All files are zipped for transfer - the pipeline doesn't produce standalone .json files.
-func detectContentType(filePath string) string {
-	name := strings.ToLower(filepath.Base(filePath))
-
-	switch {
-	case strings.HasSuffix(name, ".ndjson.zst") || strings.HasSuffix(name, ".ndjson"):
-		return "application/zip"
-	case strings.HasSuffix(name, ".csv"):
-		return "text/zip"
-	case strings.HasSuffix(name, ".parquet"):
-		return "text/zip"
-	default:
-		return "application/zip"
-	}
 }
 
 // zipSingleFile compresses a single file into an in-memory zip archive.

--- a/tests/unit/pipeline_send_test.go
+++ b/tests/unit/pipeline_send_test.go
@@ -178,7 +178,7 @@ func TestExecuteSendStep_ZipContentVerification(t *testing.T) {
 
 	// Verify the captured Binary resource
 	require.NotNil(t, binaryResource)
-	assert.Equal(t, "text/zip", binaryResource["contentType"])
+	assert.Equal(t, "application/zip", binaryResource["contentType"])
 
 	b64Data := binaryResource["data"].(string)
 	zipBytes, err := base64.StdEncoding.DecodeString(b64Data)
@@ -230,17 +230,18 @@ func TestExecuteSendStep_ContentTypeMapping(t *testing.T) {
 	// 3 Binaries + 1 DocumentReference = 4 requests
 	require.Len(t, receivedResources, 4)
 
-	// Collect content types from Binary resources
-	contentTypes := make(map[string]bool)
+	// Every file is zipped for transfer, so all Binaries carry application/zip.
+	var binaryContentTypes []string
 	for _, resource := range receivedResources {
 		if resource["resourceType"] == "Binary" {
-			ct := resource["contentType"].(string)
-			contentTypes[ct] = true
+			binaryContentTypes = append(binaryContentTypes, resource["contentType"].(string))
 		}
 	}
 
-	assert.True(t, contentTypes["application/zip"], "ndjson should have application/zip")
-	assert.True(t, contentTypes["text/zip"], "csv/parquet should have text/zip")
+	require.Len(t, binaryContentTypes, 3)
+	for _, ct := range binaryContentTypes {
+		assert.Equal(t, "application/zip", ct)
+	}
 }
 
 func TestExecuteSendStep_ServerError(t *testing.T) {


### PR DESCRIPTION
## Summary

`detectContentType` in `internal/pipeline/send.go` returned the non-standard `text/zip` for `.csv` and `.parquet` files, while `.ndjson` got `application/zip` — even though every file is zipped identically for transfer via `zipSingleFile`.

`text/zip` is not a registered IANA media type: a zip archive is binary, and `text/*` implies textual content. The `Binary.contentType` describes the **archive**, not the pre-zip payload, so all Binaries now carry the IANA-registered `application/zip`.

With every branch returning the same value, the extension switch collapsed to a single constant — `detectContentType` is inlined into `createBinaryFromFile` and removed.

## Changes

- `internal/pipeline/send.go`: drop `detectContentType`; set `contentType = "application/zip"` inline.
- `tests/unit/pipeline_send_test.go`: assert `application/zip` for the csv Binary and for all Binaries in the content-type test.

Closes #532