### PR TITLE
fix(cli): register --no-progress on pipeline continue

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -149,7 +149,10 @@ Examples:
 
   # Check status first, then resume
   aether pipeline status aether.yaml abc-123-def
-  aether pipeline continue aether.yaml abc-123-def`,
+  aether pipeline continue aether.yaml abc-123-def
+
+  # Resume without progress indicators
+  aether pipeline continue aether.yaml abc-123-def --no-progress`,
 	Args: cobra.ExactArgs(2),
 	RunE: runPipelineContinue,
 }
@@ -163,6 +166,8 @@ func init() {
 	pipelineStartCmd.Flags().BoolVar(&noProgress, "no-progress", false, "Disable progress indicators")
 	pipelineStartCmd.Flags().StringVar(&localImportDir, "dir", "", "Directory for local import (overrides config)")
 	pipelineStartCmd.Flags().BoolVar(&allowHTTPCRTDL, "allow-http-crtdl", false, "Acknowledge that combining http_import with a CRTDL may not match the endpoint's data")
+
+	pipelineContinueCmd.Flags().BoolVar(&noProgress, "no-progress", false, "Disable progress indicators")
 }
 
 func runPipelineStart(cmd *cobra.Command, args []string) error {

--- a/cmd/pipeline_test.go
+++ b/cmd/pipeline_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `pipeline continue` reads noProgress into RunOptions, so the flag must be
+// registered on that command too — otherwise --no-progress is an unknown flag
+// and a continued job can never disable progress indicators.
+func TestPipelineContinue_AcceptsNoProgressFlag(t *testing.T) {
+	flag := pipelineContinueCmd.Flags().Lookup("no-progress")
+	require.NotNil(t, flag, "continue command must register --no-progress")
+
+	t.Cleanup(func() { noProgress = false })
+	require.NoError(t, pipelineContinueCmd.Flags().Set("no-progress", "true"))
+
+	assert.True(t, noProgress, "--no-progress must bind to the noProgress variable")
+}

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -85,13 +85,16 @@ aether pipeline status aether.yaml abc-123-def
 Resume a paused or failed pipeline.
 
 ```bash
-aether pipeline continue <config> <job-id>
+aether pipeline continue <config> <job-id> [options]
 ```
 
 **Use cases:**
 - Resume after terminal close
 - Continue after fixing errors
 - Resume from wait step after placing files in wait directory
+
+**Options:**
+- `--no-progress` - Disable progress indicators
 
 **Examples:**
 ```bash
@@ -100,6 +103,9 @@ aether pipeline continue aether.yaml abc-123-def
 
 # Resume from wait step (after placing files)
 aether pipeline continue aether.yaml abc-123-def
+
+# Resume without progress bars
+aether pipeline continue aether.yaml abc-123-def --no-progress
 ```
 
 ## Job Commands


### PR DESCRIPTION
## Summary

`--no-progress` was registered only on `pipeline start`, yet `runPipelineContinue` reads the shared `noProgress` variable into its `RunOptions`. As a result `aether pipeline continue --no-progress` failed with "unknown flag", and a continued job could never disable progress indicators.

This registers the flag on `pipeline continue` so both entry points into the pipeline loop honor it.

## Changes

- Register `--no-progress` on `pipelineContinueCmd`
- Add a `--no-progress` example to the continue help text
- Document the flag for `continue` in `docs/api-reference/cli-commands.md`
- Add a unit test covering flag registration and binding on `continue`

## Acceptance criteria

- [x] `aether pipeline continue <config> <job-id> --no-progress` is accepted and disables progress indicators
- [x] `pipeline continue --help` lists the flag
- [x] cli-commands.md documents the flag for continue
- [x] Test covers flag registration/behavior on continue

Closes #555