### PR TITLE
test(httpclient): pin MaxAttempts==0 behavior and request-body replay across retries

### DIFF
--- a/internal/lib/retry.go
+++ b/internal/lib/retry.go
@@ -51,10 +51,16 @@ type RetryConfig struct {
 	MaxBackoffMs     int64
 }
 
-// NewRetryConfigFrom models creates RetryConfig from models.RetryConfig
+// NewRetryConfigFrom models creates RetryConfig from models.RetryConfig.
+// A non-positive MaxAttempts is normalized to a single attempt so the retry
+// loop always runs at least once instead of failing with a nil-wrapped error.
 func NewRetryConfigFromModel(config models.RetryConfig) RetryConfig {
+	maxAttempts := config.MaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
 	return RetryConfig{
-		MaxAttempts:      config.MaxAttempts,
+		MaxAttempts:      maxAttempts,
 		InitialBackoffMs: config.InitialBackoffMs,
 		MaxBackoffMs:     config.MaxBackoffMs,
 	}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -327,6 +327,8 @@ type PipelineConfig struct {
 
 // RetryConfig controls retry behavior for transient errors
 type RetryConfig struct {
+	// MaxAttempts is the total number of attempts (initial try plus retries).
+	// A value of 0 or less is treated as a single attempt with no retries.
 	MaxAttempts      int   `yaml:"max_attempts" json:"max_attempts" mapstructure:"max_attempts"`
 	InitialBackoffMs int64 `yaml:"initial_backoff_ms" json:"initial_backoff_ms" mapstructure:"initial_backoff_ms"`
 	MaxBackoffMs     int64 `yaml:"max_backoff_ms" json:"max_backoff_ms" mapstructure:"max_backoff_ms"`

--- a/tests/unit/httpclient_test.go
+++ b/tests/unit/httpclient_test.go
@@ -167,6 +167,63 @@ func TestHTTPClient_Put_CustomContentType(t *testing.T) {
 	}
 }
 
+// TestHTTPClient_ZeroMaxAttempts verifies that a retry config with zero max
+// attempts is treated as a single attempt rather than failing with an error
+// that wraps a nil cause.
+func TestHTTPClient_ZeroMaxAttempts(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 0, InitialBackoffMs: 100, MaxBackoffMs: 1000}, models.TLSConfig{}, logger)
+
+	resp, err := httpClient.Get(server.URL)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, callCount, "zero max attempts should run exactly one attempt")
+}
+
+// TestHTTPClient_BodyReplayedOnRetry verifies that after a retryable 5xx on the
+// first attempt, the second attempt receives the identical request body.
+func TestHTTPClient_BodyReplayedOnRetry(t *testing.T) {
+	body := []byte(`{"resourceType":"Bundle","entry":[{"resource":{"resourceType":"Patient","id":"p1"}}]}`)
+
+	var attemptBodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ := io.ReadAll(r.Body)
+		attemptBodies = append(attemptBodies, received)
+		if len(attemptBodies) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	logger := lib.NewLogger(lib.LogLevelDebug)
+	httpClient := services.NewHTTPClient(5*time.Second, models.RetryConfig{MaxAttempts: 3, InitialBackoffMs: 1, MaxBackoffMs: 5}, models.TLSConfig{}, logger)
+
+	resp, err := httpClient.Post(server.URL, "application/fhir+json", body)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Len(t, attemptBodies, 2, "expected one retry after the 5xx")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, body, attemptBodies[0], "first attempt should receive the full body")
+	assert.Equal(t, body, attemptBodies[1], "second attempt should receive the identical body")
+}
+
 // TestHTTPClient_WithInsecureSkipVerify verifies the TLS transport branch
 // where BuildTLSTransport returns a non-nil transport
 func TestHTTPClient_WithInsecureSkipVerify(t *testing.T) {


### PR DESCRIPTION
Normalizes a non-positive `RetryConfig.MaxAttempts` to a single attempt so a request always runs at least once instead of returning an error that wraps a nil cause, and documents the semantics on the config type. Adds tests pinning the zero-attempt behavior and proving the request body is replayed intact on the retry after a 5xx.

Closes #540