### PR TITLE
fix(compression): match the .zst suffix case insensitively when stripping

### DIFF
--- a/internal/lib/compression.go
+++ b/internal/lib/compression.go
@@ -17,10 +17,10 @@ func IsCompressedFile(filename string) bool {
 	return strings.HasSuffix(strings.ToLower(filename), CompressedFileExtension)
 }
 
-// GetUncompressedFilename strips the .zst extension if present.
+// GetUncompressedFilename strips the .zst extension (any case) if present.
 func GetUncompressedFilename(filename string) string {
 	if IsCompressedFile(filename) {
-		return strings.TrimSuffix(filename, CompressedFileExtension)
+		return filename[:len(filename)-len(CompressedFileExtension)]
 	}
 	return filename
 }

--- a/internal/models/file.go
+++ b/internal/models/file.go
@@ -40,12 +40,28 @@ func IsSafePath(path string) bool {
 	return true
 }
 
+// trimSuffixFold removes suffix from s if it matches case-insensitively,
+// reporting whether a match was found.
+func trimSuffixFold(s, suffix string) (string, bool) {
+	if len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix) {
+		return s[:len(s)-len(suffix)], true
+	}
+	return s, false
+}
+
 // GetNormalizedBaseName returns the base filename without compression extension.
+// The .zst and .ndjson extensions are matched case-insensitively and lowercased
+// in the result; the case of the file stem is preserved.
 // Example: "Patient.ndjson.zst" -> "Patient.ndjson"
-// Example: "Patient.ndjson" -> "Patient.ndjson"
+// Example: "Patient.NDJSON.ZST" -> "Patient.ndjson"
+// Example: "patient.ndjson" -> "patient.ndjson"
 func GetNormalizedBaseName(filename string) string {
 	base := filepath.Base(filename)
-	return strings.TrimSuffix(base, ".zst")
+	base, _ = trimSuffixFold(base, ".zst")
+	if stem, ok := trimSuffixFold(base, ".ndjson"); ok {
+		base = stem + ".ndjson"
+	}
+	return base
 }
 
 // DetectDuplicateFHIRFiles checks if there are files with both compressed and

--- a/tests/unit/compression_test.go
+++ b/tests/unit/compression_test.go
@@ -108,6 +108,21 @@ func TestGetUncompressedFilename(t *testing.T) {
 			input:    "data",
 			expected: "data",
 		},
+		{
+			name:     "Uppercase extension",
+			input:    "Patient.ndjson.ZST",
+			expected: "Patient.ndjson",
+		},
+		{
+			name:     "Mixed case extension",
+			input:    "data.Zst",
+			expected: "data",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -718,8 +733,6 @@ func TestGetCompressedFilename_EdgeCases(t *testing.T) {
 }
 
 // TestGetUncompressedFilename_EdgeCases verifies edge cases in filename handling
-// Note: GetUncompressedFilename only trims the lowercase ".zst" suffix
-// while IsCompressedFile does case-insensitive matching
 func TestGetUncompressedFilename_EdgeCases(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/tests/unit/models_validation_test.go
+++ b/tests/unit/models_validation_test.go
@@ -265,6 +265,26 @@ func TestGetNormalizedBaseName(t *testing.T) {
 			input:    "data.backup.ndjson.zst",
 			expected: "data.backup.ndjson",
 		},
+		{
+			name:     "Uppercase extensions",
+			input:    "Patient.NDJSON.ZST",
+			expected: "Patient.ndjson",
+		},
+		{
+			name:     "Mixed case extensions",
+			input:    "Patient.NdJson.Zst",
+			expected: "Patient.ndjson",
+		},
+		{
+			name:     "Stem case preserved",
+			input:    "patient.NDJSON",
+			expected: "patient.ndjson",
+		},
+		{
+			name:     "No extension",
+			input:    "Patient",
+			expected: "Patient",
+		},
 	}
 
 	for _, tt := range tests {
@@ -337,6 +357,23 @@ func TestDetectDuplicateFHIRFiles(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "Patient.ndjson",
+		},
+		{
+			name: "Duplicate - compressed version with uppercase extensions",
+			files: []string{
+				"/path/Patient.ndjson",
+				"/path/Patient.NDJSON.ZST",
+			},
+			wantErr: true,
+			errMsg:  "found duplicate FHIR files",
+		},
+		{
+			name: "No duplicates - stems differ only in case",
+			files: []string{
+				"/path/Patient.ndjson",
+				"/path/patient.ndjson",
+			},
+			wantErr: false,
 		},
 		{
 			name:    "Empty file list",


### PR DESCRIPTION
Closes #648

## Problem

`GetUncompressedFilename` (`internal/lib/compression.go`) detected the `.zst` suffix case-insensitively but removed it with a case-sensitive `strings.TrimSuffix`, so `GetUncompressedFilename("x.ZST")` returned `"x.ZST"` unchanged. `GetNormalizedBaseName` (`internal/models/file.go`) had the same mismatch — and additionally left the `.ndjson`/`.NDJSON` extension case untouched.

The consequence: `DetectDuplicateFHIRFiles` did not flag `Patient.ndjson` alongside `Patient.NDJSON.ZST`, so the pipeline read the same resources twice and emitted duplicate records.

## Fix

- `GetUncompressedFilename` now strips the suffix by length once `IsCompressedFile` has established it is present, so any case is removed.
- `GetNormalizedBaseName` matches the `.zst` and `.ndjson` extensions case-insensitively and lowercases them in the normalized key, while preserving the case of the file stem. `Patient.ndjson` and `Patient.NDJSON.ZST` now collide (duplicate detected); `Patient.ndjson` and `patient.ndjson` remain distinct, as they are genuinely different files on a case-sensitive filesystem.

## Follow-up note

PR #651 (branch `scorecard-fuzzing`, still open) adds `tests/unit/fuzz_filename_test.go` with `t.Skip` calls referencing #648 in `FuzzCompressedFilename` and `FuzzDetectDuplicateFHIRFiles`; once both PRs merge, those skips should be removed.