### PR TITLE
fix(flattening): validate lookup tables at load time

### DIFF
--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -70,17 +70,12 @@ func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 		return StepResult{}, fmt.Errorf("failed to parse CRTDL file: %w", err)
 	}
 
-	// Load lookup tables
+	// Load lookup tables (LoadLookupTables normalizes and validates them)
 	lookupPath := job.Config.Services.Flattening.LookupPath
 	logger.Debug("Loading lookup tables", "path", lookupPath)
 	lookupTables, err := services.LoadLookupTables(lookupPath, logger)
 	if err != nil {
 		return StepResult{}, fmt.Errorf("failed to load lookup tables: %w", err)
-	}
-
-	// Validate lookup tables
-	if err := services.ValidateLookupTables(lookupTables); err != nil {
-		return StepResult{}, fmt.Errorf("invalid lookup tables: %w", err)
 	}
 
 	inputDir := ctx.Layout.InputDir(stepName)

--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -12,6 +12,8 @@ import (
 
 // LoadLookupTables loads the lookup tables from a JSON file
 // The file contains an array of LookupTable objects
+// The tables are normalized and validated; a file whose children lists form
+// a cycle is rejected here, so every loaded table set is safe for the builder.
 // A nil logger suppresses the deprecation warning for authored parent fields.
 func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, error) {
 	data, err := os.ReadFile(path)
@@ -38,6 +40,10 @@ func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, er
 	}
 
 	if err := NormalizeLookupTables(tables, logger); err != nil {
+		return nil, err
+	}
+
+	if err := ValidateLookupTables(tables); err != nil {
 		return nil, err
 	}
 

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -106,6 +106,27 @@ func TestLoadLookupTables(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse lookup file")
 	})
+
+	t.Run("rejects circular children references", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Patient",
+				"resourceType": "Patient",
+				"elements": {
+					"Patient.a": {"children": ["Patient.b"]},
+					"Patient.b": {"children": ["Patient.a"]}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		_, err = services.LoadLookupTables(lookupPath, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "circular")
+	})
 }
 
 func TestGetProfileLookup(t *testing.T) {

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -389,7 +389,8 @@ func TestExecuteFlatteningStep_ConfigValidationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "service_url is required")
 }
 
-// TestExecuteFlatteningStep_LookupValidationError tests line 71-75
+// TestExecuteFlatteningStep_LookupValidationError verifies that the step
+// rejects a lookup file that fails validation at load time.
 func TestExecuteFlatteningStep_LookupValidationError(t *testing.T) {
 	tempDir := t.TempDir()
 	jobDir := filepath.Join(tempDir, "jobs", "test-job")
@@ -421,7 +422,7 @@ func TestExecuteFlatteningStep_LookupValidationError(t *testing.T) {
 
 	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid lookup tables")
+	assert.Contains(t, err.Error(), "failed to load lookup tables")
 	assert.Contains(t, err.Error(), "duplicate profile URL")
 }
 


### PR DESCRIPTION
## Summary

- `LoadLookupTables` now calls `ValidateLookupTables` after `NormalizeLookupTables`. A lookup file whose `children` lists form a cycle fails at load time for every caller.
- The safety of `isParentInAttributeList` and `resolveWithChildren` no longer depends on callers pairing the load and validate calls.
- The flattening step drops its now-redundant explicit `ValidateLookupTables` call.

## Compatibility

Not a breaking change. Valid lookup files load as before. Files with cycles, duplicate profile URLs, or dangling child references already failed in the pipeline; the failure now happens at load time for all callers.

Closes #631