### PR TITLE
fix(dimp): count entry separators when partitioning a Bundle

### DIFF
--- a/internal/services/bundle_splitter.go
+++ b/internal/services/bundle_splitter.go
@@ -141,15 +141,20 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 			}
 		}
 
-		// Check if adding this entry would exceed threshold
-		if len(currentPartition) > 0 && currentSize+entrySize+bundleOverheadBytes > thresholdBytes {
+		// Check if adding this entry (plus the JSON separator preceding it
+		// in the serialized entry array) would exceed threshold
+		if len(currentPartition) > 0 && currentSize+1+entrySize+bundleOverheadBytes > thresholdBytes {
 			// Current chunk would exceed limit - start new chunk
 			partitions = append(partitions, currentPartition)
 			currentPartition = []map[string]any{}
 			currentSize = 0
 		}
 
-		// Add entry to current partition
+		// Add entry to current partition, counting the separator byte
+		// for every entry after the first
+		if len(currentPartition) > 0 {
+			currentSize++
+		}
 		currentPartition = append(currentPartition, entry)
 		currentSize += entrySize
 	}

--- a/tests/unit/bundle_splitter_test.go
+++ b/tests/unit/bundle_splitter_test.go
@@ -1,6 +1,8 @@
 package unit
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -297,6 +299,70 @@ func TestPartitionEntriesGreedyAlgorithm(t *testing.T) {
 	// Verify all entries accounted for
 	assert.Equal(t, len(entries), totalEntries,
 		"All entries should be partitioned")
+}
+
+// TestSplitBundleChunksStayWithinThreshold verifies that every chunk produced by
+// SplitBundle serializes to at most the threshold, including the JSON separators
+// between entries, while still packing chunks close to the threshold.
+func TestSplitBundleChunksStayWithinThreshold(t *testing.T) {
+	testCases := []struct {
+		name           string
+		entryCount     int
+		thresholdBytes int
+	}{
+		{
+			name:           "many tiny entries with small threshold",
+			entryCount:     4000,
+			thresholdBytes: 4000,
+		},
+		{
+			name:           "many tiny entries with large threshold",
+			entryCount:     20000,
+			thresholdBytes: 100000,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := make([]any, 0, tc.entryCount)
+			for i := 0; i < tc.entryCount; i++ {
+				entries = append(entries, map[string]any{
+					"resource": map[string]any{"id": fmt.Sprintf("%d", i)},
+				})
+			}
+			bundle := map[string]any{
+				"resourceType": "Bundle",
+				"id":           "tiny-entry-bundle",
+				"type":         "collection",
+				"entry":        entries,
+			}
+
+			result, err := services.SplitBundle(bundle, tc.thresholdBytes)
+			require.NoError(t, err)
+			require.True(t, result.WasSplit)
+
+			totalEntries := 0
+			for i, chunk := range result.Chunks {
+				totalEntries += len(chunk.Entries)
+
+				serialized, err := json.Marshal(models.ConvertChunkToBundle(chunk))
+				require.NoError(t, err)
+				assert.LessOrEqual(t, len(serialized), tc.thresholdBytes,
+					"chunk %d serializes to %d bytes, exceeding threshold %d",
+					i, len(serialized), tc.thresholdBytes)
+
+				// All chunks except the last must stay close to the threshold,
+				// otherwise splitting degrades into too many small requests
+				if i < len(result.Chunks)-1 {
+					assert.GreaterOrEqual(t, len(serialized), tc.thresholdBytes*9/10,
+						"chunk %d serializes to %d bytes, far below threshold %d",
+						i, len(serialized), tc.thresholdBytes)
+				}
+			}
+			assert.Equal(t, tc.entryCount, totalEntries,
+				"all entries should be preserved across chunks")
+		})
+	}
 }
 
 // TestBundleMetadataRoundTrip verifies metadata survives extraction and restoration


### PR DESCRIPTION
Closes #649

## Problem

`PartitionEntries` summed only the serialized sizes of the entries when building a chunk and never counted the comma separating two entries in the serialized `entry` array. A chunk with N entries needs N-1 separator bytes, so once N-1 exceeded the slack in the flat 200-byte wrapper budget, the chunk exceeded the threshold. Measured with tiny entries: threshold 4000 produced chunks of 4034-4040 bytes; threshold 100000 produced chunks up to 103765 bytes (~3.8% over). Since the threshold models the DIMP server payload limit, oversized chunks get rejected at exactly the job splitting exists to do.

## Fix

Count one separator byte per entry after the first, both in the "does the next entry still fit" check and in the running chunk size. With the fix the same inputs produce chunks of at most 3884 and 99889 bytes respectively, and chunks still pack close to the threshold (the regression test asserts every non-final chunk reaches at least 90% of it).

## Known remaining limitation

`bundleOverheadBytes = 200` is still a flat estimate of the Bundle wrapper, but the real wrapper contains the chunk id `{originalID}-chunk-{index}`, so a sufficiently long source Bundle id can exceed that budget on its own. Fixing this exactly requires passing the Bundle metadata into `PartitionEntries` to compute the true wrapper size — an exported-signature change left for a follow-up issue.

## Note

PR #651 (branch `scorecard-fuzzing`, still open) adds `tests/unit/fuzz_bundle_split_test.go` with a `t.Skip` referencing #649 in `FuzzSplitReassembleBundle`; once both PRs merge, that skip should be removed.