### PR TITLE
fix(dimp): return an empty Bundle unchanged when splitting

### DIFF
--- a/internal/services/bundle_splitter.go
+++ b/internal/services/bundle_splitter.go
@@ -168,7 +168,7 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 // Process:
 //  1. Calculate Bundle size
 //  2. Check if splitting needed (size > threshold)
-//  3. If not needed, return single-chunk result
+//  3. If not needed, return single-chunk result (zero chunks for a Bundle without entries)
 //  4. If needed, extract metadata and entries
 //  5. Partition entries using greedy algorithm
 //  6. Create Bundle chunks from partitions
@@ -205,6 +205,16 @@ func SplitBundle(bundle map[string]any, thresholdBytes int) (models.SplitResult,
 		entries, err := lib.ExtractEntriesFromBundle(bundle)
 		if err != nil {
 			return models.SplitResult{}, fmt.Errorf("failed to extract entries: %w", err)
+		}
+
+		// A Bundle without entries has nothing to chunk - return it unchanged
+		if len(entries) == 0 {
+			return models.SplitResult{
+				Metadata:     metadata,
+				WasSplit:     false,
+				OriginalSize: bundleSize,
+				TotalChunks:  0,
+			}, nil
 		}
 
 		chunk, err := models.CreateBundleChunk(metadata, entries, 0, 1)

--- a/tests/unit/bundle_splitter_edge_cases_test.go
+++ b/tests/unit/bundle_splitter_edge_cases_test.go
@@ -170,6 +170,65 @@ func TestSplitBundle_InvalidEntries(t *testing.T) {
 	assert.Contains(t, err.Error(), "extract entries")
 }
 
+// TestSplitBundle_NoEntries tests that a Bundle without entries passes through unchanged
+func TestSplitBundle_NoEntries(t *testing.T) {
+	testCases := []struct {
+		name   string
+		bundle map[string]any
+	}{
+		{
+			name: "Empty collection bundle",
+			bundle: map[string]any{
+				"resourceType": "Bundle",
+				"id":           "empty-collection",
+				"type":         "collection",
+				"entry":        []any{},
+			},
+		},
+		{
+			name: "Empty searchset bundle with total 0",
+			bundle: map[string]any{
+				"resourceType": "Bundle",
+				"id":           "empty-searchset",
+				"type":         "searchset",
+				"total":        0,
+				"entry":        []any{},
+			},
+		},
+	}
+
+	thresholdBytes := 10 * 1024 * 1024
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := services.SplitBundle(tc.bundle, thresholdBytes)
+
+			require.NoError(t, err, "Bundle without entries should not error")
+			assert.False(t, result.WasSplit, "Bundle without entries should not be split")
+			assert.Equal(t, 0, result.TotalChunks, "Bundle without entries should produce no chunks")
+			assert.Empty(t, result.Chunks, "Bundle without entries should produce no chunks")
+			assert.Greater(t, result.OriginalSize, 0, "Original size should be recorded")
+			assert.Equal(t, tc.bundle["id"], result.Metadata.ID)
+			assert.Equal(t, tc.bundle["type"], result.Metadata.Type)
+		})
+	}
+}
+
+// TestSplitBundle_MissingEntryKey tests that a Bundle without an entry field is rejected
+func TestSplitBundle_MissingEntryKey(t *testing.T) {
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"id":           "no-entry-field",
+		"type":         "collection",
+	}
+
+	thresholdBytes := 10 * 1024 * 1024
+
+	_, err := services.SplitBundle(bundle, thresholdBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "extract entries")
+}
+
 // TestSplitBundle_OversizedSingleEntry tests bundle with single oversized entry
 func TestSplitBundle_OversizedSingleEntry(t *testing.T) {
 	// Create bundle with single oversized entry


### PR DESCRIPTION
Closes #650

`SplitBundle` rejected a structurally valid Bundle whose `entry` array is empty: the no-split path always built a single chunk, and `models.CreateBundleChunk` requires at least one entry. The no-split path now returns the Bundle unchanged when it holds no entries — a `SplitResult` with no chunks, `TotalChunks: 0` and `WasSplit: false`. `CalculateChunkStats` already handles that shape (guards at `len(result.Chunks) == 0` and `result.TotalChunks > 0`, pinned by `TestCalculateChunkStats_EmptyResult`). The guard inside `CreateBundleChunk` is unchanged; it remains correct for a real chunk.

**The defect is latent, not a live pipeline failure.** `resource_processor.go` calls `SplitBundle` only when `ShouldSplit` is true; an empty Bundle (~60 bytes) never crosses the ≥1 MB threshold, so the failing branch is unreachable from the pipeline today. The fix matters because the branch contradicted the function's own documentation, `SplitBundle` is exported and pure so a direct caller hits it immediately, and any relocation of the size check would make it live. Reviewers should weight it accordingly.

Behaviour decisions:

- A Bundle with no `entry` key at all still errors (`bundle.entry must be an array`), matching the documented contract ("must have id, type, entry fields") and the structure checks the splitter itself uses. A test pins this.
- `ReassembleBundle` still rejects an empty chunk array. Reassembly exists to combine pseudonymized chunks while preserving DIMP-added Bundle-level metadata from the first chunk; with zero chunks nothing went through DIMP, so synthesizing a Bundle from original metadata would fabricate output that was never pseudonymized. `WasSplit: false` tells callers to keep using the original Bundle, which is what the pipeline and the documented usage example already do.

Follow-up: PR #651 (branch `scorecard-fuzzing`, still open) adds `tests/unit/fuzz_bundle_split_test.go` with a `t.Skip` referencing #650 in `FuzzSplitBundleAcceptsValidBundle`; once both merge that skip should be removed. Note also that `FuzzSplitReassembleBundle` on that branch reassembles whatever `SplitBundle` returns without checking `WasSplit` — after this fix, a fuzzed empty Bundle yields zero chunks and `ReassembleBundle` rejects them, so that fuzz target will need a zero-chunk guard when the branches meet.