### PR TITLE
fix(dimp): compute the exact Bundle wrapper size when partitioning

### DIFF
--- a/internal/models/bundle.go
+++ b/internal/models/bundle.go
@@ -99,23 +99,16 @@ func CreateBundleChunk(metadata BundleMetadata, entries []map[string]any,
 		return BundleChunk{}, fmt.Errorf("chunk must contain at least one entry")
 	}
 
-	chunkID := fmt.Sprintf("%s-chunk-%d", metadata.ID, index)
+	id := chunkID(metadata.ID, index)
 
 	// Calculate estimated size of chunk
-	estimatedSize, err := CalculateJSONSize(map[string]any{
-		"resourceType": "Bundle",
-		"id":           chunkID,
-		"type":         metadata.Type,
-		"timestamp":    metadata.Timestamp.Format(time.RFC3339),
-		"total":        len(entries),
-		"entry":        entries,
-	})
+	estimatedSize, err := CalculateJSONSize(chunkBundle(id, metadata, toAnySlice(entries), len(entries)))
 	if err != nil {
 		return BundleChunk{}, fmt.Errorf("failed to calculate chunk size: %w", err)
 	}
 
 	chunk := BundleChunk{
-		ChunkID:       chunkID,
+		ChunkID:       id,
 		Index:         index,
 		TotalChunks:   totalChunks,
 		OriginalID:    metadata.ID,
@@ -127,32 +120,59 @@ func CreateBundleChunk(metadata BundleMetadata, entries []map[string]any,
 	return chunk, nil
 }
 
+// MaxChunkWrapperSize returns an upper bound for the serialized size in bytes
+// of the Bundle wrapper that ConvertChunkToBundle puts around a chunk's entries
+// — everything except the entries themselves and the separators between them.
+// Splitting entryCount entries produces at most entryCount chunks, so sizing
+// the chunk id "{originalID}-chunk-{index}" and the total field of
+// searchset/history Bundles with entryCount makes the bound hold for every chunk.
+func MaxChunkWrapperSize(metadata BundleMetadata, entryCount int) int {
+	// The wrapper holds only strings, an int and an empty slice — the timestamp
+	// is formatted to a string first — so json.Marshal cannot fail here.
+	size, _ := CalculateJSONSize(chunkBundle(chunkID(metadata.ID, entryCount-1), metadata, []any{}, entryCount))
+	return size
+}
+
 // ConvertChunkToBundle converts a BundleChunk into a valid FHIR Bundle JSON object
 // suitable for sending to DIMP or other FHIR-compliant services
 func ConvertChunkToBundle(chunk BundleChunk) map[string]any {
-	// Convert []map[string]any to []any for FHIR Bundle entry field
-	entries := make([]any, len(chunk.Entries))
-	for i, entry := range chunk.Entries {
-		entries[i] = entry
-	}
+	return chunkBundle(chunk.ChunkID, chunk.Metadata, toAnySlice(chunk.Entries), len(chunk.Entries))
+}
 
+// chunkID builds the id of a chunk Bundle from the original Bundle id
+func chunkID(bundleID string, index int) string {
+	return fmt.Sprintf("%s-chunk-%d", bundleID, index)
+}
+
+// toAnySlice converts entries to []any for the FHIR Bundle entry field
+func toAnySlice(entries []map[string]any) []any {
+	converted := make([]any, len(entries))
+	for i, entry := range entries {
+		converted[i] = entry
+	}
+	return converted
+}
+
+// chunkBundle builds the FHIR Bundle JSON object around a chunk's entry array.
+// totalEntries sizes the total field independently of the entry array, so the
+// wrapper size can be computed with an empty array.
+func chunkBundle(id string, metadata BundleMetadata, entries []any, totalEntries int) map[string]any {
 	bundle := map[string]any{
 		"resourceType": "Bundle",
-		"id":           chunk.ChunkID,
-		"type":         chunk.Metadata.Type,
+		"id":           id,
+		"type":         metadata.Type,
 		"entry":        entries,
 	}
 
 	// Add timestamp if present
-	if !chunk.Metadata.Timestamp.IsZero() {
-		bundle["timestamp"] = chunk.Metadata.Timestamp.Format(time.RFC3339)
+	if !metadata.Timestamp.IsZero() {
+		bundle["timestamp"] = metadata.Timestamp.Format(time.RFC3339)
 	}
 
 	// Add total field ONLY for searchset and history bundles (FHIR R4 invariant: "total only when a search or history")
 	// For collection/document bundles, the total field must NOT be present
-	bundleType := chunk.Metadata.Type
-	if bundleType == "searchset" || bundleType == "history" {
-		bundle["total"] = len(chunk.Entries)
+	if metadata.Type == "searchset" || metadata.Type == "history" {
+		bundle["total"] = totalEntries
 	}
 
 	return bundle

--- a/internal/pipeline/validation.go
+++ b/internal/pipeline/validation.go
@@ -387,7 +387,9 @@ func chunkResources(resources []map[string]any, thresholdBytes int, logger *lib.
 		}
 	}
 
-	partitions, err := services.PartitionEntries(entries, thresholdBytes)
+	wrapperBytes := validationWrapperBytes()
+
+	partitions, err := services.PartitionEntries(entries, thresholdBytes, wrapperBytes)
 	if err != nil {
 		// Handle oversized resources: isolate them in their own chunk
 		var oversizedErr *models.OversizedResourceError
@@ -397,7 +399,7 @@ func chunkResources(resources []map[string]any, thresholdBytes int, logger *lib.
 				"resourceID", oversizedErr.ResourceID,
 				"size", oversizedErr.Size,
 				"threshold", oversizedErr.Threshold)
-			return chunkResourcesWithOversized(entries, thresholdBytes, logger)
+			return chunkResourcesWithOversized(entries, thresholdBytes, wrapperBytes, logger)
 		}
 		return nil, err
 	}
@@ -414,9 +416,18 @@ func isOversized(err error, target **models.OversizedResourceError) bool {
 	return false
 }
 
+// validationWrapperBytes returns the serialized size of the empty collection
+// Bundle that buildCollectionBundle wraps around each validation chunk.
+func validationWrapperBytes() int {
+	// The empty collection Bundle holds only constant strings and an empty
+	// slice, so json.Marshal cannot fail here.
+	size, _ := models.CalculateJSONSize(buildCollectionBundle([]map[string]any{}))
+	return size
+}
+
 // chunkResourcesWithOversized handles the case where some resources exceed the threshold.
 // Oversized resources are placed in their own single-entry chunks.
-func chunkResourcesWithOversized(entries []map[string]any, thresholdBytes int, logger *lib.Logger) ([][]map[string]any, error) {
+func chunkResourcesWithOversized(entries []map[string]any, thresholdBytes int, wrapperBytes int, logger *lib.Logger) ([][]map[string]any, error) {
 	var partitions [][]map[string]any
 	var normalEntries []map[string]any
 
@@ -426,11 +437,10 @@ func chunkResourcesWithOversized(entries []map[string]any, thresholdBytes int, l
 			return nil, fmt.Errorf("failed to calculate entry size: %w", err)
 		}
 
-		// ~200 bytes Bundle overhead, same constant as PartitionEntries
-		if entrySize+200 > thresholdBytes {
+		if entrySize+wrapperBytes > thresholdBytes {
 			// Flush accumulated normal entries first
 			if len(normalEntries) > 0 {
-				subPartitions, err := services.PartitionEntries(normalEntries, thresholdBytes)
+				subPartitions, err := services.PartitionEntries(normalEntries, thresholdBytes, wrapperBytes)
 				if err != nil {
 					return nil, fmt.Errorf("failed to partition normal entries: %w", err)
 				}
@@ -456,7 +466,7 @@ func chunkResourcesWithOversized(entries []map[string]any, thresholdBytes int, l
 
 	// Flush remaining normal entries
 	if len(normalEntries) > 0 {
-		subPartitions, err := services.PartitionEntries(normalEntries, thresholdBytes)
+		subPartitions, err := services.PartitionEntries(normalEntries, thresholdBytes, wrapperBytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to partition remaining entries: %w", err)
 		}

--- a/internal/services/bundle_splitter.go
+++ b/internal/services/bundle_splitter.go
@@ -82,6 +82,8 @@ func ShouldSplit(bundleSizeBytes int, thresholdBytes int) bool {
 //
 //	entries - Array of Bundle entry objects (must not be empty)
 //	thresholdBytes - Maximum size per chunk in bytes
+//	wrapperBytes - Serialized size of the Bundle wrapper the caller puts around
+//	               each partition (e.g. from models.MaxChunkWrapperSize)
 //
 // Returns:
 //
@@ -90,7 +92,7 @@ func ShouldSplit(bundleSizeBytes int, thresholdBytes int) bool {
 //
 // WHY: Maximizes chunk sizes (fewer HTTP requests) while respecting threshold
 // WHY: Simple greedy algorithm over complex bin-packing (KISS principle)
-func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[string]any, error) {
+func PartitionEntries(entries []map[string]any, thresholdBytes int, wrapperBytes int) ([][]map[string]any, error) {
 	if len(entries) == 0 {
 		return nil, fmt.Errorf("cannot partition empty entry array")
 	}
@@ -98,10 +100,6 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 	var partitions [][]map[string]any
 	currentPartition := []map[string]any{}
 	currentSize := 0
-
-	// Bundle wrapper overhead (approximate fixed cost per chunk)
-	// Includes: resourceType, id, type, timestamp, total fields
-	const bundleOverheadBytes = 200
 
 	for i, entry := range entries {
 		// Calculate size of this entry
@@ -111,7 +109,7 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 		}
 
 		// Check if single entry exceeds threshold (cannot be split)
-		if entrySize+bundleOverheadBytes > thresholdBytes {
+		if entrySize+wrapperBytes > thresholdBytes {
 			// Extract resource info for error message
 			resourceType := "Unknown"
 			resourceID := "unknown"
@@ -143,7 +141,7 @@ func PartitionEntries(entries []map[string]any, thresholdBytes int) ([][]map[str
 
 		// Check if adding this entry (plus the JSON separator preceding it
 		// in the serialized entry array) would exceed threshold
-		if len(currentPartition) > 0 && currentSize+1+entrySize+bundleOverheadBytes > thresholdBytes {
+		if len(currentPartition) > 0 && currentSize+1+entrySize+wrapperBytes > thresholdBytes {
 			// Current chunk would exceed limit - start new chunk
 			partitions = append(partitions, currentPartition)
 			currentPartition = []map[string]any{}
@@ -242,8 +240,10 @@ func SplitBundle(bundle map[string]any, thresholdBytes int) (models.SplitResult,
 		return models.SplitResult{}, fmt.Errorf("failed to extract entries: %w", err)
 	}
 
+	wrapperBytes := models.MaxChunkWrapperSize(metadata, len(entries))
+
 	// Partition entries using greedy algorithm
-	partitions, err := PartitionEntries(entries, thresholdBytes)
+	partitions, err := PartitionEntries(entries, thresholdBytes, wrapperBytes)
 	if err != nil {
 		return models.SplitResult{}, fmt.Errorf("failed to partition entries: %w", err)
 	}

--- a/tests/unit/bundle_splitter_edge_cases_test.go
+++ b/tests/unit/bundle_splitter_edge_cases_test.go
@@ -12,12 +12,16 @@ import (
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
 
+// testWrapperBytes is a representative Bundle wrapper size for partitioning tests
+// that exercise the greedy algorithm rather than the wrapper computation
+const testWrapperBytes = 200
+
 // TestPartitionEntries_EmptyArray tests error handling for empty entry array
 func TestPartitionEntries_EmptyArray(t *testing.T) {
 	entries := []map[string]any{}
 	thresholdBytes := 10 * 1024 * 1024
 
-	_, err := services.PartitionEntries(entries, thresholdBytes)
+	_, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty entry array")
 }
@@ -38,7 +42,7 @@ func TestPartitionEntries_OversizedEntry(t *testing.T) {
 	entries := []map[string]any{largeEntry}
 	thresholdBytes := 10 * 1024 * 1024 // 10MB
 
-	_, err := services.PartitionEntries(entries, thresholdBytes)
+	_, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 	require.Error(t, err)
 
 	// Should be an OversizedResourceError
@@ -73,7 +77,7 @@ func TestPartitionEntries_MultipleOversizedEntries(t *testing.T) {
 
 	thresholdBytes := 10 * 1024 * 1024
 
-	_, err := services.PartitionEntries(entries, thresholdBytes)
+	_, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 	require.Error(t, err)
 
 	// Should fail on the first oversized entry
@@ -101,7 +105,7 @@ func TestPartitionEntries_OversizedEntryWithoutResourceInfo(t *testing.T) {
 
 	thresholdBytes := 10 * 1024 * 1024
 
-	_, err := services.PartitionEntries(entries, thresholdBytes)
+	_, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 	require.Error(t, err)
 
 	oversizedErr, ok := err.(*models.OversizedResourceError)
@@ -706,6 +710,36 @@ func TestSplitBundle_BundleExactlyAtThreshold(t *testing.T) {
 	assert.Equal(t, 1, result.TotalChunks)
 }
 
+// TestPartitionEntries_WrapperBudgetCountsAgainstThreshold tests that an entry
+// only fits a chunk when entry size plus wrapper size stay within the threshold
+func TestPartitionEntries_WrapperBudgetCountsAgainstThreshold(t *testing.T) {
+	entries := []map[string]any{
+		{
+			"resource": map[string]any{
+				"resourceType": "Patient",
+				"id":           "pat-1",
+			},
+		},
+	}
+	entrySize, err := models.CalculateJSONSize(entries[0])
+	require.NoError(t, err)
+	thresholdBytes := entrySize + 10
+
+	t.Run("entry fits with small wrapper", func(t *testing.T) {
+		partitions, err := services.PartitionEntries(entries, thresholdBytes, 10)
+		require.NoError(t, err)
+		assert.Len(t, partitions, 1)
+	})
+
+	t.Run("entry is oversized with large wrapper", func(t *testing.T) {
+		_, err := services.PartitionEntries(entries, thresholdBytes, 11)
+		require.Error(t, err)
+		var oversizedErr *models.OversizedResourceError
+		require.True(t, errors.As(err, &oversizedErr))
+		assert.Equal(t, "Patient", oversizedErr.ResourceType)
+	})
+}
+
 // TestPartitionEntries_SingleEntry tests error path with single small entry
 func TestPartitionEntries_SingleEntry(t *testing.T) {
 	entries := []map[string]any{
@@ -723,7 +757,7 @@ func TestPartitionEntries_SingleEntry(t *testing.T) {
 
 	thresholdBytes := 10 * 1024 * 1024
 
-	partitions, err := services.PartitionEntries(entries, thresholdBytes)
+	partitions, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 
 	// Should succeed
 	require.NoError(t, err)
@@ -756,7 +790,7 @@ func TestPartitionEntries_EntryAtBoundary(t *testing.T) {
 
 	thresholdBytes := 10 * 1024 * 1024 // 10MB - should fit first entry with second
 
-	partitions, err := services.PartitionEntries(entries, thresholdBytes)
+	partitions, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 
 	require.NoError(t, err)
 	assert.Len(t, partitions, 1, "Both entries should fit in single partition under 10MB threshold")
@@ -781,7 +815,7 @@ func TestPartitionEntries_MultiplePartitions(t *testing.T) {
 
 	thresholdBytes := 5 * 1024 * 1024 // 5MB - should split entries into multiple partitions
 
-	partitions, err := services.PartitionEntries(entries, thresholdBytes)
+	partitions, err := services.PartitionEntries(entries, thresholdBytes, testWrapperBytes)
 
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(partitions), 2, "Should create at least 2 partitions")

--- a/tests/unit/bundle_splitter_test.go
+++ b/tests/unit/bundle_splitter_test.go
@@ -3,6 +3,7 @@ package unit
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -235,6 +236,54 @@ func TestConvertChunkToBundle(t *testing.T) {
 	assert.NotEmpty(t, bundle["timestamp"]) // Should have timestamp
 }
 
+// TestMaxChunkWrapperSize verifies the wrapper size matches the serialized
+// Bundle that ConvertChunkToBundle produces: wrapper bytes plus entry bytes
+// plus one separator per entry after the first equals the full chunk payload
+// size. The bound is exact here because the id and total digit counts of the
+// tested chunk match the bound's digit counts.
+func TestMaxChunkWrapperSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		metadata models.BundleMetadata
+	}{
+		{
+			name:     "collection without timestamp",
+			metadata: models.BundleMetadata{ID: "original-bundle", Type: "collection"},
+		},
+		{
+			name:     "searchset with timestamp includes total",
+			metadata: models.BundleMetadata{ID: "original-bundle", Type: "searchset", Timestamp: time.Now()},
+		},
+	}
+
+	entries := []map[string]any{
+		{"resource": map[string]any{"resourceType": "Patient", "id": "patient-1"}},
+		{"resource": map[string]any{"resourceType": "Condition", "id": "condition-1"}},
+		{"resource": map[string]any{"resourceType": "Observation", "id": "observation-1"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapperSize := models.MaxChunkWrapperSize(tc.metadata, len(entries))
+
+			entryBytes := 0
+			for _, entry := range entries {
+				entrySize, err := models.CalculateJSONSize(entry)
+				require.NoError(t, err)
+				entryBytes += entrySize
+			}
+			separatorBytes := len(entries) - 1
+
+			chunk, err := models.CreateBundleChunk(tc.metadata, entries, 0, 1)
+			require.NoError(t, err)
+			serialized, err := json.Marshal(models.ConvertChunkToBundle(chunk))
+			require.NoError(t, err)
+
+			assert.Equal(t, len(serialized), wrapperSize+entryBytes+separatorBytes)
+		})
+	}
+}
+
 // TestExtractEntriesFromBundle verifies entry extraction
 func TestExtractEntriesFromBundle(t *testing.T) {
 	bundle := CreateTestBundle(5, 1)
@@ -307,18 +356,40 @@ func TestPartitionEntriesGreedyAlgorithm(t *testing.T) {
 func TestSplitBundleChunksStayWithinThreshold(t *testing.T) {
 	testCases := []struct {
 		name           string
+		bundleID       string
+		bundleType     string
+		withTimestamp  bool
 		entryCount     int
 		thresholdBytes int
 	}{
 		{
 			name:           "many tiny entries with small threshold",
+			bundleID:       "tiny-entry-bundle",
+			bundleType:     "collection",
 			entryCount:     4000,
 			thresholdBytes: 4000,
 		},
 		{
 			name:           "many tiny entries with large threshold",
+			bundleID:       "tiny-entry-bundle",
+			bundleType:     "collection",
 			entryCount:     20000,
 			thresholdBytes: 100000,
+		},
+		{
+			name:           "long Bundle id enlarges the chunk wrapper",
+			bundleID:       strings.Repeat("very-long-bundle-id-", 15),
+			bundleType:     "collection",
+			entryCount:     4000,
+			thresholdBytes: 4000,
+		},
+		{
+			name:           "searchset with timestamp adds total and timestamp to the wrapper",
+			bundleID:       "tiny-entry-bundle",
+			bundleType:     "searchset",
+			withTimestamp:  true,
+			entryCount:     4000,
+			thresholdBytes: 4000,
 		},
 	}
 
@@ -332,9 +403,12 @@ func TestSplitBundleChunksStayWithinThreshold(t *testing.T) {
 			}
 			bundle := map[string]any{
 				"resourceType": "Bundle",
-				"id":           "tiny-entry-bundle",
-				"type":         "collection",
+				"id":           tc.bundleID,
+				"type":         tc.bundleType,
 				"entry":        entries,
+			}
+			if tc.withTimestamp {
+				bundle["timestamp"] = time.Now().Format(time.RFC3339)
 			}
 
 			result, err := services.SplitBundle(bundle, tc.thresholdBytes)


### PR DESCRIPTION
Closes #659

Stacked on #657 — this PR targets `issue-649-bundle-chunk-separator` and builds on the separator fix; merge #657 first.

## Problem

`PartitionEntries` reserved a flat `bundleOverheadBytes = 200` for the JSON wrapper of each chunk Bundle. The real wrapper contains the chunk id `{originalID}-chunk-{index}` plus the `resourceType`, `type`, `timestamp`, and `total` fields, so a sufficiently long source Bundle id made the real wrapper larger than 200 bytes. Chunks then exceeded the threshold even though the size check passed — with a 300-character id and threshold 4000, chunks serialized to 4152 bytes.

## Fix

- `models.MaxChunkWrapperSize(metadata, entryCount)` computes an upper bound for the chunk wrapper from the Bundle metadata, through the same `chunkBundle` builder that produces the real chunk payload. Splitting `entryCount` entries produces at most `entryCount` chunks, so sizing the id and the `total` field with `entryCount` makes the bound hold for every chunk.
- `PartitionEntries` takes the wrapper size as a parameter instead of the flat constant, so both size checks count the real wrapper. This deviates slightly from the issue text: the metadata flows into the wrapper computation, not into `PartitionEntries` itself, because the two callers use different wrappers.
- `SplitBundle` passes the metadata-derived bound; the validation pipeline passes the exact size of its empty collection Bundle and drops its duplicated `entrySize+200` check.
- `CreateBundleChunk` estimates chunk sizes through the shared builder as well, so a single definition of the chunk wrapper remains.

## Tests

- `TestSplitBundleChunksStayWithinThreshold` gains a long-Bundle-id case (red before the fix) and a searchset-with-timestamp case, asserting every chunk serializes within the threshold while non-final chunks stay above 90% of it.
- `TestMaxChunkWrapperSize` pins the wrapper size to the serialized output of `ConvertChunkToBundle`: wrapper + entry bytes + separators equals the full payload size.
- `TestPartitionEntries_WrapperBudgetCountsAgainstThreshold` covers the oversized-entry check including the wrapper budget.