### PR TITLE
ci(docs-deploy): scope contents: write to the deploy job

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -23,8 +23,9 @@ on:
         type: boolean
         default: false
 
+# Declare default permissions as read only.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: "pages"
@@ -34,6 +35,9 @@ jobs:
   deploy:
     name: Build and Deploy Documentation
     runs-on: ubuntu-24.04
+    permissions:
+      # Needed to push the built docs to the gh-pages branch.
+      contents: write
     if: >-
       ${{
         !(github.event_name == 'release' && github.event.release.prerelease)


### PR DESCRIPTION
## Problem

Scorecard alert #23 (high): `.github/workflows/docs-deploy.yml` declared `contents: write` at the top level, so every job in the workflow received a write token.

## Change

- Top level: `permissions: contents: read`
- `deploy` job: `permissions: contents: write`, with a comment naming the reason (the push to `gh-pages`)

This matches the pattern already used in `scorecard.yml`.

## Why not the GitHub Pages deployment flow

The issue proposed `actions/upload-pages-artifact` + `actions/deploy-pages` as the preferred fix. That flow does not fit this workflow:

- The site is multi-version. The `gh-pages` branch accumulates one directory per version (`dev`, `stable`, `v0.9.0` … `v0.15.0`) plus a cumulative `versions.json`.
- `deploy-pages` publishes one artifact as the complete site, so each run would have to reproduce every published version. Either the workflow rebuilds all versions on every run, or it keeps `gh-pages` as the store and writes the new version back — which still needs `contents: write`.
- The repository currently uses legacy Pages (`build_type: legacy`, source branch `gh-pages`). Migrating also requires an admin change of the Pages source.

Closes #641
