### PR TITLE
docs: add AI-assisted contributions section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,21 @@ cd docs && npm install && npm run docs:build
 - Maintain or improve test coverage
 - Follow [Coding Guidelines](https://medizininformatik-initiative.github.io/aether/stable/development/coding-guidelines.html)
 
+## AI-Assisted Contributions
+
+AI tools are allowed. We don't ask you to disclose their use — but you own
+the result either way.
+
+**DCO — you sign, you own it.** Every commit must carry a `Signed-off-by`
+line (`git commit -s`). By signing off you certify the
+[Developer Certificate of Origin](https://developercertificate.org/): you
+understand the code, you have the right to submit it, and **you are
+responsible for it** — regardless of how it was written. Never let an AI
+tool add its own `Signed-off-by`; only a human can certify the DCO.
+
+You must understand your own changes. If you can't explain what your patch
+does and why, it will be closed.
+
 ## License
 
 Aether is released under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). By contributing to this project, you agree that your contributions will be licensed under the same license.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -73,6 +73,21 @@ All contributions must meet these standards:
 
 See [Coding Guidelines](./coding-guidelines.md) for detailed standards.
 
+## AI-Assisted Contributions
+
+AI tools are allowed. We don't ask you to disclose their use — but you own
+the result either way.
+
+**DCO — you sign, you own it.** Every commit must carry a `Signed-off-by`
+line (`git commit -s`). By signing off you certify the
+[Developer Certificate of Origin](https://developercertificate.org/): you
+understand the code, you have the right to submit it, and **you are
+responsible for it** — regardless of how it was written. Never let an AI
+tool add its own `Signed-off-by`; only a human can certify the DCO.
+
+You must understand your own changes. If you can't explain what your patch
+does and why, it will be closed.
+
 ## Build Tools
 
 - Go 1.26+ ([download](https://go.dev/dl/))


### PR DESCRIPTION
## Summary
Adds an **AI-Assisted Contributions** section to both `CONTRIBUTING.md` and the docs contributing page (`docs/development/contributing.md`).

The section states that AI tools are allowed (no disclosure required) and clarifies DCO responsibility: contributors sign off, own, and must be able to explain their changes — regardless of how the code was written. It also notes that only a human may add the `Signed-off-by` line.

## Changes
- `CONTRIBUTING.md`: new section after "Requirements for Acceptable Contributions"
- `docs/development/contributing.md`: same section, before "Build Tools"

Docs build (`npm run docs:build`) passes cleanly.

Closes #602