### PR TITLE
fix(flattening): skip child attributeRefs covered by a parent ref

### DIFF
--- a/.github/test/example-flattening/queries/example-crtdl.json
+++ b/.github/test/example-flattening/queries/example-crtdl.json
@@ -72,6 +72,10 @@
             "mustHave": true
           },
           {
+            "attributeRef": "Condition.code.coding:sct",
+            "mustHave": false
+          },
+          {
             "attributeRef": "Condition.recordedDate",
             "mustHave": false
           },

--- a/.github/test/example-flattening/queries/flatten-lookup.json
+++ b/.github/test/example-flattening/queries/flatten-lookup.json
@@ -87,7 +87,6 @@
                 ]
             },
             "Condition.code.coding:sct": {
-                "parent": "Condition.code",
                 "viewDefinition": {
                     "forEachOrNull": "coding.where(system = 'http://snomed.info/sct')",
                     "select": [

--- a/internal/services/viewdefinition_builder.go
+++ b/internal/services/viewdefinition_builder.go
@@ -54,7 +54,7 @@ func (b *ViewDefinitionBuilder) BuildViewDefinition(group models.AttributeGroup)
 	for _, attr := range group.Attributes {
 		// Skip if this element's parent (or any ancestor) is already in the attribute list
 		// Parent's downward traversal will include this child automatically
-		if isParentInAttributeList(lookup, attr.AttributeRef, attrRefSet) {
+		if hasAncestorRef(lookup, attr.AttributeRef, attrRefSet) || isParentInAttributeList(lookup, attr.AttributeRef, attrRefSet) {
 			continue
 		}
 
@@ -68,6 +68,20 @@ func (b *ViewDefinitionBuilder) BuildViewDefinition(group models.AttributeGroup)
 
 	viewDef.Select = selectClauses
 	return &viewDef, nil
+}
+
+// hasAncestorRef checks if any prefix of ref that ends at a "." boundary is in the
+// attribute list (e.g. "Encounter.extension:A" is an ancestor of
+// "Encounter.extension:A.extension:B"). Unlike isParentInAttributeList, this works
+// without Parent links in the lookup table. The ancestor must resolve in the
+// lookup table — otherwise it produces no columns and the child must stay.
+func hasAncestorRef(lookup *models.LookupTable, ref string, attrRefs map[string]bool) bool {
+	for i := len(ref) - 1; i > 0; i-- {
+		if ref[i] == '.' && attrRefs[ref[:i]] && GetElement(lookup, ref[:i]) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // isParentInAttributeList checks if the element's parent (or any ancestor) is in the attribute list.

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -1127,6 +1127,96 @@ func TestBuildViewDefinitionWithOverlappingAttributes(t *testing.T) {
 	})
 }
 
+func TestParentAndChildAttributeRefsWithoutParentLinks(t *testing.T) {
+	t.Run("child ref is skipped even when lookup has no parent links", func(t *testing.T) {
+		// Mirrors issue #619: the lookup resolves the child through the parent's
+		// children list, but the child element itself has no Parent link, so the
+		// ancestry-based skip cannot detect the overlap.
+		lookupTables := []models.LookupTable{
+			newLookupTable("https://example.com/Encounter", "Encounter", map[string]models.LookupElement{
+				"Encounter.extension:Aufnahmegrund": {
+					Children: []string{"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle"},
+					ViewDefinition: models.ViewDefSnippet{
+						ForEachOrNull: "extension.where(url = 'aufnahmegrund')",
+					},
+				},
+				"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle": {
+					ViewDefinition: models.ViewDefSnippet{
+						ForEachOrNull: "extension.where(url = 'ErsteUndZweiteStelle')",
+						Column: []models.ColumnDefinition{
+							{Name: "aufnahmegrund_stelle12_code", Path: "value.code"},
+						},
+					},
+				},
+			}),
+		}
+
+		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
+			"Encounter.extension:Aufnahmegrund",
+			"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle",
+		)
+
+		viewDef := buildAndAssertViewDef(t, lookupTables, group)
+
+		columnNames := services.ExtractColumnNames(*viewDef)
+		assert.Equal(t, 1, countOccurrences(columnNames, "aufnahmegrund_stelle12_code"),
+			"aufnahmegrund_stelle12_code should appear exactly once")
+	})
+
+	t.Run("child ref is kept when the parent ref is missing from the lookup", func(t *testing.T) {
+		// The parent produces no columns, so skipping the child would lose
+		// its data entirely.
+		lookupTables := []models.LookupTable{
+			newLookupTable("https://example.com/Encounter", "Encounter", map[string]models.LookupElement{
+				"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle": {
+					ViewDefinition: models.ViewDefSnippet{
+						ForEachOrNull: "extension.where(url = 'ErsteUndZweiteStelle')",
+						Column: []models.ColumnDefinition{
+							{Name: "aufnahmegrund_stelle12_code", Path: "value.code"},
+						},
+					},
+				},
+			}),
+		}
+
+		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
+			"Encounter.extension:Aufnahmegrund",
+			"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle",
+		)
+
+		viewDef := buildAndAssertViewDef(t, lookupTables, group)
+
+		columnNames := services.ExtractColumnNames(*viewDef)
+		assert.Contains(t, columnNames, "aufnahmegrund_stelle12_code")
+	})
+
+	t.Run("sibling ref sharing a string prefix is not skipped", func(t *testing.T) {
+		// "Encounter.classHistory" starts with "Encounter.class" as a string,
+		// but it is a sibling, not a child, so both must produce columns.
+		lookupTables := []models.LookupTable{
+			newLookupTable("https://example.com/Encounter", "Encounter", map[string]models.LookupElement{
+				"Encounter.class": {
+					ViewDefinition: newViewDefSnippet(newSelectClause("class_code", "class.code")),
+				},
+				"Encounter.classHistory": {
+					ViewDefinition: newViewDefSnippet(newSelectClause("class_history_code", "classHistory.class.code")),
+				},
+			}),
+		}
+
+		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
+			"Encounter.class",
+			"Encounter.classHistory",
+		)
+
+		viewDef := buildAndAssertViewDef(t, lookupTables, group)
+
+		columnNames := services.ExtractColumnNames(*viewDef)
+		assert.Contains(t, columnNames, "class_code")
+		assert.Contains(t, columnNames, "class_history_code")
+	})
+}
+
 // TestCloneSelectClause tests the cloneSelectClause function
 func TestCloneSelectClause(t *testing.T) {
 	t.Run("parent with forEach in select clause wraps child correctly", func(t *testing.T) {


### PR DESCRIPTION
## Summary

When a CRTDL attribute group lists both a parent `attributeRef` (e.g. `Encounter.extension:Aufnahmegrund`) and one of its children (e.g. `Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle`), the child resolved twice: once through the parent's downward traversal and once standalone. The existing ancestry check (`isParentInAttributeList`) only detects the overlap when the lookup table carries `Parent` links, so lookups without them produced duplicate columns and the flattener rejected the ViewDefinition with HTTP 500.

## Changes

- Add `hasAncestorRef` to `ViewDefinitionBuilder`: skip an attributeRef when another ref in the same group is a prefix of it at a `.` boundary and that ancestor resolves in the lookup table.
- The resolve guard keeps the child when the parent ref is missing from the lookup table, so its columns are not lost.
- Refs that only share a string prefix without a `.` boundary (e.g. `Encounter.class` vs `Encounter.classHistory`) are not affected.
- Unit tests for all three cases in `tests/unit/viewdefinition_builder_test.go`.

Closes #619