### PR TITLE
Add compatibility test against pinned fhir-ontology-generator flattening release

### DIFF
--- a/.github/scripts/download-flattening-lookup.sh
+++ b/.github/scripts/download-flattening-lookup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Downloads the flattening.zip asset of the pinned fhir-ontology-generator
+# release and extracts it into ./flattening-lookup.
+#
+# Env: FLATTENING_VERSION  release tag, e.g. v4.2.0
+#      FLATTENING_CHECKSUM sha256 of flattening.zip
+
+url="https://github.com/medizininformatik-initiative/fhir-ontology-generator/releases/download/${FLATTENING_VERSION}/flattening.zip"
+curl -sSfL --retry 3 "${url}" >flattening.zip
+echo "${FLATTENING_CHECKSUM} flattening.zip" | sha256sum -c
+
+unzip -o -q flattening.zip -d flattening-lookup
+rm flattening.zip

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -66,6 +66,39 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: medizininformatik-initiative/aether
 
+  lookup-compat:
+    name: Flattening Lookup Compatibility
+    runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.code == 'true'
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Download flattening lookup release
+        env:
+          # renovate: datasource=github-release-attachments depName=medizininformatik-initiative/fhir-ontology-generator
+          FLATTENING_VERSION: v4.2.0
+          FLATTENING_CHECKSUM: a730537bde612b04cbc7920e80c9fc8455b6ef9279bff3546e4877f85d45561e
+        run: .github/scripts/download-flattening-lookup.sh
+
+      - name: Run lookup compatibility test
+        env:
+          COMPAT_FLATTENING_LOOKUP: ${{ github.workspace }}/flattening-lookup/flatteningLookup.json
+        run: go test ./tests/compat/...
+
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-24.04
@@ -429,7 +462,7 @@ jobs:
   test-status:
     name: Test Status
     runs-on: ubuntu-24.04
-    needs: [detect-changes, e2e-test, e2e-test-direct-load, e2e-test-flattening, e2e-test-validation]
+    needs: [detect-changes, lookup-compat, e2e-test, e2e-test-direct-load, e2e-test-flattening, e2e-test-validation]
     if: always()
     timeout-minutes: 5
     steps:
@@ -440,6 +473,7 @@ jobs:
 
       - name: Check test results
         run: |
+          echo "Lookup Compatibility Result: ${{ needs.lookup-compat.result }}"
           echo "E2E Tests Result: ${{ needs.e2e-test.result }}"
           echo "E2E Direct Load Tests Result: ${{ needs.e2e-test-direct-load.result }}"
           echo "E2E Flattening Tests Result: ${{ needs.e2e-test-flattening.result }}"
@@ -447,10 +481,15 @@ jobs:
           echo "Code Changed: ${{ needs.detect-changes.outputs.code }}"
 
           # Pass if all e2e tests succeeded or were skipped (docs-only changes)
+          COMPAT_OK=false
           E2E_OK=false
           DIRECT_OK=false
           FLAT_OK=false
           VAL_OK=false
+
+          if [[ "${{ needs.lookup-compat.result }}" == "success" ]] || [[ "${{ needs.lookup-compat.result }}" == "skipped" ]]; then
+            COMPAT_OK=true
+          fi
 
           if [[ "${{ needs.e2e-test.result }}" == "success" ]] || [[ "${{ needs.e2e-test.result }}" == "skipped" ]]; then
             E2E_OK=true
@@ -468,7 +507,7 @@ jobs:
             VAL_OK=true
           fi
 
-          if [[ "$E2E_OK" == "true" ]] && [[ "$DIRECT_OK" == "true" ]] && [[ "$FLAT_OK" == "true" ]] && [[ "$VAL_OK" == "true" ]]; then
+          if [[ "$COMPAT_OK" == "true" ]] && [[ "$E2E_OK" == "true" ]] && [[ "$DIRECT_OK" == "true" ]] && [[ "$FLAT_OK" == "true" ]] && [[ "$VAL_OK" == "true" ]]; then
             echo "Tests passed or were not required"
             exit 0
           else

--- a/tests/compat/flattening_lookup_compat_test.go
+++ b/tests/compat/flattening_lookup_compat_test.go
@@ -1,0 +1,71 @@
+// Package compat tests aether against real release artifacts of upstream
+// projects. These tests skip unless the artifact path env var is set; CI
+// downloads a pinned release and runs them.
+package compat
+
+import (
+	"maps"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/medizininformatik-initiative/aether/internal/models"
+	"github.com/medizininformatik-initiative/aether/internal/services"
+)
+
+// lookupPathEnv points at a flatteningLookup.json extracted from the
+// flattening.zip asset of a fhir-ontology-generator release.
+const lookupPathEnv = "COMPAT_FLATTENING_LOOKUP"
+
+// TestReleasedFlatteningLookup verifies that a released lookup file loads and
+// that every profile in it yields a valid ViewDefinition when all of its
+// elements are requested. This is the layer where generator output breaks
+// aether, so no FHIR data or flattener service is needed.
+func TestReleasedFlatteningLookup(t *testing.T) {
+	path := os.Getenv(lookupPathEnv)
+	if path == "" {
+		t.Skipf("%s not set; set it to a flatteningLookup.json from a fhir-ontology-generator release", lookupPathEnv)
+	}
+
+	tables, err := services.LoadLookupTables(path, nil)
+	require.NoError(t, err, "released lookup file must load")
+	require.NotEmpty(t, tables, "released lookup file must contain profiles")
+
+	builder := services.NewViewDefinitionBuilder(tables)
+	for _, table := range tables {
+		t.Run(table.URL, func(t *testing.T) {
+			group := models.AttributeGroup{
+				ID:             table.URL,
+				Name:           "compat",
+				GroupReference: table.URL,
+				Attributes:     allElementsAsAttributes(table),
+			}
+
+			viewDef, err := builder.BuildViewDefinition(group)
+			require.NoError(t, err)
+			require.NoError(t, services.ValidateViewDefinition(viewDef))
+
+			// The builder prepends an id column (plus a patient column for
+			// patient-compartment resources), so the profile's own elements
+			// must contribute at least one more.
+			fixedColumns := 1
+			if _, ok := models.GetPatientReferencePath(table.ResourceType); ok {
+				fixedColumns++
+			}
+			names := services.ExtractColumnNames(*viewDef)
+			require.Greater(t, len(names), fixedColumns, "profile elements must yield columns")
+		})
+	}
+}
+
+// allElementsAsAttributes requests every element of a profile, sorted for
+// deterministic runs, so the builder walks all lookup entries.
+func allElementsAsAttributes(table models.LookupTable) []models.Attribute {
+	attrs := make([]models.Attribute, 0, len(table.Elements))
+	for _, id := range slices.Sorted(maps.Keys(table.Elements)) {
+		attrs = append(attrs, models.Attribute{AttributeRef: id})
+	}
+	return attrs
+}


### PR DESCRIPTION
## Summary

- New `tests/compat` package: an env-gated test loads a released `flatteningLookup.json` with `LoadLookupTables` and builds a ViewDefinition for every profile in it. Each profile must yield at least one column beyond the fixed `id`/`patient` columns. Without `COMPAT_FLATTENING_LOOKUP`, the test skips, so local runs stay offline.
- New CI job `Flattening Lookup Compatibility`: downloads the pinned `flattening.zip` release asset with sha256 verification and runs the test. The `test-status` gate includes the new job.
- The pin uses the repo's existing Renovate convention (`FLATTENING_VERSION` + `FLATTENING_CHECKSUM` with a `github-release-attachments` annotation), so no `renovate.json` change is needed. A new upstream release arrives as a bump PR; if the file is incompatible, only that PR fails and `main` stays green.

## Pin choice

The pin is **v4.2.0**, not the latest v4.2.2:

- v4.2.2 and v4.2.1 both fail to load with the duplicate-child defect from medizininformatik-initiative/fhir-ontology-generator#519 (still open).
- v4.2.0 is the newest release whose file loads; all 332 profiles in it build valid ViewDefinitions.
- When Renovate proposes the bump to v4.2.2, that PR fails in the new job and is the place to link the upstream issue.

Closes #645