### PR TITLE
ci: build the binary for all platforms on every pull request

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: build-artifacts-${{ github.run_id }}
+          name: build-artifacts-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
           path: bin/aether-*
-          retention-days: 7
+          retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build All Platforms
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Build binaries for all platforms
+        run: make build-all
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-artifacts-${{ github.run_id }}
+          path: bin/aether-*
+          retention-days: 7

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -34,3 +34,4 @@ jobs:
           name: build-artifacts-${{ github.run_id }}
           path: bin/aether-*
           retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,11 @@ jobs:
     uses: ./.github/workflows/_vuln.yaml
     secrets: inherit
 
+  build:
+    name: Build
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    uses: ./.github/workflows/_build.yaml
+
   tests:
     name: Tests
     needs: [lint]

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,44 @@
+name: Cleanup PR Artifacts
+
+# pull_request_target gives a write token, which a fork pull request does not
+# get from pull_request. The job checks out no code and only calls the REST API.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Delete Build Artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Delete build artifacts of the pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_NAME: build-artifacts-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          ids="$(gh api --paginate \
+            "/repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME" \
+            --jq '.artifacts[].id')"
+
+          if [ -z "$ids" ]; then
+            echo "No artifacts named $ARTIFACT_NAME"
+            exit 0
+          fi
+
+          for id in $ids; do
+            echo "Deleting artifact $id ($ARTIFACT_NAME)"
+            gh api -X DELETE "/repos/$REPO/actions/artifacts/$id"
+          done


### PR DESCRIPTION
## Summary

CI built the `aether` binaries only through `_release.yaml`, which `ci.yaml` invoked for tag pushes. A change that broke a cross-compilation target stayed hidden until release time.

This adds a reusable `_build.yaml` workflow that runs `make build-all` (linux/amd64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64) and uploads the binaries as artifacts. `ci.yaml` calls it as a `build` job.

It also adds `cleanup-pr-artifacts.yaml`, which deletes those artifacts when the pull request closes.

## Notes

- The build job skips on tag pushes, because the release job builds there.
- The build job runs for all pull requests, also docs-only ones. Unlike `tests`, it does not use `dorny/paths-filter`, because the build is quick and a simple, always-present check is easier to make a required check.
- Artifacts keep for 14 days. Their name is stable per pull request (`build-artifacts-pr-<number>`), so the cleanup job finds every artifact of that pull request across all of its runs. Runs without a pull request keep the run ID as the name.
- The cleanup job runs for merged and for closed-unmerged pull requests. It uses `pull_request_target`, because a fork pull request gets no write token from `pull_request`. The job checks out no code and only calls the REST API.

Closes #644
