### PR TITLE
fix(flattening): normalize parent links in lookup tables at load time

### DIFF
--- a/.github/test/example-flattening/queries/flatten-lookup.json
+++ b/.github/test/example-flattening/queries/flatten-lookup.json
@@ -108,7 +108,6 @@
                 }
             },
             "Condition.code.coding:icd10-gm": {
-                "parent": "Condition.code",
                 "viewDefinition": {
                     "forEachOrNull": "coding.where(system = 'http://fhir.de/CodeSystem/bfarm/icd-10-gm')",
                     "select": [
@@ -130,7 +129,6 @@
                 }
             },
             "Condition.code.coding:alpha-id": {
-                "parent": "Condition.code",
                 "viewDefinition": {
                     "forEachOrNull": "coding.where(system = 'http://fhir.de/CodeSystem/bfarm/alpha-id')",
                     "select": [
@@ -152,7 +150,6 @@
                 }
             },
             "Condition.code.coding:orphanet": {
-                "parent": "Condition.code",
                 "viewDefinition": {
                     "forEachOrNull": "coding.where(system = 'http://www.orpha.net')",
                     "select": [
@@ -263,7 +260,6 @@
                 ]
             },
             "Procedure.code.coding:ops": {
-                "parent": "Procedure.code",
                 "viewDefinition": {
                     "forEachOrNull": "coding.where(system = 'http://fhir.de/CodeSystem/bfarm/ops')",
                     "select": [
@@ -283,7 +279,6 @@
                 }
             },
             "Procedure.code.coding:sct": {
-                "parent": "Procedure.code",
                 "viewDefinition": {
                     "forEachOrNull": "coding.where(system = 'http://snomed.info/sct')",
                     "select": [

--- a/.github/test/torch/queries/flatten-lookup.json
+++ b/.github/test/torch/queries/flatten-lookup.json
@@ -68,7 +68,6 @@
         }
       },
       "Patient.name.family": {
-        "parent": "Patient.name",
         "viewDefinition": {
           "select": [
             {
@@ -80,7 +79,6 @@
         }
       },
       "Patient.name.given": {
-        "parent": "Patient.name",
         "viewDefinition": {
           "select": [
             {
@@ -135,7 +133,6 @@
         }
       },
       "Condition.coding.icd10": {
-        "parent": "Condition.coding",
         "viewDefinition": {
           "select": [
             {
@@ -149,7 +146,6 @@
         }
       },
       "Condition.coding.snomed": {
-        "parent": "Condition.coding",
         "viewDefinition": {
           "select": [
             {

--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -73,7 +73,7 @@ func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 	// Load lookup tables
 	lookupPath := job.Config.Services.Flattening.LookupPath
 	logger.Debug("Loading lookup tables", "path", lookupPath)
-	lookupTables, err := services.LoadLookupTables(lookupPath)
+	lookupTables, err := services.LoadLookupTables(lookupPath, logger)
 	if err != nil {
 		return StepResult{}, fmt.Errorf("failed to load lookup tables: %w", err)
 	}

--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -34,7 +34,44 @@ func LoadLookupTables(path string) ([]models.LookupTable, error) {
 		}
 	}
 
+	if err := NormalizeLookupTables(tables); err != nil {
+		return nil, err
+	}
+
 	return tables, nil
+}
+
+// NormalizeLookupTables derives every Parent link from the Children lists.
+// Authored parent values are ignored: each Parent is cleared and set to the
+// element whose Children list names it. A child that two elements claim is an error.
+func NormalizeLookupTables(tables []models.LookupTable) error {
+	for _, table := range tables {
+		for elementID, element := range table.Elements {
+			if element.Parent != "" {
+				element.Parent = ""
+				table.Elements[elementID] = element
+			}
+		}
+
+		claimedBy := make(map[string]string)
+		for elementID, element := range table.Elements {
+			for _, childID := range element.Children {
+				if parentID, claimed := claimedBy[childID]; claimed && parentID != elementID {
+					return fmt.Errorf("element '%s' is listed as child of both '%s' and '%s' in profile '%s'",
+						childID, parentID, elementID, table.URL)
+				}
+				claimedBy[childID] = elementID
+
+				child, exists := table.Elements[childID]
+				if !exists {
+					continue
+				}
+				child.Parent = elementID
+				table.Elements[childID] = child
+			}
+		}
+	}
+	return nil
 }
 
 // GetProfileLookup finds a LookupTable by profile URL
@@ -84,6 +121,7 @@ func GetElementChildren(table *models.LookupTable, elementID string) []models.Lo
 // - Duplicate profile URLs
 // - Circular references in children
 // - Invalid child references
+// - Invalid parent references
 func ValidateLookupTables(tables []models.LookupTable) error {
 	// Check for duplicate URLs
 	urlSet := make(map[string]bool)
@@ -94,7 +132,7 @@ func ValidateLookupTables(tables []models.LookupTable) error {
 		urlSet[table.URL] = true
 	}
 
-	// Check for invalid child references within each table
+	// Check for invalid child and parent references within each table
 	for _, table := range tables {
 		for elementID, element := range table.Elements {
 			for _, childID := range element.Children {
@@ -103,8 +141,53 @@ func ValidateLookupTables(tables []models.LookupTable) error {
 						elementID, childID, table.URL)
 				}
 			}
+			if element.Parent != "" {
+				if _, exists := table.Elements[element.Parent]; !exists {
+					return fmt.Errorf("element '%s' references non-existent parent '%s' in profile '%s'",
+						elementID, element.Parent, table.URL)
+				}
+			}
+		}
+		if err := detectChildrenCycle(table); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// detectChildrenCycle reports an error when the Children lists of a table form a cycle.
+// The builder recurses over Children and Parent links, so a cycle would not terminate.
+func detectChildrenCycle(table models.LookupTable) error {
+	const inProgress, done = 1, 2
+	state := make(map[string]int)
+
+	var visit func(elementID string) error
+	visit = func(elementID string) error {
+		switch state[elementID] {
+		case inProgress:
+			return fmt.Errorf("circular children reference involving element '%s' in profile '%s'",
+				elementID, table.URL)
+		case done:
+			return nil
+		}
+		state[elementID] = inProgress
+		for _, childID := range table.Elements[elementID].Children {
+			if _, exists := table.Elements[childID]; !exists {
+				continue
+			}
+			if err := visit(childID); err != nil {
+				return err
+			}
+		}
+		state[elementID] = done
+		return nil
+	}
+
+	for elementID := range table.Elements {
+		if err := visit(elementID); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -172,10 +172,9 @@ func detectChildrenCycle(table models.LookupTable) error {
 			return nil
 		}
 		state[elementID] = inProgress
+		// A childID that is not in Elements is rejected by ValidateLookupTables
+		// before this runs; visiting it is a harmless no-op (no children).
 		for _, childID := range table.Elements[elementID].Children {
-			if _, exists := table.Elements[childID]; !exists {
-				continue
-			}
 			if err := visit(childID); err != nil {
 				return err
 			}

--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -116,12 +116,13 @@ func GetElementChildren(table *models.LookupTable, elementID string) []models.Lo
 	return children
 }
 
-// ValidateLookupTables performs additional validation on the lookup tables
+// ValidateLookupTables performs additional validation on the lookup tables.
+// It expects tables that NormalizeLookupTables has processed, so Parent links
+// are derived and need no check of their own.
 // Checks for:
 // - Duplicate profile URLs
 // - Circular references in children
 // - Invalid child references
-// - Invalid parent references
 func ValidateLookupTables(tables []models.LookupTable) error {
 	// Check for duplicate URLs
 	urlSet := make(map[string]bool)
@@ -132,19 +133,13 @@ func ValidateLookupTables(tables []models.LookupTable) error {
 		urlSet[table.URL] = true
 	}
 
-	// Check for invalid child and parent references within each table
+	// Check for invalid child references within each table
 	for _, table := range tables {
 		for elementID, element := range table.Elements {
 			for _, childID := range element.Children {
 				if _, exists := table.Elements[childID]; !exists {
 					return fmt.Errorf("element '%s' references non-existent child '%s' in profile '%s'",
 						elementID, childID, table.URL)
-				}
-			}
-			if element.Parent != "" {
-				if _, exists := table.Elements[element.Parent]; !exists {
-					return fmt.Errorf("element '%s' references non-existent parent '%s' in profile '%s'",
-						elementID, element.Parent, table.URL)
 				}
 			}
 		}

--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 
+	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
 // LoadLookupTables loads the lookup tables from a JSON file
 // The file contains an array of LookupTable objects
-func LoadLookupTables(path string) ([]models.LookupTable, error) {
+// A nil logger suppresses the deprecation warning for authored parent fields.
+func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read lookup file: %w", err)
@@ -34,7 +37,7 @@ func LoadLookupTables(path string) ([]models.LookupTable, error) {
 		}
 	}
 
-	if err := NormalizeLookupTables(tables); err != nil {
+	if err := NormalizeLookupTables(tables, logger); err != nil {
 		return nil, err
 	}
 
@@ -44,13 +47,23 @@ func LoadLookupTables(path string) ([]models.LookupTable, error) {
 // NormalizeLookupTables derives every Parent link from the Children lists.
 // Authored parent values are ignored: each Parent is cleared and set to the
 // element whose Children list names it. A child that two elements claim is an error.
-func NormalizeLookupTables(tables []models.LookupTable) error {
+// Authored parent fields are deprecated; when logger is non-nil, each profile
+// that sets them produces one warning.
+func NormalizeLookupTables(tables []models.LookupTable, logger *lib.Logger) error {
 	for _, table := range tables {
+		var authored []string
 		for elementID, element := range table.Elements {
 			if element.Parent != "" {
+				authored = append(authored, elementID)
 				element.Parent = ""
 				table.Elements[elementID] = element
 			}
+		}
+		if len(authored) > 0 && logger != nil {
+			sort.Strings(authored)
+			logger.Warn("lookup table sets deprecated 'parent' fields; the values are ignored and derived from 'children' lists instead, and the field will be removed in a future flatten-lookup version",
+				"profile", table.URL,
+				"elements", authored)
 		}
 
 		claimedBy := make(map[string]string)

--- a/internal/services/viewdefinition_builder.go
+++ b/internal/services/viewdefinition_builder.go
@@ -54,7 +54,7 @@ func (b *ViewDefinitionBuilder) BuildViewDefinition(group models.AttributeGroup)
 	for _, attr := range group.Attributes {
 		// Skip if this element's parent (or any ancestor) is already in the attribute list
 		// Parent's downward traversal will include this child automatically
-		if hasAncestorRef(lookup, attr.AttributeRef, attrRefSet) || isParentInAttributeList(lookup, attr.AttributeRef, attrRefSet) {
+		if isParentInAttributeList(lookup, attr.AttributeRef, attrRefSet) {
 			continue
 		}
 
@@ -70,21 +70,8 @@ func (b *ViewDefinitionBuilder) BuildViewDefinition(group models.AttributeGroup)
 	return &viewDef, nil
 }
 
-// hasAncestorRef checks if any prefix of ref that ends at a "." boundary is in the
-// attribute list (e.g. "Encounter.extension:A" is an ancestor of
-// "Encounter.extension:A.extension:B"). Unlike isParentInAttributeList, this works
-// without Parent links in the lookup table. The ancestor must resolve in the
-// lookup table — otherwise it produces no columns and the child must stay.
-func hasAncestorRef(lookup *models.LookupTable, ref string, attrRefs map[string]bool) bool {
-	for i := len(ref) - 1; i > 0; i-- {
-		if ref[i] == '.' && attrRefs[ref[:i]] && GetElement(lookup, ref[:i]) != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // isParentInAttributeList checks if the element's parent (or any ancestor) is in the attribute list.
+// NormalizeLookupTables derives Parent links at load time, so the parent chain is complete here.
 // This is used to avoid duplicates when both a parent and its children are specified in the CRTDL.
 // When a parent is in the list, its downward traversal includes all children automatically,
 // so the children should be skipped to avoid duplicates.

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -430,18 +430,4 @@ func TestValidateLookupTables(t *testing.T) {
 		assert.Contains(t, err.Error(), "circular")
 	})
 
-	t.Run("invalid parent reference", func(t *testing.T) {
-		tables := []models.LookupTable{
-			{
-				URL:          "https://example.com/Patient",
-				ResourceType: "Patient",
-				Elements: map[string]models.LookupElement{
-					"Patient.name.family": {Parent: "Patient.nonexistent"},
-				},
-			},
-		}
-		err := services.ValidateLookupTables(tables)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "non-existent parent")
-	})
 }

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -294,6 +294,26 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		assert.Empty(t, child.Parent)
 	})
 
+	t.Run("skips a child ID that is not in the elements map", func(t *testing.T) {
+		tables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Encounter",
+				ResourceType: "Encounter",
+				Elements: map[string]models.LookupElement{
+					"Encounter.extension:A": {
+						Children: []string{"Encounter.extension:A.extension:Missing", "Encounter.extension:A.extension:B"},
+					},
+					"Encounter.extension:A.extension:B": {},
+				},
+			},
+		}
+
+		err := services.NormalizeLookupTables(tables)
+		require.NoError(t, err)
+		assert.Equal(t, "Encounter.extension:A", tables[0].Elements["Encounter.extension:A.extension:B"].Parent)
+		assert.NotContains(t, tables[0].Elements, "Encounter.extension:A.extension:Missing")
+	})
+
 	t.Run("rejects a child claimed by two parents", func(t *testing.T) {
 		tempDir := t.TempDir()
 		lookupPath := filepath.Join(tempDir, "lookup.json")
@@ -360,6 +380,23 @@ func TestValidateLookupTables(t *testing.T) {
 		err := services.ValidateLookupTables(tables)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "non-existent child")
+	})
+
+	t.Run("valid nested children hierarchy", func(t *testing.T) {
+		tables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Patient",
+				ResourceType: "Patient",
+				Elements: map[string]models.LookupElement{
+					"Patient.a":     {Children: []string{"Patient.a.b", "Patient.a.c"}},
+					"Patient.a.b":   {Children: []string{"Patient.a.b.d"}},
+					"Patient.a.c":   {},
+					"Patient.a.b.d": {},
+				},
+			},
+		}
+		err := services.ValidateLookupTables(tables)
+		assert.NoError(t, err)
 	})
 
 	t.Run("circular children reference", func(t *testing.T) {

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
@@ -33,7 +35,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath)
+		tables, err := services.LoadLookupTables(lookupPath, nil)
 		require.NoError(t, err)
 		assert.Len(t, tables, 1)
 		assert.Equal(t, "https://example.com/Patient", tables[0].URL)
@@ -59,7 +61,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath)
+		tables, err := services.LoadLookupTables(lookupPath, nil)
 		require.NoError(t, err)
 		assert.Len(t, tables, 2)
 	})
@@ -71,7 +73,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath)
+		_, err = services.LoadLookupTables(lookupPath, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing 'url' field")
 	})
@@ -83,13 +85,13 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath)
+		_, err = services.LoadLookupTables(lookupPath, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing 'resourceType' field")
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		_, err := services.LoadLookupTables("/nonexistent/path/lookup.json")
+		_, err := services.LoadLookupTables("/nonexistent/path/lookup.json", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read lookup file")
 	})
@@ -100,7 +102,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte("not valid json"), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath)
+		_, err = services.LoadLookupTables(lookupPath, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse lookup file")
 	})
@@ -202,7 +204,7 @@ func TestLoadLookupTablesMissingElements(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath)
+		_, err = services.LoadLookupTables(lookupPath, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing 'elements' field")
 	})
@@ -233,7 +235,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath)
+		tables, err := services.LoadLookupTables(lookupPath, nil)
 		require.NoError(t, err)
 		child := tables[0].Elements["Encounter.extension:A.extension:B"]
 		assert.Equal(t, "Encounter.extension:A", child.Parent)
@@ -261,7 +263,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath)
+		tables, err := services.LoadLookupTables(lookupPath, nil)
 		require.NoError(t, err)
 		child := tables[0].Elements["Encounter.extension:A.extension:B"]
 		assert.Equal(t, "Encounter.extension:A", child.Parent)
@@ -288,7 +290,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath)
+		tables, err := services.LoadLookupTables(lookupPath, nil)
 		require.NoError(t, err)
 		child := tables[0].Elements["Encounter.extension:A.extension:B"]
 		assert.Empty(t, child.Parent)
@@ -308,7 +310,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 			},
 		}
 
-		err := services.NormalizeLookupTables(tables)
+		err := services.NormalizeLookupTables(tables, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Encounter.extension:A", tables[0].Elements["Encounter.extension:A.extension:B"].Parent)
 		assert.NotContains(t, tables[0].Elements, "Encounter.extension:A.extension:Missing")
@@ -339,11 +341,76 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath)
+		_, err = services.LoadLookupTables(lookupPath, nil)
 		require.Error(t, err)
 		// Map order decides which parent backfills first and which one the
 		// error names, so assert only the child ID.
 		assert.Contains(t, err.Error(), "Encounter.extension:A.extension:C")
+	})
+}
+
+func TestLoadLookupTablesWarnsOnAuthoredParentFields(t *testing.T) {
+	t.Run("warns once per profile that sets deprecated parent fields", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"children": ["Encounter.extension:A.extension:B"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:A.extension:B": {
+						"parent": "Encounter.extension:A",
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		var logBuf bytes.Buffer
+		logger := lib.NewLoggerWithWriter(lib.LogLevelWarn, &logBuf)
+
+		_, err = services.LoadLookupTables(lookupPath, logger)
+		require.NoError(t, err)
+
+		logOutput := logBuf.String()
+		assert.Contains(t, logOutput, "deprecated")
+		assert.Contains(t, logOutput, "https://example.com/Encounter")
+		assert.Contains(t, logOutput, "Encounter.extension:A.extension:B")
+	})
+
+	t.Run("stays silent when no parent fields are set", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"children": ["Encounter.extension:A.extension:B"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:A.extension:B": {
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		var logBuf bytes.Buffer
+		logger := lib.NewLoggerWithWriter(lib.LogLevelWarn, &logBuf)
+
+		_, err = services.LoadLookupTables(lookupPath, logger)
+		require.NoError(t, err)
+		assert.Empty(t, logBuf.String())
 	})
 }
 

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -208,6 +208,125 @@ func TestLoadLookupTablesMissingElements(t *testing.T) {
 	})
 }
 
+func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
+	t.Run("backfills missing parent link from children list", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"children": ["Encounter.extension:A.extension:B"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:A.extension:B": {
+						"viewDefinition": {
+							"forEachOrNull": "extension.where(url = 'B')",
+							"column": [{"name": "b_code", "path": "value.code"}]
+						}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		tables, err := services.LoadLookupTables(lookupPath)
+		require.NoError(t, err)
+		child := tables[0].Elements["Encounter.extension:A.extension:B"]
+		assert.Equal(t, "Encounter.extension:A", child.Parent)
+	})
+
+	t.Run("overwrites authored parent link from children list", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"children": ["Encounter.extension:A.extension:B"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:A.extension:B": {
+						"parent": "Encounter.extension:Other",
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		tables, err := services.LoadLookupTables(lookupPath)
+		require.NoError(t, err)
+		child := tables[0].Elements["Encounter.extension:A.extension:B"]
+		assert.Equal(t, "Encounter.extension:A", child.Parent)
+	})
+
+	t.Run("clears authored parent link that no children list confirms", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:A.extension:B": {
+						"parent": "Encounter.extension:A",
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		tables, err := services.LoadLookupTables(lookupPath)
+		require.NoError(t, err)
+		child := tables[0].Elements["Encounter.extension:A.extension:B"]
+		assert.Empty(t, child.Parent)
+	})
+
+	t.Run("rejects a child claimed by two parents", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"children": ["Encounter.extension:A.extension:C"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:B": {
+						"children": ["Encounter.extension:A.extension:C"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
+					},
+					"Encounter.extension:A.extension:C": {
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'C')"}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		_, err = services.LoadLookupTables(lookupPath)
+		require.Error(t, err)
+		// Map order decides which parent backfills first and which one the
+		// error names, so assert only the child ID.
+		assert.Contains(t, err.Error(), "Encounter.extension:A.extension:C")
+	})
+}
+
 func TestValidateLookupTables(t *testing.T) {
 	t.Run("valid tables", func(t *testing.T) {
 		tables := []models.LookupTable{
@@ -241,5 +360,51 @@ func TestValidateLookupTables(t *testing.T) {
 		err := services.ValidateLookupTables(tables)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "non-existent child")
+	})
+
+	t.Run("circular children reference", func(t *testing.T) {
+		tables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Patient",
+				ResourceType: "Patient",
+				Elements: map[string]models.LookupElement{
+					"Patient.a": {Children: []string{"Patient.b"}},
+					"Patient.b": {Children: []string{"Patient.a"}},
+				},
+			},
+		}
+		err := services.ValidateLookupTables(tables)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "circular")
+	})
+
+	t.Run("self-referencing children entry", func(t *testing.T) {
+		tables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Patient",
+				ResourceType: "Patient",
+				Elements: map[string]models.LookupElement{
+					"Patient.a": {Children: []string{"Patient.a"}},
+				},
+			},
+		}
+		err := services.ValidateLookupTables(tables)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "circular")
+	})
+
+	t.Run("invalid parent reference", func(t *testing.T) {
+		tables := []models.LookupTable{
+			{
+				URL:          "https://example.com/Patient",
+				ResourceType: "Patient",
+				Elements: map[string]models.LookupElement{
+					"Patient.name.family": {Parent: "Patient.nonexistent"},
+				},
+			},
+		}
+		err := services.ValidateLookupTables(tables)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-existent parent")
 	})
 }

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -1150,7 +1150,7 @@ func TestParentChildRefsFromChildrenListOnly(t *testing.T) {
 				},
 			}),
 		}
-		require.NoError(t, services.NormalizeLookupTables(lookupTables))
+		require.NoError(t, services.NormalizeLookupTables(lookupTables, nil))
 
 		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
 			"Encounter.extension:Aufnahmegrund",
@@ -1186,7 +1186,7 @@ func TestParentChildRefsFromChildrenListOnly(t *testing.T) {
 				},
 			}),
 		}
-		require.NoError(t, services.NormalizeLookupTables(lookupTables))
+		require.NoError(t, services.NormalizeLookupTables(lookupTables, nil))
 
 		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
 			"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle",

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -1127,11 +1127,11 @@ func TestBuildViewDefinitionWithOverlappingAttributes(t *testing.T) {
 	})
 }
 
-func TestParentAndChildAttributeRefsWithoutParentLinks(t *testing.T) {
-	t.Run("child ref is skipped even when lookup has no parent links", func(t *testing.T) {
-		// Mirrors issue #619: the lookup resolves the child through the parent's
-		// children list, but the child element itself has no Parent link, so the
-		// ancestry-based skip cannot detect the overlap.
+func TestParentChildRefsFromChildrenListOnly(t *testing.T) {
+	t.Run("child ref is skipped when the parent ref is also in the group", func(t *testing.T) {
+		// The lookup declares the child only through the parent's children list.
+		// Normalization backfills the Parent link, so the parent-based skip
+		// detects the overlap.
 		lookupTables := []models.LookupTable{
 			newLookupTable("https://example.com/Encounter", "Encounter", map[string]models.LookupElement{
 				"Encounter.extension:Aufnahmegrund": {
@@ -1150,6 +1150,7 @@ func TestParentAndChildAttributeRefsWithoutParentLinks(t *testing.T) {
 				},
 			}),
 		}
+		require.NoError(t, services.NormalizeLookupTables(lookupTables))
 
 		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
 			"Encounter.extension:Aufnahmegrund",
@@ -1161,6 +1162,44 @@ func TestParentAndChildAttributeRefsWithoutParentLinks(t *testing.T) {
 		columnNames := services.ExtractColumnNames(*viewDef)
 		assert.Equal(t, 1, countOccurrences(columnNames, "aufnahmegrund_stelle12_code"),
 			"aufnahmegrund_stelle12_code should appear exactly once")
+	})
+
+	t.Run("child-only ref gets the parent forEach wrap after normalization", func(t *testing.T) {
+		// The lookup fills only the children direction. Without normalization the
+		// child resolves at the resource root and its columns stay empty. After
+		// normalization the backfilled Parent link wraps it in the parent context.
+		lookupTables := []models.LookupTable{
+			newLookupTable("https://example.com/Encounter", "Encounter", map[string]models.LookupElement{
+				"Encounter.extension:Aufnahmegrund": {
+					Children: []string{"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle"},
+					ViewDefinition: models.ViewDefSnippet{
+						ForEachOrNull: "extension.where(url = 'aufnahmegrund')",
+					},
+				},
+				"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle": {
+					ViewDefinition: models.ViewDefSnippet{
+						ForEachOrNull: "extension.where(url = 'ErsteUndZweiteStelle')",
+						Column: []models.ColumnDefinition{
+							{Name: "aufnahmegrund_stelle12_code", Path: "value.code"},
+						},
+					},
+				},
+			}),
+		}
+		require.NoError(t, services.NormalizeLookupTables(lookupTables))
+
+		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
+			"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle",
+		)
+
+		viewDef := buildAndAssertViewDef(t, lookupTables, group)
+
+		require.Len(t, viewDef.Select, 2)
+		wrapper := viewDef.Select[1]
+		assert.Equal(t, "extension.where(url = 'aufnahmegrund')", wrapper.ForEachOrNull,
+			"child must be wrapped in the parent forEach context")
+		require.Len(t, wrapper.Select, 1)
+		assert.Equal(t, "extension.where(url = 'ErsteUndZweiteStelle')", wrapper.Select[0].ForEachOrNull)
 	})
 
 	t.Run("child ref is kept when the parent ref is missing from the lookup", func(t *testing.T) {


### PR DESCRIPTION
Closes #624

## Summary

- `LoadLookupTables` now derives every `parent` link from the `children` lists, which are the single source of truth. A CRTDL that lists only a child therefore gets the ancestor `forEach` wrapping, instead of columns that stay silently empty.
- Authored `parent` values are deprecated and ignored: each link is cleared and re-derived. A profile that still sets the field produces one load-time warning (also in the job log); the field will be removed in a future version of the flatten-lookup files (#630, closed in favor of this deprecation path). A child that two elements claim in their `children` lists is rejected with a load error.
- `ValidateLookupTables` gains a cycle check on the `children` lists. A cycle previously caused unbounded recursion in the builder. A parent-resolution check is unnecessary because every `Parent` link is derived.
- With parent links complete after load, the textual ancestor detection (`hasAncestorRef`) in `BuildViewDefinition` is redundant; `isParentInAttributeList` alone now covers the parent-child overlap skip, as proposed in the issue's follow-up cleanup.

Related: #619, #623, #630
Follow-ups: #631 (cycle protection without caller pairing), #632 (duplicate child IDs in one `children` list)