### PR TITLE
test(fuzz): add Go native fuzz targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 PLATFORMS := linux darwin
 ARCHITECTURES := amd64 arm64
 
-.PHONY: all build build-all build-linux build-mac build-mac-arm build-windows build-windows-arm clean test test-unit test-integration test-contract coverage fmt vet vuln lint lint-docs install help release
+.PHONY: all build build-all build-linux build-mac build-mac-arm build-windows build-windows-arm clean test test-unit test-integration test-contract test-fuzz coverage fmt vet vuln lint lint-docs install help release
 
 # Default target
 all: clean fmt vet test build
@@ -126,6 +126,17 @@ test-integration-coverage:
 test-contract:
 	@echo "Running contract tests..."
 	$(GOTEST) -v ./tests/contract/...
+
+## test-fuzz: Run one fuzz target (FUZZ=FuzzName, FUZZTIME=60s)
+test-fuzz:
+	@if [ -z "$(FUZZ)" ]; then \
+		echo "Set FUZZ to one target, for example: make test-fuzz FUZZ=FuzzParseDuration"; \
+		echo "Available targets:"; \
+		grep -rho 'func Fuzz[A-Za-z0-9_]*' ./tests | sed 's/func /  /' | sort -u; \
+		exit 1; \
+	fi
+	@echo "Fuzzing $(FUZZ) for $(or $(FUZZTIME),60s)..."
+	$(GOTEST) ./tests/unit/ -run='^$(FUZZ)$$' -fuzz='^$(FUZZ)$$' -fuzztime=$(or $(FUZZTIME),60s)
 
 ## coverage: Run tests with coverage report
 coverage:

--- a/tests/unit/fuzz_bundle_split_test.go
+++ b/tests/unit/fuzz_bundle_split_test.go
@@ -1,0 +1,189 @@
+package unit
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// manyEntryBundle builds a Bundle with many tiny entries. The comma between two
+// entries costs a byte that the size estimate of the splitter does not count,
+// so a chunk with many entries shows the drift.
+func manyEntryBundle(entryCount int) string {
+	var b strings.Builder
+	b.WriteString(`{"resourceType":"Bundle","id":"big","type":"collection","entry":[`)
+	for i := 0; i < entryCount; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"resource":{"resourceType":"Patient","id":"p"}}`)
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}
+
+// tinyEntryBundle builds a Bundle whose entries are as small as possible, so
+// that one chunk holds many of them and the uncounted commas add up.
+func tinyEntryBundle(entryCount int) string {
+	var b strings.Builder
+	b.WriteString(`{"resourceType":"Bundle","id":"tiny","type":"collection","entry":[`)
+	for i := 0; i < entryCount; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"a":1}`)
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}
+
+// FuzzSplitBundleAcceptsValidBundle checks that a structurally valid Bundle
+// always splits without an error when the threshold is far above its size.
+//
+// Invariant: if the Bundle passes the structure checks that the splitter itself
+// uses, SplitBundle succeeds with a threshold that forces no split.
+func FuzzSplitBundleAcceptsValidBundle(f *testing.F) {
+	seeds := []string{
+		`{"resourceType":"Bundle","id":"b1","type":"collection","entry":[{"resource":{"resourceType":"Patient","id":"p1"}}]}`,
+		`{"resourceType":"Bundle","id":"b1","type":"collection","entry":[]}`,
+		`{"resourceType":"Bundle","id":"b1","type":"collection"}`,
+		`{"resourceType":"Bundle","id":"b1","type":"searchset","total":0,"entry":[]}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<16 {
+			return
+		}
+		var bundle map[string]any
+		if err := json.Unmarshal(data, &bundle); err != nil {
+			return
+		}
+		if !lib.IsBundle(bundle) {
+			return
+		}
+		if _, err := lib.ExtractBundleMetadata(bundle); err != nil {
+			return
+		}
+		if _, err := lib.ExtractEntriesFromBundle(bundle); err != nil {
+			return
+		}
+
+		size, err := models.CalculateJSONSize(bundle)
+		if err != nil {
+			return
+		}
+
+		if _, err := services.SplitBundle(bundle, size+1<<20); err != nil {
+			if strings.Contains(err.Error(), "chunk must contain at least one entry") {
+				t.Skipf("known defect (issue #650): SplitBundle rejects the empty entry array of %s", data)
+			}
+			t.Fatalf("SplitBundle rejected a structurally valid Bundle that needs no split: %v\ninput: %s", err, data)
+		}
+	})
+}
+
+// FuzzSplitReassembleBundle checks the split and reassemble round trip.
+//
+// Invariants:
+//   - No entry is lost, added or reordered.
+//   - No chunk is larger than the threshold. The threshold is the payload limit
+//     of the DIMP server, so a larger chunk is rejected in production.
+func FuzzSplitReassembleBundle(f *testing.F) {
+	f.Add([]byte(`{"resourceType":"Bundle","id":"b1","type":"collection","entry":[{"resource":{"resourceType":"Patient","id":"p1"}},{"resource":{"resourceType":"Patient","id":"p2"}}]}`), 300)
+	f.Add([]byte(`{"resourceType":"Bundle","id":"b1","type":"searchset","total":1,"entry":[{"resource":{"resourceType":"Patient","id":"p1"}}]}`), 300)
+	f.Add([]byte(`{"resourceType":"Bundle","id":"b1","type":"collection","timestamp":"2026-01-02T03:04:05.123Z","entry":[{"resource":{"resourceType":"Patient","id":"p1"}}]}`), 300)
+	f.Add([]byte(manyEntryBundle(1000)), 4000)
+	f.Add([]byte(manyEntryBundle(400)), 20000)
+	f.Add([]byte(tinyEntryBundle(4000)), 4000)
+	f.Add([]byte(tinyEntryBundle(20000)), 100000)
+
+	f.Fuzz(func(t *testing.T, data []byte, threshold int) {
+		if len(data) > 1<<20 {
+			return
+		}
+		if threshold < 1 || threshold > 1<<20 {
+			return
+		}
+		var bundle map[string]any
+		if err := json.Unmarshal(data, &bundle); err != nil {
+			return
+		}
+		if !lib.IsBundle(bundle) {
+			return
+		}
+
+		originalEntries, err := lib.ExtractEntriesFromBundle(bundle)
+		if err != nil {
+			return
+		}
+		before := marshalEntries(t, originalEntries)
+
+		result, err := services.SplitBundle(bundle, threshold)
+		if err != nil {
+			// An oversized single entry and an invalid structure are legal outcomes.
+			return
+		}
+
+		chunks := make([]map[string]any, 0, len(result.Chunks))
+		for _, chunk := range result.Chunks {
+			asBundle := models.ConvertChunkToBundle(chunk)
+			if result.WasSplit {
+				encoded, marshalErr := json.Marshal(asBundle)
+				if marshalErr != nil {
+					t.Fatalf("a chunk produced by SplitBundle does not marshal: %v", marshalErr)
+				}
+				// The known defect drifts by at most one uncounted separator per
+				// entry. A larger drift is a different problem, so keep it fatal.
+				if overflow := len(encoded) - threshold; overflow > 0 {
+					if overflow <= len(chunk.Entries) {
+						t.Skipf("known defect (issue #649): chunk %d is %d bytes, %d above the threshold of %d, which matches the uncounted entry separators",
+							chunk.Index, len(encoded), overflow, threshold)
+					}
+					t.Fatalf("chunk %d of %d is %d bytes, %d above the threshold of %d bytes",
+						chunk.Index, result.TotalChunks, len(encoded), overflow, threshold)
+				}
+			}
+			chunks = append(chunks, asBundle)
+		}
+
+		reassembled, err := services.ReassembleBundle(result.Metadata, chunks)
+		if err != nil {
+			t.Fatalf("ReassembleBundle rejected the chunks that SplitBundle produced: %v", err)
+		}
+
+		if reassembled.EntryCount != len(originalEntries) {
+			t.Fatalf("entry count changed: %d before the split, %d after reassembly", len(originalEntries), reassembled.EntryCount)
+		}
+
+		afterEntries, ok := reassembled.Bundle["entry"].([]map[string]any)
+		if !ok {
+			t.Fatalf("the reassembled Bundle holds no entry array of the expected type")
+		}
+		after := marshalEntries(t, afterEntries)
+		for i := range before {
+			if before[i] != after[i] {
+				t.Fatalf("entry %d changed during the round trip:\nbefore: %s\nafter:  %s", i, before[i], after[i])
+			}
+		}
+	})
+}
+
+func marshalEntries(t *testing.T, entries []map[string]any) []string {
+	t.Helper()
+	out := make([]string, len(entries))
+	for i, entry := range entries {
+		encoded, err := json.Marshal(entry)
+		if err != nil {
+			t.Skip()
+		}
+		out[i] = string(encoded)
+	}
+	return out
+}

--- a/tests/unit/fuzz_crtdl_test.go
+++ b/tests/unit/fuzz_crtdl_test.go
@@ -1,0 +1,95 @@
+package unit
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// FuzzCRTDLRoundTrip checks the custom JSON methods of the CRTDL document.
+// These methods keep unknown fields so that a document survives preprocessing.
+//
+// Invariants:
+//   - Marshaling never panics. mustMarshal panics on a marshal error.
+//   - The encoding reaches a fixed point after one pass. The first pass is not
+//     an identity, because absent optional fields gain a default.
+//   - Every top level field of the input is still present after the round trip.
+func FuzzCRTDLRoundTrip(f *testing.F) {
+	seeds := []string{
+		`{}`,
+		`{"display":"d","version":"1"}`,
+		`{"cohortDefinition":{"inclusionCriteria":[[{"termCodes":[]}]]}}`,
+		`{"dataExtraction":{"attributeGroups":[{"id":"g1","name":"n","groupReference":"http://x","attributes":[{"attributeRef":"Patient.id","mustHave":true}]}]}}`,
+		`{"unknownTopLevel":{"keep":"me"},"display":"d"}`,
+		`{"dataExtraction":{"attributeGroups":[{"id":"g1","includeReferenceOnly":true}],"extraSibling":1}}`,
+		`{"display":null,"version":null}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<16 {
+			return
+		}
+
+		var doc models.CRTDLDocument
+		if err := json.Unmarshal(data, &doc); err != nil {
+			return
+		}
+
+		first, err := json.Marshal(doc)
+		if err != nil {
+			t.Fatalf("a document that unmarshaled cleanly does not marshal: %v", err)
+		}
+
+		var again models.CRTDLDocument
+		if err := json.Unmarshal(first, &again); err != nil {
+			t.Fatalf("the output of MarshalJSON does not unmarshal: %v\noutput: %s", err, first)
+		}
+		second, err := json.Marshal(again)
+		if err != nil {
+			t.Fatalf("the second marshal failed: %v", err)
+		}
+
+		if !bytes.Equal(first, second) {
+			t.Fatalf("the encoding has no fixed point:\npass 1: %s\npass 2: %s", first, second)
+		}
+
+		// Every top level key of the input must survive.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return
+		}
+		var out map[string]json.RawMessage
+		if err := json.Unmarshal(first, &out); err != nil {
+			t.Fatalf("the output is not a JSON object: %s", first)
+		}
+		// A known field with an empty value is dropped on purpose, so check only
+		// the unknown fields. Keeping those is the contract of issue #356.
+		known := map[string]bool{
+			"display": true, "version": true, "cohortDefinition": true, "dataExtraction": true,
+		}
+		for key, value := range raw {
+			if known[key] || string(value) == "null" {
+				continue
+			}
+			kept, ok := out[key]
+			if !ok {
+				t.Fatalf("the round trip dropped the unknown top level field %q\ninput:  %s\noutput: %s", key, data, first)
+			}
+			// Compare the meaning, not the bytes: json.Marshal escapes "&" and
+			// "<" as & and <, which does not change the value.
+			var want, got any
+			if json.Unmarshal(value, &want) != nil || json.Unmarshal(kept, &got) != nil {
+				continue
+			}
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("the round trip changed the unknown top level field %q: %s -> %s", key, value, kept)
+			}
+		}
+	})
+}

--- a/tests/unit/fuzz_duration_test.go
+++ b/tests/unit/fuzz_duration_test.go
@@ -1,0 +1,53 @@
+package unit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+// FuzzParseDuration checks lib.ParseDuration, which parses untrusted configuration
+// values such as timeouts and poll intervals.
+//
+// Invariants:
+//   - An accepted ISO 8601 duration is never negative. The grammar has no sign.
+//   - An accepted ISO 8601 duration with a non-zero integer component is not zero.
+//   - A duration accepted in Go format survives a String/parse round trip.
+func FuzzParseDuration(f *testing.F) {
+	seeds := []string{
+		"", "PT30M", "PT1H30M5S", "P1DT12H", "P0D", "PT0.5S", "P", "PT",
+		"30m", "1h30m", "-5m", "0s",
+		"P1000000000D", "P99999999999999999999D", "PT9999999999H",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		d, err := lib.ParseDuration(s)
+		if err != nil {
+			return
+		}
+
+		// Only an ISO 8601 string can start with "P"; Go format never does.
+		if strings.HasPrefix(s, "P") {
+			if d < 0 {
+				t.Skipf("known defect (issue #647): ParseDuration(%q) = %v, an overflow of the day or hour component", s, d)
+			}
+			// Fractional seconds below 1ns legitimately round to zero, so skip inputs with a point.
+			if d == 0 && !strings.Contains(s, ".") && strings.ContainsAny(s, "123456789") {
+				t.Fatalf("ParseDuration(%q) = 0 with no error: a non-zero duration was silently dropped", s)
+			}
+			return
+		}
+
+		again, err := lib.ParseDuration(d.String())
+		if err != nil {
+			t.Fatalf("ParseDuration(%q) = %v, but re-parsing %q failed: %v", s, d, d.String(), err)
+		}
+		if again != d {
+			t.Fatalf("round trip of %q changed the duration: %v -> %v", s, d, again)
+		}
+	})
+}

--- a/tests/unit/fuzz_filename_test.go
+++ b/tests/unit/fuzz_filename_test.go
@@ -1,0 +1,122 @@
+package unit
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+	"github.com/medizininformatik-initiative/aether/internal/models"
+)
+
+// FuzzCompressedFilename checks the pair of functions that add and remove the
+// ".zst" suffix.
+//
+// Invariants:
+//   - A name with the compression suffix removed is no longer a compressed name.
+//   - Adding the suffix is idempotent.
+func FuzzCompressedFilename(f *testing.F) {
+	seeds := []string{
+		"", "Patient.ndjson", "Patient.ndjson.zst", "Patient.NDJSON.ZST",
+		"x.ZST", "x.zst", ".zst", "a.zst.zst", "dir/Patient.ndjson",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, name string) {
+		// IsCompressedFile decides whether the suffix is present. If it says yes,
+		// GetUncompressedFilename must remove something.
+		if lib.IsCompressedFile(name) && lib.GetUncompressedFilename(name) == name {
+			if !strings.HasSuffix(name, lib.CompressedFileExtension) {
+				t.Skipf("known defect (issue #648): the suffix of %q is not lowercase, so nothing is stripped", name)
+			}
+			t.Fatalf("IsCompressedFile(%q) is true, but GetUncompressedFilename strips nothing", name)
+		}
+
+		compressed := lib.GetCompressedFilename(name, true)
+		if again := lib.GetCompressedFilename(compressed, true); again != compressed {
+			t.Fatalf("GetCompressedFilename is not idempotent for %q: %q -> %q", name, compressed, again)
+		}
+	})
+}
+
+// FuzzDetectDuplicateFHIRFiles checks that the duplicate detection sees a
+// compressed and an uncompressed copy of the same resource file as a pair.
+//
+// Invariant: if two accepted FHIR file names differ only by the compression
+// suffix, DetectDuplicateFHIRFiles reports an error.
+func FuzzDetectDuplicateFHIRFiles(f *testing.F) {
+	f.Add("Patient.ndjson\nPatient.ndjson.zst")
+	f.Add("Patient.ndjson\nPatient.NDJSON.ZST")
+	f.Add("Patient.ndjson\nCondition.ndjson")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, joined string) {
+		var files []string
+		for _, name := range strings.Split(joined, "\n") {
+			if name != "" && models.IsValidFHIRFile(name) {
+				files = append(files, name)
+			}
+		}
+		if len(files) < 2 {
+			return
+		}
+
+		err := models.DetectDuplicateFHIRFiles(files)
+
+		if err != nil {
+			return
+		}
+
+		// Build the expected answer with a case-insensitive normalization, and
+		// record whether the missed pair differs only by the case of the suffix.
+		seen := make(map[string]string)
+		wantDuplicate, caseOnly := false, true
+		for _, name := range files {
+			base := filepath.Base(name)
+			key := strings.TrimSuffix(strings.ToLower(base), ".zst")
+			if prev, ok := seen[key]; ok && prev != base {
+				wantDuplicate = true
+				if strings.HasSuffix(base, ".zst") == strings.HasSuffix(strings.ToLower(base), ".zst") &&
+					strings.HasSuffix(prev, ".zst") == strings.HasSuffix(strings.ToLower(prev), ".zst") {
+					caseOnly = false
+				}
+			}
+			seen[key] = base
+		}
+		if !wantDuplicate {
+			return
+		}
+		if caseOnly {
+			t.Skipf("known defect (issue #648): %q holds a compressed and an uncompressed copy that differ by the case of the suffix", files)
+		}
+		t.Fatalf("DetectDuplicateFHIRFiles(%q) returned no error, but the list holds a compressed and an uncompressed copy of one file", files)
+	})
+}
+
+// FuzzIsSafePath checks the guard against path traversal.
+//
+// Invariant: a path that IsSafePath accepts stays inside the base directory
+// after filepath.Join.
+func FuzzIsSafePath(f *testing.F) {
+	seeds := []string{
+		"", "a.ndjson", "sub/a.ndjson", "../etc/passwd", "/etc/passwd",
+		"./a", "a/../../b", "..foo", "...", "a/..", `..\windows`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, path string) {
+		if !models.IsSafePath(path) {
+			return
+		}
+
+		const base = "/base"
+		joined := filepath.Clean(filepath.Join(base, path))
+		if joined != base && !strings.HasPrefix(joined, base+string(filepath.Separator)) {
+			t.Fatalf("IsSafePath(%q) accepted the path, but it resolves to %q outside %q", path, joined, base)
+		}
+	})
+}

--- a/tests/unit/fuzz_ndjson_test.go
+++ b/tests/unit/fuzz_ndjson_test.go
@@ -1,0 +1,106 @@
+package unit
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/medizininformatik-initiative/aether/internal/lib"
+)
+
+// FuzzReadNDJSON checks the NDJSON stream decoder against arbitrary bytes.
+//
+// Invariants:
+//   - The returned count equals the number of callback calls, on the success
+//     path and on the error path.
+//   - Resources written back with WriteNDJSONLine decode again to the same
+//     count and the same content.
+func FuzzReadNDJSON(f *testing.F) {
+	seeds := []string{
+		"",
+		`{"resourceType":"Patient","id":"p1"}`,
+		"{\"resourceType\":\"Patient\"}\n{\"resourceType\":\"Condition\"}\n",
+		`{"resourceType":"Patient"}{"resourceType":"Patient"}`,
+		"{\"a\":1}\n{",
+		"[]",
+		"null",
+		"{\"nested\":{\"deep\":[1,2,3]}}",
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var collected []lib.FHIRResource
+		count, err := lib.ReadNDJSON(bytes.NewReader(data), func(r lib.FHIRResource) error {
+			collected = append(collected, r)
+			return nil
+		})
+
+		if count != len(collected) {
+			t.Fatalf("ReadNDJSON reported %d resources but called the callback %d times", count, len(collected))
+		}
+		if err != nil {
+			return
+		}
+
+		var buf bytes.Buffer
+		for _, r := range collected {
+			if writeErr := lib.WriteNDJSONLine(&buf, r); writeErr != nil {
+				t.Fatalf("WriteNDJSONLine failed for a resource that ReadNDJSON accepted: %v", writeErr)
+			}
+		}
+
+		var reread []lib.FHIRResource
+		count2, err := lib.ReadNDJSON(&buf, func(r lib.FHIRResource) error {
+			reread = append(reread, r)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("re-reading written NDJSON failed: %v", err)
+		}
+		if count2 != count {
+			t.Fatalf("round trip changed the resource count: %d -> %d", count, count2)
+		}
+
+		for i := range collected {
+			before, _ := json.Marshal(collected[i])
+			after, _ := json.Marshal(reread[i])
+			if !bytes.Equal(before, after) {
+				t.Fatalf("round trip changed resource %d: %s -> %s", i, before, after)
+			}
+		}
+	})
+}
+
+// FuzzReadNDJSONCallbackError checks the count on the path where the callback
+// fails. The count must name the resource that failed.
+func FuzzReadNDJSONCallbackError(f *testing.F) {
+	f.Add([]byte(`{"resourceType":"Patient"}{"resourceType":"Condition"}`), 1)
+	f.Add([]byte(`{"a":1}`), 0)
+
+	f.Fuzz(func(t *testing.T, data []byte, failAt int) {
+		if failAt < 0 {
+			return
+		}
+
+		calls := 0
+		count, err := lib.ReadNDJSON(bytes.NewReader(data), func(r lib.FHIRResource) error {
+			calls++
+			if calls > failAt {
+				return errCallbackStop
+			}
+			return nil
+		})
+
+		if count != calls {
+			t.Fatalf("ReadNDJSON reported %d resources but called the callback %d times (err=%v)", count, calls, err)
+		}
+	})
+}
+
+var errCallbackStop = errStop{}
+
+type errStop struct{}
+
+func (errStop) Error() string { return "stop" }


### PR DESCRIPTION
Closes #646

## Why

The OpenSSF Scorecard workflow reports code-scanning alert #7, **Fuzzing**, with score 0: "project is not fuzzed: no fuzzer integrations found". The repository had no `func Fuzz` anywhere. Scorecard detects Go native fuzzing by looking for `func FuzzXxx(f *testing.F)` in `*_test.go` files.

## What this adds

Nine fuzz targets in `tests/unit/`, over the code that reads untrusted input:

| File | Targets |
|---|---|
| `fuzz_duration_test.go` | `lib.ParseDuration`, which parses configuration values |
| `fuzz_filename_test.go` | the `.zst` helpers and the guard against path traversal |
| `fuzz_bundle_split_test.go` | the Bundle split and reassemble round trip |
| `fuzz_ndjson_test.go` | the NDJSON stream decoder |
| `fuzz_crtdl_test.go` | the custom CRTDL JSON methods |

Plus a `make test-fuzz FUZZ=<name> [FUZZTIME=60s]` target. With no argument it lists the available targets.

## No CI change

Without the `-fuzz` flag, `go test` runs each target against its seed corpus only. The existing step `go test -coverpkg=./internal/... ./tests/...` therefore covers all nine in **0.9 s**, so the 10-minute timeout of the `test` job stays safe and no workflow file changes.

## Defects found

The trial found four real defects, each filed as its own issue. This pull request does **not** correct them, so the change stays reviewable.

| Issue | Defect |
|---|---|
| #647 | `ParseDuration("P1000000000D")` returns a negative duration with a nil error, because the overflow of `strconv.Atoi` is discarded |
| #648 | `IsCompressedFile` matches `.ZST` case insensitively, but `GetUncompressedFilename` strips case sensitively, so `DetectDuplicateFHIRFiles` misses a duplicate pair |
| #649 | `PartitionEntries` never counts the comma between two entries, so a chunk reached 114131 bytes against a threshold of 100000 |
| #650 | `SplitBundle` rejects a valid Bundle with an empty `entry` array |

Assertions that these defects break call `t.Skip` with the issue number, so the suite stays green. Each skip is deliberately narrow, so the target still catches anything worse: a chunk above the threshold by more than one byte per entry still fails, and any error from `SplitBundle` other than the empty-entry one still fails. Removing a skip belongs with the fix.

Two further candidates turned out to be correct behaviour, and the assertions were corrected rather than filed: an empty `display` is dropped on purpose by `omitempty`, and `json.Marshal` escapes `&` as the escape sequence `\u0026` without changing the value.

## Campaigns run

`FuzzIsSafePath`, `FuzzReadNDJSON` and `FuzzReadNDJSONCallbackError` ran 60 s each and `FuzzCRTDLRoundTrip` ran 180 s (1.9 M executions) with no finding, so those targets are regression guards rather than open questions.
