### PR TITLE
fix(oauth2): token cache not keyed by issuer/clientID serves wrong token across services

### DIFF
--- a/internal/services/oauth2.go
+++ b/internal/services/oauth2.go
@@ -11,13 +11,24 @@ import (
 	"time"
 )
 
-// oauth2TokenCache stores cached OAuth2 tokens to avoid fetching a new token for every request.
-// Thread-safe for concurrent access.
-var oauth2TokenCache = struct {
-	sync.RWMutex
+// oauth2CacheKey identifies a cached token by the credentials used to obtain it.
+// Different issuers or clients must never share a token.
+type oauth2CacheKey struct {
+	issuerURI string
+	clientID  string
+}
+
+type oauth2CacheEntry struct {
 	token     string
 	expiresAt time.Time
-}{}
+}
+
+// oauth2TokenCache stores cached OAuth2 tokens per (issuerURI, clientID) to avoid
+// fetching a new token for every request. Thread-safe for concurrent access.
+var oauth2TokenCache = struct {
+	sync.RWMutex
+	entries map[oauth2CacheKey]oauth2CacheEntry
+}{entries: make(map[oauth2CacheKey]oauth2CacheEntry)}
 
 // oauth2TokenResponse represents the response from an OAuth2 token endpoint
 type oauth2TokenResponse struct {
@@ -29,12 +40,13 @@ type oauth2TokenResponse struct {
 // FetchOAuth2Token retrieves an access token using the OAuth2 client credentials flow.
 // Uses the Keycloak standard token endpoint: {issuer_uri}/protocol/openid-connect/token
 func FetchOAuth2Token(issuerURI, clientID, clientSecret string, httpClient *HTTPClient) (string, error) {
+	cacheKey := oauth2CacheKey{issuerURI: issuerURI, clientID: clientID}
+
 	// Check cache first
 	oauth2TokenCache.RLock()
-	if oauth2TokenCache.token != "" && time.Now().Before(oauth2TokenCache.expiresAt) {
-		token := oauth2TokenCache.token
+	if entry, ok := oauth2TokenCache.entries[cacheKey]; ok && entry.token != "" && time.Now().Before(entry.expiresAt) {
 		oauth2TokenCache.RUnlock()
-		return token, nil
+		return entry.token, nil
 	}
 	oauth2TokenCache.RUnlock()
 
@@ -77,23 +89,23 @@ func FetchOAuth2Token(issuerURI, clientID, clientSecret string, httpClient *HTTP
 	}
 
 	// Cache the token with a small buffer before expiration (30 seconds)
-	oauth2TokenCache.Lock()
-	oauth2TokenCache.token = tokenResp.AccessToken
+	entry := oauth2CacheEntry{token: tokenResp.AccessToken}
 	if tokenResp.ExpiresIn > 30 {
-		oauth2TokenCache.expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn-30) * time.Second)
+		entry.expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn-30) * time.Second)
 	} else {
 		// Token expires very soon, don't cache
-		oauth2TokenCache.expiresAt = time.Now()
+		entry.expiresAt = time.Now()
 	}
+	oauth2TokenCache.Lock()
+	oauth2TokenCache.entries[cacheKey] = entry
 	oauth2TokenCache.Unlock()
 
 	return tokenResp.AccessToken, nil
 }
 
-// ClearOAuth2TokenCache clears the cached OAuth2 token (useful for testing)
+// ClearOAuth2TokenCache clears all cached OAuth2 tokens (useful for testing)
 func ClearOAuth2TokenCache() {
 	oauth2TokenCache.Lock()
-	oauth2TokenCache.token = ""
-	oauth2TokenCache.expiresAt = time.Time{}
+	oauth2TokenCache.entries = make(map[oauth2CacheKey]oauth2CacheEntry)
 	oauth2TokenCache.Unlock()
 }

--- a/tests/unit/oauth2_test.go
+++ b/tests/unit/oauth2_test.go
@@ -3,6 +3,7 @@ package unit
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,6 +73,86 @@ func TestFetchOAuth2Token_CacheHit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "cached-token", token2)
 	assert.Equal(t, 1, requestCount) // Still 1, cache was used
+}
+
+func TestFetchOAuth2Token_DifferentIssuersNoCollision(t *testing.T) {
+	services.ClearOAuth2TokenCache()
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token-A","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer serverA.Close()
+
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token-B","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer serverB.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
+
+	tokenA, err := services.FetchOAuth2Token(serverA.URL, "client-a", "secret-a", httpClient)
+	require.NoError(t, err)
+	assert.Equal(t, "token-A", tokenA)
+
+	// Second issuer within the first token's expiry window must not receive A's token.
+	tokenB, err := services.FetchOAuth2Token(serverB.URL, "client-b", "secret-b", httpClient)
+	require.NoError(t, err)
+	assert.Equal(t, "token-B", tokenB)
+}
+
+func TestFetchOAuth2Token_DifferentClientsSameIssuerNoCollision(t *testing.T) {
+	services.ClearOAuth2TokenCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token-` + r.Form.Get("client_id") + `","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
+
+	token1, err := services.FetchOAuth2Token(server.URL, "client-one", "secret", httpClient)
+	require.NoError(t, err)
+	assert.Equal(t, "token-client-one", token1)
+
+	token2, err := services.FetchOAuth2Token(server.URL, "client-two", "secret", httpClient)
+	require.NoError(t, err)
+	assert.Equal(t, "token-client-two", token2)
+}
+
+func TestFetchOAuth2Token_ConcurrentSameKey(t *testing.T) {
+	services.ClearOAuth2TokenCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"concurrent-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelError)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 1}, models.TLSConfig{}, logger)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			token, err := services.FetchOAuth2Token(server.URL, "test-client", "test-secret", httpClient)
+			assert.NoError(t, err)
+			assert.Equal(t, "concurrent-token", token)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestFetchOAuth2Token_HTTPError(t *testing.T) {


### PR DESCRIPTION
Keys the OAuth2 client-credentials token cache by (issuerURI, clientID) instead of a single process-global slot, so a second caller using a different issuer or client within the expiry window no longer receives the first service's cached token.

- Added a failing test demonstrating the cross-issuer collision, then made it green by keying the cache.
- Added a same-issuer/different-client collision test.
- Added a concurrent-fetch test (20 goroutines, same key) that passes under `go test -race`.
- Existing oauth2 tests (cache hit, short expiry, error paths, trailing slash, clear) still pass.

Closes #534