### PR TITLE
ci: set Go up in the e2e-test job

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -170,6 +170,12 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y jq ripgrep
 
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
       - name: Build aether
         run: make build
 


### PR DESCRIPTION
## Summary

The `e2e-test` job in `_tests.yaml` built `aether` with the Go of the runner image and had no module cache. The three other e2e jobs set Go up from `go.mod` with `cache: true`. This adds the same step to `e2e-test`, so all four jobs build with the same toolchain.

Measured in run 30898632683 on `main`, the same `make build` took 31s in `E2E Tests` against 14–16s in the three jobs that set Go up.

Closes #662
