### PR TITLE
test: pure-function coverage sweep (throughput, utils, fhir, transitions, state deletion, compression close)

### DIFF
--- a/tests/unit/compression_test.go
+++ b/tests/unit/compression_test.go
@@ -454,6 +454,30 @@ func TestCompressionReader_CloseError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestCompressionReader_CloseSurfacesFileErrorWithDecoder verifies that for a
+// compressed reader (decoder present), a failing underlying file close is
+// surfaced rather than swallowed by the decoder-close path.
+func TestCompressionReader_CloseSurfacesFileErrorWithDecoder(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.ndjson.zst")
+
+	writer, err := lib.CreateCompressedFileWriter(testFile, "default")
+	require.NoError(t, err)
+	_, err = writer.Write([]byte(`{"resourceType":"Patient","id":"1"}` + "\n"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	reader, err := lib.OpenFileForReading(testFile)
+	require.NoError(t, err)
+
+	// First close releases the decoder and the file cleanly.
+	require.NoError(t, reader.Close())
+
+	// The decoder is present, but a second close must still report the file
+	// close error instead of returning nil.
+	assert.Error(t, reader.Close(), "file close error must not be swallowed when a decoder is present")
+}
+
 // TestCompressionWriter_WriteMultipleBlocks verifies writing multiple blocks of data
 func TestCompressionWriter_WriteMultipleBlocks(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/tests/unit/fhir_helpers_test.go
+++ b/tests/unit/fhir_helpers_test.go
@@ -1,0 +1,92 @@
+package unit
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+func TestWriteNDJSONLine(t *testing.T) {
+	var buf bytes.Buffer
+	resource := lib.FHIRResource{"resourceType": "Patient", "id": "p1"}
+
+	require.NoError(t, lib.WriteNDJSONLine(&buf, resource))
+
+	out := buf.String()
+	assert.True(t, strings.HasSuffix(out, "\n"), "each NDJSON record ends with a newline")
+	assert.Contains(t, out, `"resourceType":"Patient"`)
+	assert.Contains(t, out, `"id":"p1"`)
+	assert.Equal(t, 1, strings.Count(out, "\n"), "single resource writes exactly one line")
+}
+
+func TestGroupByResourceType(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []lib.FHIRResource
+		want      map[string]int
+		wantErr   bool
+	}{
+		{
+			name: "groups by type preserving counts",
+			resources: []lib.FHIRResource{
+				{"resourceType": "Patient", "id": "1"},
+				{"resourceType": "Observation", "id": "2"},
+				{"resourceType": "Patient", "id": "3"},
+			},
+			want: map[string]int{"Patient": 2, "Observation": 1},
+		},
+		{
+			name:      "empty input yields empty map",
+			resources: []lib.FHIRResource{},
+			want:      map[string]int{},
+		},
+		{
+			name: "missing resourceType is an error",
+			resources: []lib.FHIRResource{
+				{"id": "1"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups, err := lib.GroupByResourceType(tt.resources)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, groups, len(tt.want))
+			for rt, count := range tt.want {
+				assert.Len(t, groups[rt], count)
+			}
+		})
+	}
+}
+
+func TestValidateFHIRResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource lib.FHIRResource
+		wantErr  bool
+	}{
+		{"valid resource", lib.FHIRResource{"resourceType": "Patient"}, false},
+		{"missing resourceType", lib.FHIRResource{"id": "1"}, true},
+		{"non-string resourceType", lib.FHIRResource{"resourceType": 42}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := lib.ValidateFHIRResource(tt.resource)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/unit/lib/utils_test.go
+++ b/tests/unit/lib/utils_test.go
@@ -1,12 +1,77 @@
 package lib_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 )
+
+func TestFileExists(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "present.txt")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0644))
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"existing file", file, true},
+		{"existing directory", dir, true},
+		{"missing path", filepath.Join(dir, "absent.txt"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, lib.FileExists(tt.path))
+		})
+	}
+}
+
+func TestDirExists(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0644))
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"existing directory", dir, true},
+		{"file is not a directory", file, false},
+		{"missing path", filepath.Join(dir, "nope"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, lib.DirExists(tt.path))
+		})
+	}
+}
+
+func TestGetFileSize(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "sized.txt")
+	require.NoError(t, os.WriteFile(file, []byte("hello"), 0644))
+
+	tests := []struct {
+		name string
+		path string
+		want int64
+	}{
+		{"size of existing file", file, 5},
+		{"missing file yields zero", filepath.Join(dir, "absent.txt"), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, lib.GetFileSize(tt.path))
+		})
+	}
+}
 
 func TestSanitizeFilename(t *testing.T) {
 	tests := []struct {

--- a/tests/unit/models/transitions_test.go
+++ b/tests/unit/models/transitions_test.go
@@ -150,3 +150,83 @@ func TestResetStepAndDownstream(t *testing.T) {
 	u, _ := models.GetStepByName(unchanged, models.StepSend)
 	assert.Equal(t, models.StepStatusCompleted, u.Status)
 }
+
+// TestUpdateStepProgress proves progress counters are overwritten while the rest
+// of the step is left intact, and the original step is not mutated.
+func TestUpdateStepProgress(t *testing.T) {
+	tests := []struct {
+		name       string
+		startFiles int
+		startBytes int64
+		files      int
+		bytes      int64
+	}{
+		{"from zero", 0, 0, 10, 2048},
+		{"overwrites prior progress", 3, 100, 7, 4096},
+		{"back to zero", 5, 500, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := models.PipelineStep{
+				Name:           models.StepDIMP,
+				Status:         models.StepStatusInProgress,
+				FilesProcessed: tt.startFiles,
+				BytesProcessed: tt.startBytes,
+			}
+
+			updated := models.UpdateStepProgress(step, tt.files, tt.bytes)
+
+			assert.Equal(t, tt.files, updated.FilesProcessed)
+			assert.Equal(t, tt.bytes, updated.BytesProcessed)
+			assert.Equal(t, models.StepStatusInProgress, updated.Status, "status is untouched")
+			assert.Equal(t, models.StepDIMP, updated.Name, "name is untouched")
+
+			assert.Equal(t, tt.startFiles, step.FilesProcessed, "original step must not be mutated")
+			assert.Equal(t, tt.startBytes, step.BytesProcessed, "original step must not be mutated")
+		})
+	}
+}
+
+// TestGetNextPendingStep proves the first pending step (in order) is returned,
+// and that a job with no pending steps reports none.
+func TestGetNextPendingStep(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []models.StepStatus
+		wantName models.StepName
+		wantOK   bool
+	}{
+		{
+			name:     "first pending is returned",
+			statuses: []models.StepStatus{models.StepStatusCompleted, models.StepStatusPending, models.StepStatusPending},
+			wantName: models.StepDIMP,
+			wantOK:   true,
+		},
+		{
+			name:     "no pending steps",
+			statuses: []models.StepStatus{models.StepStatusCompleted, models.StepStatusCompleted},
+			wantOK:   false,
+		},
+		{
+			name:     "empty job has no pending step",
+			statuses: nil,
+			wantOK:   false,
+		},
+	}
+	names := []models.StepName{models.StepLocalImport, models.StepDIMP, models.StepValidation}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			steps := make([]models.PipelineStep, len(tt.statuses))
+			for i, s := range tt.statuses {
+				steps[i] = models.PipelineStep{Name: names[i], Status: s}
+			}
+			job := models.PipelineJob{Steps: steps}
+
+			step, ok := models.GetNextPendingStep(job)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantName, step.Name)
+			}
+		})
+	}
+}

--- a/tests/unit/state_persistence_test.go
+++ b/tests/unit/state_persistence_test.go
@@ -467,6 +467,30 @@ func TestLoadJobState_BackfillSkippedForNonCRTDL(t *testing.T) {
 	assert.Empty(t, loaded.CRTDLPath, "non-CRTDL jobs must NOT backfill CRTDLPath")
 }
 
+// TestDeleteJob covers both deletion paths: removing an existing job directory,
+// and reporting an error when the job does not exist.
+func TestDeleteJob(t *testing.T) {
+	t.Run("removes an existing job directory", func(t *testing.T) {
+		jobsDir := t.TempDir()
+		job := createTestJob(uuid.New().String(), jobsDir)
+		require.NoError(t, services.SaveJobState(jobsDir, job))
+
+		jobDir := services.GetJobDir(jobsDir, job.JobID)
+		require.DirExists(t, jobDir)
+
+		require.NoError(t, services.DeleteJob(jobsDir, job.JobID))
+		assert.NoDirExists(t, jobDir, "job directory is gone after deletion")
+	})
+
+	t.Run("deleting a missing job returns an error", func(t *testing.T) {
+		jobsDir := t.TempDir()
+
+		err := services.DeleteJob(jobsDir, "does-not-exist")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "job not found")
+	})
+}
+
 // Helper function to create a test job
 func createTestJob(jobID, jobsDir string) *models.PipelineJob {
 	now := time.Now()

--- a/tests/unit/ui/throughput_test.go
+++ b/tests/unit/ui/throughput_test.go
@@ -1,0 +1,111 @@
+package ui_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/medizininformatik-initiative/aether/internal/ui"
+)
+
+func TestFormatItemsPerSecond(t *testing.T) {
+	tests := []struct {
+		name string
+		rate float64
+		want string
+	}{
+		{"below floor rounds to placeholder", 0.005, "< 0.01 items/sec"},
+		{"zero rounds to placeholder", 0, "< 0.01 items/sec"},
+		{"at floor is printed", 0.01, "0.01 items/sec"},
+		{"typical rate", 2.345, "2.35 items/sec"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ui.FormatItemsPerSecond(tt.rate))
+		})
+	}
+}
+
+func TestFormatBytesPerSecond(t *testing.T) {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	tests := []struct {
+		name string
+		rate float64
+		want string
+	}{
+		{"bytes", 512, "512 B/sec"},
+		{"kilobytes", 2 * kb, "2.00 KB/sec"},
+		{"megabytes", 5 * mb, "5.00 MB/sec"},
+		{"gigabytes", 3 * gb, "3.00 GB/sec"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ui.FormatBytesPerSecond(tt.rate))
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+		tb = 1024 * gb
+	)
+	tests := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{"bytes", 512, "512 B"},
+		{"kilobytes", 2 * kb, "2.00 KB"},
+		{"megabytes", 3 * mb, "3.00 MB"},
+		{"gigabytes", 4 * gb, "4.00 GB"},
+		{"terabytes", 5 * tb, "5.00 TB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ui.FormatBytes(tt.bytes))
+		})
+	}
+}
+
+func TestThroughputCalculator_UpdateComputesRates(t *testing.T) {
+	calc := ui.NewThroughputCalculator()
+	time.Sleep(5 * time.Millisecond)
+	calc.Update(100, 4096)
+
+	assert.Positive(t, calc.GetInstantItemsPerSecond(), "instant items rate is computed after update")
+	assert.Positive(t, calc.GetInstantBytesPerSecond(), "instant bytes rate is computed after update")
+	assert.Positive(t, calc.GetAverageItemsPerSecond(), "average items rate is computed after update")
+	assert.Positive(t, calc.GetAverageBytesPerSecond(), "average bytes rate is computed after update")
+	assert.Positive(t, calc.GetElapsedTime(), "elapsed time advances after update")
+}
+
+func TestThroughputCalculator_ResetClearsState(t *testing.T) {
+	calc := ui.NewThroughputCalculator()
+	time.Sleep(5 * time.Millisecond)
+	calc.Update(100, 4096)
+	calc.Reset()
+
+	assert.Zero(t, calc.GetInstantItemsPerSecond(), "reset clears instant items rate")
+	assert.Zero(t, calc.GetInstantBytesPerSecond(), "reset clears instant bytes rate")
+	assert.Zero(t, calc.GetAverageItemsPerSecond(), "reset clears totals so average is zero")
+	assert.Zero(t, calc.GetAverageBytesPerSecond(), "reset clears totals so average is zero")
+}
+
+func TestThroughputCalculator_Summary(t *testing.T) {
+	calc := ui.NewThroughputCalculator()
+	time.Sleep(5 * time.Millisecond)
+	calc.Update(42, 1000)
+
+	summary := calc.Summary()
+	assert.Contains(t, summary, "42 items", "summary reports item count")
+	assert.Contains(t, summary, "1000 B", "summary reports byte total")
+	assert.Contains(t, summary, "Avg:", "summary reports averages")
+}


### PR DESCRIPTION
Adds low-effort table tests for previously untested pure/near-pure helpers across six areas, guarding their behavior:

- Throughput: byte/rate formatting, instant/average rates, reset, summary, elapsed
- Filesystem helpers: FileExists, DirExists, GetFileSize (via t.TempDir())
- FHIR helpers: NDJSON line writing, grouping by resourceType, resource validation
- Job state-machine helpers: step progress update, next pending step
- Job deletion: removing a job directory; deleting a missing job returns an error
- Compression reader close: a failing file close is surfaced (not swallowed) even when a decoder is present

All added tests pass under go test -race.

Closes #542