### PR TITLE
docs: fix inaccurate CLI help texts and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ Contributions follow a standard GitHub workflow:
 
 ## Full Contribution Guide
 
-For detailed instructions on development setup, workflow, code style, testing requirements, and more, please see our complete [Contributing Guide](https://medizininformatik-initiative.github.io/aether/development/contributing.html).
+For detailed instructions on development setup, workflow, code style, testing requirements, and more, please see our complete [Contributing Guide](https://medizininformatik-initiative.github.io/aether/stable/development/contributing.html).
 
 ## Prerequisites
 
-- Go 1.21+
+- Go 1.26+
 - Make
 - Git
 - Docker & Docker Compose (for integration tests)
@@ -33,9 +33,9 @@ make build
 make test
 
 # Run a specific test
-make test TEST=TestName
+go test -run TestName ./tests/unit/...
 
-# Format and lint code
+# Lint code
 make lint
 
 # Build documentation
@@ -47,7 +47,7 @@ cd docs && npm install && npm run docs:build
 - All code must be formatted with `gofmt`
 - All CI checks must pass
 - Maintain or improve test coverage
-- Follow [Coding Guidelines](https://medizininformatik-initiative.github.io/aether/development/coding-guidelines.html)
+- Follow [Coding Guidelines](https://medizininformatik-initiative.github.io/aether/stable/development/coding-guidelines.html)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A command-line tool for processing FHIR healthcare data through configurable pipeline steps.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.26%2B-00ADD8?logo=go)](https://go.dev/)
 [![Documentation](https://img.shields.io/badge/Documentation-GitHub%20Pages-success?logo=github)](https://medizininformatik-initiative.github.io/aether/)
 [![codecov](https://codecov.io/gh/medizininformatik-initiative/aether/branch/main/graph/badge.svg)](https://codecov.io/gh/medizininformatik-initiative/aether)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/medizininformatik-initiative/aether/badge)](https://scorecard.dev/viewer/?uri=github.com/medizininformatik-initiative/aether)

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -288,7 +288,7 @@ func runJobRun(cmd *cobra.Command, args []string) error {
 	logger := lib.DefaultLogger
 	lock, err := services.AcquireJobLock(config.JobsDir, jobID, logger)
 	if err != nil {
-		return fmt.Errorf("cannot execute step: %w\n\nAnother process may be working on this job. Wait for it to complete or check job status", err)
+		return fmt.Errorf("cannot execute step: %w\n\nAnother process may be working on this job. Wait for it to complete or check its status with 'pipeline status'", err)
 	}
 	defer func() {
 		if err := lock.Release(); err != nil {
@@ -346,7 +346,7 @@ func executeStepManually(job *models.PipelineJob, stepName models.StepName, conf
 	// pre-execution guard: nothing runs, so job state is left untouched (not marked
 	// failed) and the error surfaces for a non-zero exit. With --force, reset the step
 	// and every step ordered after it to pending (a re-run invalidates the output later
-	// steps consumed), flip the job to in_progress, and persist now so `job status`
+	// steps consumed), flip the job to in_progress, and persist now so `pipeline status`
 	// shows the in-flight re-run. The invalidated downstream steps stay pending until
 	// re-run; only the target step runs here.
 	if s, ok := models.GetStepByName(*job, stepName); ok && s.Status == models.StepStatusCompleted {

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -355,7 +355,7 @@ func runPipelineContinue(cmd *cobra.Command, args []string) error {
 
 	lock, err := services.AcquireJobLock(config.JobsDir, jobID, logger)
 	if err != nil {
-		return fmt.Errorf("cannot continue pipeline: %w\n\nAnother process may be working on this job. Wait for it to complete or check job status", err)
+		return fmt.Errorf("cannot continue pipeline: %w\n\nAnother process may be working on this job. Wait for it to complete or check its status with 'pipeline status'", err)
 	}
 	defer func() {
 		if err := lock.Release(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,10 +26,13 @@ var rootCmd = &cobra.Command{
 	Short: "Aether - Data Use Process (DUP) Pipeline CLI",
 	Long: `Aether orchestrates Data Use Process (DUP) pipelines for medical FHIR data.
 
-The CLI imports TORCH-extracted FHIR data and processes it through configurable steps:
+The CLI imports FHIR data (TORCH extraction, a local directory, or an HTTP URL)
+and processes it through configurable steps:
   • DIMP pseudonymization (de-identification)
-  • Validation (placeholder - not yet implemented)
-  • Format conversion (CSV/Parquet - services not available yet)
+  • FHIR validation against a validation service
+  • Flattening FHIR to CSV via fhir-flattener (SQL-on-FHIR ViewDefinitions)
+  • Send to a FHIR server, DSF transfer server, or S3 bucket
+  • Wait checkpoints for manual inspection between steps
 
 Key Features:
   • Session-independent: Resume pipelines across terminal sessions

--- a/config/aether.example.yaml
+++ b/config/aether.example.yaml
@@ -9,9 +9,16 @@ services:
     # TORCH server base URL
     base_url: "http://localhost:8080"
 
-    # TORCH authentication credentials
+    # TORCH authentication credentials (Basic Auth)
     username: "test"
     password: "test"
+
+    # OAuth2 client-credentials auth (alternative to username/password).
+    # When oauth_issuer_uri is set, aether fetches a bearer token from the issuer
+    # and uses it instead of Basic Auth. Keep secrets in environment variables.
+    # oauth_issuer_uri: "${TORCH_OAUTH_ISSUER_URI}"
+    # oauth_client_id: "${TORCH_OAUTH_CLIENT_ID}"
+    # oauth_client_secret: "${TORCH_OAUTH_CLIENT_SECRET}"
 
     # Liveness window: max time to wait WITHOUT a response from TORCH, not a
     # total cap. Reset on every status response (200/202), so a long-running
@@ -158,7 +165,7 @@ services:
       # Leave empty for AWS S3
       # endpoint: "http://localhost:9000"
 
-      # AWS region (default: eu-central-1)
+      # AWS region (required for s3_upload; no default)
       region: "eu-central-1"
 
       # S3 bucket name (required for s3_upload mode)
@@ -206,7 +213,7 @@ services:
 pipeline:
   # List of steps to execute in order
   # Import step options (must be first): torch, local_import, http_import
-  # Other step options: dimp, validation, wait, flattening
+  # Other step options: dimp, validation, wait, flattening, send
   #
   # IMPORTANT: Only ONE import step should be enabled at a time!
   #   - torch: Use with CRTDL for TORCH extraction

--- a/docs/api-reference/cli-commands.md
+++ b/docs/api-reference/cli-commands.md
@@ -119,7 +119,7 @@ aether job list <config>
 ```
 
 **Output columns:**
-- JOB ID - Full UUID
+- JOB ID - Job ID (`YYYYMMDD_HHMM_UUID`)
 - STATUS - completed/in_progress/failed/pending
 - STEP - Current step
 - FILES - Total files processed
@@ -148,7 +148,7 @@ aether job run <config> <job-id> --step <step-name>
 - `--step` - Step to execute (required)
 - `--force` - Re-run the step even if it has already completed
 
-**Valid steps:** `torch`, `local_import`, `http_import`, `dimp`, `validation`
+**Valid steps:** `torch`, `local_import`, `http_import`, `dimp`, `validation`, `flattening`, `send`
 
 **Re-running completed steps:** An already-completed step is not re-run unless
 `--force` is passed. Without `--force`, the command fails fast with `step
@@ -164,7 +164,7 @@ run --step` or by resuming the pipeline.
 
 **Job status after a manual run:** The job-level status is always derived from
 its steps. While a `--force` re-run runs, the job reads `in_progress` (visible in
-`aether job status`). After it finishes, the status is re-derived: the job
+`aether pipeline status`). After it finishes, the status is re-derived: the job
 returns to `completed` only if every step is completed — so re-running the last
 step completes the job, while re-running an earlier step leaves it `in_progress`
 until the invalidated downstream steps re-run. Likewise, a manual run that
@@ -201,14 +201,6 @@ aether completion bash > /etc/bash_completion.d/aether
 
 # Generate zsh completions
 aether completion zsh > "${fpath[1]}/_aether"
-```
-
-### aether version
-
-Show version information.
-
-```bash
-aether version
 ```
 
 ### aether help

--- a/docs/api-reference/config-reference.md
+++ b/docs/api-reference/config-reference.md
@@ -10,9 +10,13 @@ services:
     base_url: string
     username: string
     password: string
-    extraction_timeout: duration  # default: PT30M
-    polling_interval: duration    # default: PT5S
-    max_polling_interval: duration # default: PT30S
+    oauth_issuer_uri: string        # OAuth2 client-credentials (alt to username/password)
+    oauth_client_id: string
+    oauth_client_secret: string
+    extraction_timeout: duration    # default: PT30M
+    polling_interval: duration      # default: PT5S
+    max_polling_interval: duration  # default: PT30S
+    download_stall_timeout: duration # default: PT1M
 
   dimp:
     url: string
@@ -104,16 +108,24 @@ services:
     max_polling_interval: PT30S
 ```
 
+Authenticate with either Basic Auth (`username`/`password`) or OAuth2
+client credentials (`oauth_issuer_uri`/`oauth_client_id`/`oauth_client_secret`);
+when `oauth_issuer_uri` is set, aether uses bearer tokens instead of Basic Auth.
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `base_url` | string | - | TORCH server URL (required if torch step enabled) |
-| `username` | string | - | Authentication username |
-| `password` | string | - | Authentication password |
+| `username` | string | - | Basic Auth username |
+| `password` | string | - | Basic Auth password |
+| `oauth_issuer_uri` | string | - | OAuth2 issuer URI. When set, aether fetches client-credentials bearer tokens instead of using Basic Auth. |
+| `oauth_client_id` | string | - | OAuth2 client ID |
+| `oauth_client_secret` | string | - | OAuth2 client secret |
 | `extraction_timeout` | duration | PT30M | Liveness window, not a total cap: max time to wait without a response from TORCH. Reset on every status response (200/202), so a long but responsive extraction never trips it. See [ADR 0001](../adr/0001-extraction-timeout-liveness.md). |
 | `polling_interval` | duration | PT5S | Initial status check interval |
 | `max_polling_interval` | duration | PT30S | Max interval (exponential backoff cap) |
 | `file_ready_retries` | int | 10 | Number of retries for file availability check |
 | `file_ready_interval` | duration | PT10S | Interval between file availability checks |
+| `download_stall_timeout` | duration | PT1M | Inactivity window while streaming a result file to disk: the download aborts only if no bytes arrive for this long. `0` uses the built-in default. |
 
 ### DIMP
 
@@ -469,7 +481,7 @@ uppercased, with `.` replaced by `_`:
 
 ```bash
 export AETHER_SERVICES_TORCH_BASE_URL="http://torch.internal:8080"
-export AETHER_SERVICES_DIMP_URL="http://dimp.internal:8080/fhir"
+export AETHER_SERVICES_DIMP_URL="http://dimp.internal:8080"
 export AETHER_RETRY_MAX_ATTEMPTS=8
 ```
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -19,7 +19,7 @@ Aether is a command-line tool for orchestrating FHIR data processing pipelines. 
 │  ┌─────────────────────────────────┐   │
 │  │  Cobra Commands                 │   │
 │  │  - pipeline start/continue      │   │
-│  │  - job list/status/logs         │   │
+│  │  - job list/run                 │   │
 │  └──────────┬──────────────────────┘   │
 │             ▼                            │
 │  ┌─────────────────────────────────┐   │
@@ -56,7 +56,7 @@ aether/
 ├── cmd/                      # CLI entry points
 │   ├── root.go               # Root command (aether)
 │   ├── pipeline.go           # Pipeline commands (start, continue, status)
-│   └── job.go                # Job management (list, logs, delete)
+│   └── job.go                # Job management (list, run)
 ├── internal/
 │   ├── models/               # Domain models (immutable)
 │   │   ├── job.go            # PipelineJob, JobStatus
@@ -173,18 +173,17 @@ Job state is persisted to JSON files in the jobs directory:
 ```
 jobs/
 └── {job-id}/
-    ├── status.json               # Job metadata and step status
-    ├── config.json               # Configuration snapshot
+    ├── state.json                       # Job metadata and step status
     ├── import/
-    │   ├── Patient.ndjson.zst    # Compressed FHIR data (zstd)
+    │   ├── Patient.ndjson.zst           # Compressed FHIR data (zstd)
     │   └── Observation.ndjson.zst
     ├── validation/
-    │   ├── Patient.validation.ndjson     # OperationOutcome reports
+    │   ├── Patient.validation.ndjson    # OperationOutcome reports
     │   └── Observation.validation.ndjson
     ├── dimp/
-    │   ├── Patient.ndjson.zst    # De-identified data (zstd)
-    │   └── Observation.ndjson.zst
-    └── logs.txt                  # Execution logs
+    │   ├── dimped_Patient.ndjson.zst    # De-identified data (zstd)
+    │   └── dimped_Observation.ndjson.zst
+    └── job.log                          # Execution logs
 ```
 
 **Note**: File extension is `.ndjson.zst` when compression is enabled (default) or `.ndjson` when disabled.
@@ -233,7 +232,7 @@ Persisted Results
 ### Disk Usage
 
 - One job directory per execution
-- Can clean up old jobs with `aether job delete`
+- Clean up old jobs by removing their directory (`rm -rf jobs/<job-id>`)
 - **Zstd compression** reduces file sizes by 4-7x (enabled by default)
 - Files use `.ndjson.zst` extension when compressed
 - Automatic detection of both compressed and uncompressed files for backward compatibility

--- a/docs/development/coding-guidelines.md
+++ b/docs/development/coding-guidelines.md
@@ -17,10 +17,11 @@ Code style and standards for Aether development. All code must follow these guid
 Use standard Go formatting tools:
 
 ```bash
-# Format code
+# Format code (and order imports via golangci-lint fmt / gci)
 gofmt -w .
+golangci-lint fmt ./...
 
-# Also handles imports and linting
+# Format, vet, and run all tests
 make check
 ```
 
@@ -38,8 +39,8 @@ import (
     "errors"
     "fmt"
 
-    "aether/internal/models"
-    "aether/internal/services"
+    "github.com/medizininformatik-initiative/aether/internal/models"
+    "github.com/medizininformatik-initiative/aether/internal/services"
 )
 
 // ImportStep processes FHIR NDJSON files.
@@ -119,20 +120,33 @@ ic := 0                            // 'ic' is unclear
 
 ### Constants
 
-- Use **UPPERCASE_WITH_UNDERSCORES** for package-level constants
-- Use **CamelCase** for local constants
+- Use **MixedCaps** (not `UPPERCASE_WITH_UNDERSCORES`) — idiomatic Go, and what
+  this codebase uses everywhere
+- Prefer **typed constants** for enumerated values (e.g. `StepName`, `StepStatus`)
+- Export with an uppercase first letter, keep package-private with lowercase
 
 ```go
 // ✅ Good
 const (
-    DEFAULT_TIMEOUT_MINUTES = 30
-    MAX_RETRY_ATTEMPTS = 5
+    DefaultTimeoutMinutes = 30
+    MaxRetryAttempts      = 5
+)
+
+// ✅ Good: typed constants for an enumerated set
+type StepName string
+
+const (
+    StepTorchImport StepName = "torch"
+    StepDIMP        StepName = "dimp"
 )
 
 func doWork() {
     const maxBundleSize = 10 * 1024 * 1024  // Local constant
     ...
 }
+
+// ❌ Bad: screaming snake case is not idiomatic Go
+const MAX_RETRY_ATTEMPTS = 5
 ```
 
 ### Interface Names
@@ -174,8 +188,8 @@ import (
     "github.com/vendor/package"
 
     // Internal packages
-    "aether/internal/models"
-    "aether/internal/services"
+    "github.com/medizininformatik-initiative/aether/internal/models"
+    "github.com/medizininformatik-initiative/aether/internal/services"
 )
 
 // Interfaces
@@ -218,14 +232,14 @@ import (
 
     "github.com/vendor/package"
 
-    "aether/internal/models"
+    "github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 // ❌ Bad
 import (
     "github.com/vendor/package"
     "context"
-    "aether/internal/models"
+    "github.com/medizininformatik-initiative/aether/internal/models"
     "fmt"
 )
 ```
@@ -453,7 +467,7 @@ func ProcessEntries(entries []Entry) []Entry {
 
 ```go
 // ✅ Good
-if err := validateCRTDL.json); err != nil {
+if err := validateCRTDL(crtdlPath); err != nil {
     return fmt.Errorf("invalid CRTDL query: %w", err)
 }
 
@@ -490,7 +504,7 @@ func (e *ValidationError) Error() string {
 // Usage
 if !IsValidInput(input) {
     return &ValidationError{
-        Field:   .json",
+        Field:   "cohort",
         Message: "cohort criteria missing",
     }
 }

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -75,7 +75,7 @@ See [Coding Guidelines](./coding-guidelines.md) for detailed standards.
 
 ## Build Tools
 
-- Go 1.21+ ([download](https://go.dev/dl/))
+- Go 1.26+ ([download](https://go.dev/dl/))
 - Make
 - Git
 - Docker & Docker Compose (for integration tests)
@@ -110,7 +110,7 @@ git checkout -b feature/your-feature-name
 Before committing, ensure code quality:
 
 ```bash
-# Format and lint
+# Format, vet, and run tests
 make check
 
 # Run all tests
@@ -187,7 +187,7 @@ git push origin feature/your-feature-name
 3. **Ensure all checks pass locally:**
 
 ```bash
-make check      # Format and lint
+make check      # Format, vet, and test
 make test       # Unit tests
 make coverage   # Check coverage
 ```
@@ -253,11 +253,11 @@ Your PR will be reviewed for:
 ### Running Specific Tests
 
 ```bash
-# Run tests for specific package
-go test -v ./internal/pipeline/...
+# Run tests for a specific suite
+go test -v ./tests/unit/...
 
 # Run specific test function
-go test -v ./internal/pipeline/ -run TestImportStep
+go test -v ./tests/unit/ -run TestImportStep
 
 # Run with verbose output
 go test -v -count=1 ./...
@@ -269,8 +269,8 @@ go test -race ./...
 ### Debugging
 
 ```bash
-# Enable debug logging
-AETHER_LOG_LEVEL=debug ./bin/aether pipeline start test.json
+# Enable debug logging (the -v/--verbose flag)
+./bin/aether -v pipeline start aether.yaml crtdl.json
 
 # Run with CPU profile
 go test -cpuprofile=cpu.prof ./...
@@ -282,7 +282,7 @@ go tool pprof cpu.prof
 ```bash
 # Start test environment
 cd .github/test
-make services-up
+make start
 
 # Run full test suite
 cd ../..
@@ -290,7 +290,7 @@ make test-with-services
 
 # Stop services
 cd .github/test
-make services-down
+make stop
 ```
 
 ## Common Tasks

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -47,10 +47,10 @@ Unit tests validate pure functions in isolation without external dependencies.
 make test-unit
 
 # Run specific test suite
-go test -v ./internal/pipeline/...
+go test -v ./tests/unit/...
 
 # Run specific test
-go test -v ./internal/pipeline/ -run TestImportStep
+go test -v ./tests/unit/ -run TestImportStep
 ```
 
 ### Unit Test Example
@@ -102,7 +102,7 @@ for _, tc := range testCases {
 // Define interface-based mock
 type mockTORCHClient struct{}
 
-func (m *mockTORCHClient) Extract(ctx context.Context,.json string) (io.Reader, error) {
+func (m *mockTORCHClient) Extract(ctx context.Context, crtdlPath string) (io.Reader, error) {
     return strings.NewReader("sample data"), nil
 }
 
@@ -127,7 +127,7 @@ Integration tests validate the entire pipeline with real services.
 ```bash
 # Start test environment
 cd .github/test
-make services-up
+make start
 
 # In another terminal, run tests
 cd ../..
@@ -135,7 +135,7 @@ make test-integration
 
 # Stop services
 cd .github/test
-make services-down
+make stop
 ```
 
 ### Service-Specific Integration Tests
@@ -166,7 +166,7 @@ func TestTORCHIntegration(t *testing.T) {
     client := services.NewTORCHClient("http://localhost:8080")
 
     // Test with real CRTDL query
-    result, err := client.Extract(context.Background(), "queries/test.json.json")
+    result, err := client.Extract(context.Background(), "queries/test.json")
     assert.NoError(t, err)
     assert.NotNil(t, result)
 }
@@ -180,14 +180,14 @@ Contract tests verify HTTP API specifications between services.
 
 ```bash
 # Start services first
-cd .github/test && make services-up
+cd .github/test && make start
 
 # Run contract tests
 cd ../..
 make test-contract
 
 # Stop services
-cd .github/test && make services-down
+cd .github/test && make stop
 ```
 
 ### Example Contract Test
@@ -235,14 +235,14 @@ Generates coverage report in `coverage/` directory.
 
 1. **Write failing test** (RED):
    ```bash
-   vim internal/pipeline/feature_test.go
-   go test -v ./internal/pipeline/ -run TestNewFeature
+   vim tests/unit/feature_test.go
+   go test -v ./tests/unit/ -run TestNewFeature
    ```
 
 2. **Implement minimum code** (GREEN):
    ```bash
    vim internal/pipeline/feature.go
-   go test -v ./internal/pipeline/ -run TestNewFeature
+   go test -v ./tests/unit/ -run TestNewFeature
    ```
 
 3. **Refactor** (REFACTOR):
@@ -283,7 +283,7 @@ go test -v ./...
 ### Run Specific Test with Debugging
 
 ```bash
-go test -v ./internal/pipeline/ -run TestImportStep -v
+go test -v ./tests/unit/ -run TestImportStep
 ```
 
 ### Profile Test Performance
@@ -306,7 +306,7 @@ go test -race ./...
 Ensure test services are running:
 ```bash
 cd .github/test
-make services-up
+make start
 ```
 
 ### Import Tests Fail

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -32,8 +32,13 @@ services:
     base_url: "https://your-torch-server.org"
     username: "your-username"
     password: "your-password"
-    extraction_timeout: PT30M
+    # OAuth2 client credentials (alternative to username/password):
+    # oauth_issuer_uri: "${TORCH_OAUTH_ISSUER_URI}"
+    # oauth_client_id: "${TORCH_OAUTH_CLIENT_ID}"
+    # oauth_client_secret: "${TORCH_OAUTH_CLIENT_SECRET}"
+    extraction_timeout: PT30M         # liveness window (silence before giving up)
     polling_interval: PT5S
+    download_stall_timeout: PT1M      # abort a result download after this much inactivity
 ```
 
 ### DIMP

--- a/docs/guides/dimp.md
+++ b/docs/guides/dimp.md
@@ -42,8 +42,9 @@ Results are saved in:
 
 ```
 jobs/<job-id>/
-├── status.json          # Job status
-└── dimp_results.ndjson  # Pseudonymized data
+├── state.json                    # Job state and step status
+└── dimp/
+    └── dimped_<name>.ndjson.zst  # Pseudonymized data (one file per input; .ndjson when compression is disabled)
 ```
 
 ## CRTDL Preprocessing

--- a/docs/guides/steps/flattening.md
+++ b/docs/guides/steps/flattening.md
@@ -39,12 +39,22 @@ pipeline:
 
 ## How it Works
 
-1. Parses CRTDL file to extract attribute groups
-2. Builds ViewDefinitions from lookup tables
-3. Streams FHIR resources from input files in a single pass
-4. Routes each resource to its attribute group based on `meta.profile[0]`
-5. When a group's batch exceeds `batch_size_mb`, flushes it to fhir-flattener
-6. Appends CSV output incrementally (one header, multiple data batches)
+Flattening parses the CRTDL to extract attribute groups, builds a ViewDefinition
+for each group from the lookup tables, then runs **two passes** over the input
+files:
+
+1. **Pass 1 — build the Provenance index:** scans every input file for
+   `Provenance` resources only (clinical resources are discarded to keep memory
+   low). Each Provenance maps its `target[].reference`s to an attribute-group ID,
+   taken from the `entity[].what.identifier` entry whose system is the
+   attribute-group naming system.
+2. **Pass 2 — stream, route, and flatten:** streams the clinical resources and
+   routes each one to attribute groups by looking up its `ResourceType/id`
+   reference in the Provenance index. **A resource with no matching entry in the
+   index is dropped** — it is not written to any group.
+3. When a group's batch exceeds its share of `batch_size_mb`, the batch is flushed
+   to fhir-flattener and its CSV output is appended (one header, multiple data
+   batches).
 
 Memory usage is bounded by `batch_size_mb` regardless of total dataset size — the budget is divided equally across attribute groups.
 

--- a/docs/guides/steps/torch-import.md
+++ b/docs/guides/steps/torch-import.md
@@ -27,6 +27,7 @@ services:
     max_polling_interval: PT30S  # default
     file_ready_retries: 10       # default
     file_ready_interval: PT10S   # default
+    download_stall_timeout: PT1M # default
 
 pipeline:
   enabled_steps:
@@ -61,3 +62,4 @@ URLs containing `/fhir/extraction/` or `/fhir/result/` are automatically recogni
 | `max_polling_interval` | duration | PT30S | Max interval (exponential backoff) |
 | `file_ready_retries` | int | 10 | Retries while waiting for files to appear after extraction completes |
 | `file_ready_interval` | duration | PT10S | Interval between file-availability checks |
+| `download_stall_timeout` | duration | PT1M | Inactivity window while streaming a result file; the download aborts only if no bytes arrive for this long. `0` uses the built-in default. |

--- a/docs/guides/torch-integration.md
+++ b/docs/guides/torch-integration.md
@@ -50,11 +50,14 @@ services:
     base_url: "https://your-torch-server.org"
     username: "your-username"
     password: "your-password"
-    extraction_timeout: PT1H     # Default is PT30M
-    polling_interval: PT10S      # Default is PT5S
+    extraction_timeout: PT1H       # Default is PT30M
+    polling_interval: PT10S        # Default is PT5S
+    download_stall_timeout: PT2M   # Default is PT1M
 ```
 
 `extraction_timeout` is a **liveness window**, not a total cap: it bounds how long aether waits *without a response from TORCH*, and it resets on every status response (`200`/`202`). A multi-hour extraction that keeps responding never trips it, so you no longer need to size the timeout to the whole extraction — the default `PT30M` means "give up after 30 minutes of TORCH silence". See [ADR 0001](../adr/0001-extraction-timeout-liveness.md).
+
+`download_stall_timeout` (default `PT1M`) is a similar liveness window for the *download* of each result file: aether aborts a download only if no bytes arrive for this long. A large but steadily streaming NDJSON file completes regardless of total size, while a hung connection fails fast — so it never needs to be sized to the largest expected download.
 
 ### Polling Resilience
 

--- a/docs/shell-completions.md
+++ b/docs/shell-completions.md
@@ -109,8 +109,7 @@ Aether completions provide suggestions for:
   - `pipeline start`, `pipeline status`, `pipeline continue`
   - `job list`, `job run`
   - `completion bash`, `completion zsh`, `completion fish`, `completion powershell`
-- **Flags**: `--verbose`, `--help`, `--version`, `--no-progress`, `--dir`, `--allow-http-crtdl`, `--step`
-- **Job IDs**: Tab-complete existing job IDs for `pipeline status` and `pipeline continue`
+- **Flags**: `--verbose`, `--help`, `--version`, `--no-progress`, `--dir`, `--allow-http-crtdl`, `--step`, `--force`
 - **File paths**: Autocomplete paths for `pipeline start` input
 
 ## Examples
@@ -118,13 +117,10 @@ Aether completions provide suggestions for:
 ```bash
 # Type and press TAB
 aether <TAB>
-# Shows: pipeline  job  completion  help  version
+# Shows: pipeline  job  completion  help
 
 aether pipeline <TAB>
 # Shows: start  status  continue
-
-aether pipeline status <TAB>
-# Shows: list of existing job IDs
 
 aether pipeline start <TAB>
 # Shows: files and directories in current path
@@ -167,18 +163,6 @@ source ~/.zshrc
 2. Check `_aether` file exists in that directory
 3. Verify `aether` is in your plugins array: `grep "plugins=" ~/.zshrc`
 4. Restart shell: `exec zsh`
-
-### Completions work but job IDs don't autocomplete
-
-Job ID completion requires:
-- The `jobs` directory exists
-- You have created at least one job
-- The shell has permission to read the jobs directory
-
-Check with:
-```bash
-ls -la jobs/
-```
 
 ## Uninstallation
 


### PR DESCRIPTION
## Summary

Fixes #553. A docs-audit found CLI help and several published docs described behavior that no longer exists or never existed. This brings them back in line with the current code (each claim verified against source).

## Changes

**CLI help (code):**
- `cmd/root.go`: rewrote the feature overview to the real step set (TORCH/local/HTTP import, DIMP, validation, flattening, send, wait); removed the "not yet implemented" validation note and the CSV/Parquet "services not available yet" claim (no Parquet exists anywhere).
- `cmd/job.go`, `cmd/pipeline.go`: the lock-contention hint and a code comment now point at `pipeline status` (there is no `job status` command).

**Docs:**
- `cli-commands.md`: job-id format `YYYYMMDD_HHMM_UUID` (or legacy UUID); valid-steps list now includes `flattening`/`send`; removed the nonexistent `aether version` subcommand; `job status` -> `pipeline status`.
- `shell-completions.md`: removed job-id tab-completion and `version` claims (no `ValidArgsFunction` exists); added `--force`.
- `coding-guidelines.md`: real module path `github.com/medizininformatik-initiative/aether/...`; MixedCaps typed-constant guidance; fixed mangled find/replace snippets.
- `testing.md` / `contributing.md`: real make targets (`make start`/`make stop`); tests live under `tests/{unit,integration,contract}`; verbosity via `-v/--verbose` (no `AETHER_LOG_LEVEL`); `make check` = fmt+vet+test; dropped the unsupported `make test TEST=`.
- `architecture.md` / `dimp.md`: real job layout -- `state.json`, `dimp/dimped_<name>.ndjson(.zst)`; removed the nonexistent `aether job delete`.
- `flattening.md`: describes the real two-pass Provenance-index routing (resources absent from the index are dropped).

**Config docs:**
- `aether.example.yaml`, `config-reference.md`, `configuration.md`: documented TORCH OAuth2 (`oauth_issuer_uri`/`oauth_client_id`/`oauth_client_secret`) and `download_stall_timeout`; S3 region marked required (no default); `send` added to the step-list comment; fixed the `AETHER_SERVICES_DIMP_URL` example that wrongly ended in `/fhir`.

**Cross-cutting:**
- `README.md` badge and both CONTRIBUTING docs -> Go 1.26 (matches `go.mod`); CONTRIBUTING links use the `/stable/` path segment.

Verified `go build ./...` and `go test ./cmd/...` pass; gofmt clean.

Closes #553
