### PR TITLE
fix(renovate): stop version-only managers shadowing the digest-aware one

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     "config:best-practices",
     ":automergeMinor",
     ":automergeDigest",
-    ":maintainLockFilesWeekly",
-    "customManagers:githubActionsVersions"
+    ":maintainLockFilesWeekly"
   ],
   "ignorePaths": [
     "**/node_modules/**",
@@ -44,7 +43,8 @@
   "customManagers": [
     {
       "description": [
-        "Like customManagers:githubActionsVersions, but also finds the digest for github-release-attachments datasource."
+        "Owns UPPERCASE *_VERSION env vars, which must be paired with a *_CHECKSUM line so version and digest are rewritten together.",
+        "Replaces customManagers:githubActionsVersions, which matches the same annotations but rewrites only the version line."
       ],
       "customType": "regex",
       "managerFilePatterns": [
@@ -58,7 +58,8 @@
     },
     {
       "description": [
-        "Like customManagers:githubActionsVersions, but matches annotated action inputs (e.g. version:) instead of _VERSION env vars."
+        "Owns lowercase annotated action inputs (e.g. version:).",
+        "The leading [a-z] keeps it off UPPERCASE *_VERSION env vars owned by the digest-aware manager above; overlapping there would rewrite the version and leave the checksum stale."
       ],
       "customType": "regex",
       "managerFilePatterns": [
@@ -66,7 +67,7 @@
         "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+\\w+\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[a-z][\\w-]*\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
       ]
     }
   ]


### PR DESCRIPTION
Closes #589

## Problem

PR #588 bumped `BLAZECTL_VERSION` to v1.5.0 and left the v1.4.0 `BLAZECTL_CHECKSUM`, which breaks `sha256sum -c` in `.github/scripts/install-blazectl.sh`.

## Root cause (verified by dry run)

`npx renovate --platform=local --dry-run=full` with `LOG_LEVEL=debug` showed **three** managers matching the same annotated block, producing 6 blazectl deps from 2 occurrences:

| Source | Captures digest? | `replaceString` covers |
|---|---|---|
| `customManagers:githubActionsVersions` (preset in `extends`) | no | version line only |
| custom manager 1 (digest-aware) | yes | version + checksum |
| custom manager 2 (generic annotated inputs) | no | version line only |

The digest lookup itself was never the problem — the digest-aware manager resolved `newDigest: bb2127c2…` correctly. The two version-only managers simply shadowed it.

## Fix

- Drop `customManagers:githubActionsVersions` from `extends`. Custom manager 2 already matches a superset of it (`\w+` covers `*_VERSION` keys), so it contributed nothing but the collision.
- Anchor custom manager 2's key pattern to `[a-z][\w-]*` so it owns lowercase action inputs (`version:`) and UPPERCASE `*_VERSION` env vars belong solely to the digest-aware manager.

Renovate runs RE2 (`DEBUG: Using RE2 regex engine`), so a negative lookahead to exclude the checksum-paired block was not available; splitting on key case is the RE2-safe equivalent.

## Verification

Re-ran the same dry run against the patched config:

- blazectl deps: 6 → 2, each with `currentDigest`, `newDigest`, and a `replaceString` spanning both the version and checksum lines.
- `golangci/golangci-lint` (lowercase `version:` input) still extracted, so manager 2 is not regressed.
- Renovate's `newDigest` `bb2127c23d3a523e5fd02b3fa84decee27eb5ec32f8726ce1f3f29b49182ff5f` matches `sha256sum` of the real `blazectl-1.5.0-linux-amd64.tar.gz`.

## Follow-up

- PR #588 should be closed so Renovate regenerates it with both lines updated.
- Known trade-off: an UPPERCASE `*_VERSION` env var added *without* a paired `*_CHECKSUM` is now silently untracked. The manager `description` fields record this; a CI lint over `# renovate:` annotations would close the gap if it becomes a recurring pattern.