### PR TITLE
fix(flattening): reject duplicate child IDs within one children list

### DIFF
--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -52,7 +52,8 @@ func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, er
 
 // NormalizeLookupTables derives every Parent link from the Children lists.
 // Authored parent values are ignored: each Parent is cleared and set to the
-// element whose Children list names it. A child that two elements claim is an error.
+// element whose Children list names it. A child that two elements claim, or
+// that one Children list names twice, is an error.
 // Authored parent fields are deprecated; when logger is non-nil, each profile
 // that sets them produces one warning.
 func NormalizeLookupTables(tables []models.LookupTable, logger *lib.Logger) error {
@@ -75,7 +76,11 @@ func NormalizeLookupTables(tables []models.LookupTable, logger *lib.Logger) erro
 		claimedBy := make(map[string]string)
 		for elementID, element := range table.Elements {
 			for _, childID := range element.Children {
-				if parentID, claimed := claimedBy[childID]; claimed && parentID != elementID {
+				if parentID, claimed := claimedBy[childID]; claimed {
+					if parentID == elementID {
+						return fmt.Errorf("element '%s' is listed more than once in the children of '%s' in profile '%s'",
+							childID, elementID, table.URL)
+					}
 					return fmt.Errorf("element '%s' is listed as child of both '%s' and '%s' in profile '%s'",
 						childID, parentID, elementID, table.URL)
 				}

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -368,6 +368,33 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		// error names, so assert only the child ID.
 		assert.Contains(t, err.Error(), "Encounter.extension:A.extension:C")
 	})
+
+	t.Run("rejects a children list that names the same child twice", func(t *testing.T) {
+		tempDir := t.TempDir()
+		lookupPath := filepath.Join(tempDir, "lookup.json")
+		lookupJSON := `[
+			{
+				"url": "https://example.com/Encounter",
+				"resourceType": "Encounter",
+				"elements": {
+					"Encounter.extension:A": {
+						"children": ["Encounter.extension:A.extension:B", "Encounter.extension:A.extension:B"],
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
+					},
+					"Encounter.extension:A.extension:B": {
+						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
+					}
+				}
+			}
+		]`
+		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
+		require.NoError(t, err)
+
+		_, err = services.LoadLookupTables(lookupPath, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Encounter.extension:A.extension:B")
+		assert.Contains(t, err.Error(), "listed more than once")
+	})
 }
 
 func TestLoadLookupTablesWarnsOnAuthoredParentFields(t *testing.T) {


### PR DESCRIPTION
## Summary

- `NormalizeLookupTables` rejected only a child that two different elements claim in their `children` lists. The check `parentID != elementID` let one element list the same child twice, and the builder then resolved that child twice, so its columns appeared twice in the ViewDefinition output.
- The `claimedBy` check now also fails a `children` list that names the same child ID more than once, with a distinct error message: `element 'X' is listed more than once in the children of 'Y' in profile 'Z'`.

## Compatibility

Not a breaking change for valid files. Only malformed files that already produced duplicated columns now fail at load time, with a clear error instead of wrong output.

Independent of #636: the new check runs inside `NormalizeLookupTables`, which `LoadLookupTables` calls before the `ValidateLookupTables` call that #636 adds. The two changes touch different functions and merge in either order.

Closes #632