### PR TITLE
fix(config): reject ISO 8601 durations that overflow time.Duration

### DIFF
--- a/internal/lib/duration.go
+++ b/internal/lib/duration.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"time"
@@ -18,11 +19,15 @@ func ParseDuration(s string) (time.Duration, error) {
 		return 0, nil
 	}
 
-	if d, ok := parseISO8601Duration(s); ok {
+	d, ok, err := parseISO8601Duration(s)
+	if err != nil {
+		return 0, err
+	}
+	if ok {
 		return d, nil
 	}
 
-	d, err := time.ParseDuration(s)
+	d, err = time.ParseDuration(s)
 	if err != nil {
 		return 0, fmt.Errorf("invalid duration %q: must be ISO 8601 (e.g. PT30M) or Go format (e.g. 30m)", s)
 	}
@@ -30,37 +35,59 @@ func ParseDuration(s string) (time.Duration, error) {
 }
 
 // parseISO8601Duration attempts to parse an ISO 8601 duration string.
-// Returns the duration and true if successful, or zero and false if the string
-// is not in ISO 8601 format.
-func parseISO8601Duration(s string) (time.Duration, bool) {
+// Returns ok=false if the string is not in ISO 8601 format, or an error if it
+// matches the format but the value does not fit in a time.Duration.
+func parseISO8601Duration(s string) (time.Duration, bool, error) {
 	matches := iso8601Pattern.FindStringSubmatch(s)
 	if matches == nil {
-		return 0, false
+		return 0, false, nil
 	}
 
 	// Reject bare "P" or "PT" with no components
 	if matches[1] == "" && matches[2] == "" && matches[3] == "" && matches[4] == "" {
-		return 0, false
+		return 0, false, nil
 	}
+
+	errOutOfRange := fmt.Errorf("invalid duration %q: value out of range", s)
 
 	var d time.Duration
 
-	if matches[1] != "" {
-		days, _ := strconv.Atoi(matches[1])
-		d += time.Duration(days) * 24 * time.Hour
+	components := []struct {
+		value string
+		unit  time.Duration
+	}{
+		{matches[1], 24 * time.Hour},
+		{matches[2], time.Hour},
+		{matches[3], time.Minute},
 	}
-	if matches[2] != "" {
-		hours, _ := strconv.Atoi(matches[2])
-		d += time.Duration(hours) * time.Hour
-	}
-	if matches[3] != "" {
-		minutes, _ := strconv.Atoi(matches[3])
-		d += time.Duration(minutes) * time.Minute
-	}
-	if matches[4] != "" {
-		seconds, _ := strconv.ParseFloat(matches[4], 64)
-		d += time.Duration(seconds * float64(time.Second))
+	for _, c := range components {
+		if c.value == "" {
+			continue
+		}
+		n, err := strconv.ParseInt(c.value, 10, 64)
+		if err != nil || n > int64(math.MaxInt64/c.unit) {
+			return 0, false, errOutOfRange
+		}
+		scaled := time.Duration(n) * c.unit
+		if d > math.MaxInt64-scaled {
+			return 0, false, errOutOfRange
+		}
+		d += scaled
 	}
 
-	return d, true
+	if matches[4] != "" {
+		seconds, err := strconv.ParseFloat(matches[4], 64)
+		// Reject before converting to time.Duration: float-to-integer
+		// conversion is implementation-defined when the value overflows.
+		if err != nil || seconds > float64(math.MaxInt64/time.Second) {
+			return 0, false, errOutOfRange
+		}
+		scaled := time.Duration(seconds * float64(time.Second))
+		if d > math.MaxInt64-scaled {
+			return 0, false, errOutOfRange
+		}
+		d += scaled
+	}
+
+	return d, true, nil
 }

--- a/tests/unit/lib/duration_test.go
+++ b/tests/unit/lib/duration_test.go
@@ -68,6 +68,53 @@ func TestParseDuration_Empty(t *testing.T) {
 	assert.Equal(t, time.Duration(0), d)
 }
 
+func TestParseDuration_Overflow(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"days overflow int64 nanoseconds", "P1000000000D"},
+		{"days exceed int64", "P99999999999999999999D"},
+		{"hours overflow int64 nanoseconds", "PT9999999999H"},
+		{"days one above max", "P106752D"},
+		{"hours one above max", "PT2562048H"},
+		{"minutes one above max", "PT153722868M"},
+		{"seconds one above max", "PT9223372037S"},
+		{"component sum overflows", "P106751DT24H"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := lib.ParseDuration(tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "out of range")
+			assert.Equal(t, time.Duration(0), d)
+		})
+	}
+}
+
+func TestParseDuration_MaxBoundary(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{"max representable days", "P106751D", 106751 * 24 * time.Hour},
+		{"max representable hours", "PT2562047H", 2562047 * time.Hour},
+		{"max representable minutes", "PT153722867M", 153722867 * time.Minute},
+		{"max representable seconds", "PT9223372036S", 9223372036 * time.Second},
+		{"large sum within range", "P106751DT23H", 106751*24*time.Hour + 23*time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := lib.ParseDuration(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, d)
+		})
+	}
+}
+
 func TestParseDuration_Invalid(t *testing.T) {
 	invalid := []string{"abc", "30", "PT", "P", "PTXM"}
 	for _, s := range invalid {


### PR DESCRIPTION
Closes #647

`parseISO8601Duration` discarded the errors from `strconv.Atoi` / `strconv.ParseFloat` and multiplied the parsed components without an overflow check, so inputs like `P1000000000D`, `P99999999999999999999D`, or `PT9999999999H` silently wrapped around to negative durations. Since ISO 8601 durations are unsigned, a negative result is always wrong — and via `stringToDurationHookFunc` a negative timeout makes HTTP contexts expire immediately.

## Changes

- Check the errors from `strconv.ParseInt` / `strconv.ParseFloat`.
- Guard each component multiplication (`value > math.MaxInt64/unit`) and the running sum (`d > math.MaxInt64 - scaled`) against overflow.
- Reject float seconds before converting to `time.Duration`, since float-to-integer conversion is implementation-defined on overflow.
- `parseISO8601Duration` gains an error return: input that matches the ISO grammar but is out of range now reports `invalid duration %q: value out of range` instead of falling through to `time.ParseDuration` and producing the misleading format-error message.
- Behaviour for valid input is unchanged (`""` → 0, `PT30M` → 30m, Go-format fallback including negative values like `-5m`).

Tests cover the three overflow reproducers, the exact per-unit boundaries at `math.MaxInt64` (largest valid value and one above for days/hours/minutes/seconds), and a component sum that overflows although each component is individually in range.

## Follow-up

PR #651 (branch `scorecard-fuzzing`, still open) adds `tests/unit/fuzz_duration_test.go` containing a `t.Skip` that references #647; once both merge, that skip should be removed so the fuzz target enforces the invariant again.