### PR TITLE
feat: add install-dev.sh to install a PR or main build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,17 @@ make lint-docs
 cd docs && npm install && npm run docs:build
 ```
 
+## Testing a Development Build
+
+CI builds a binary for every pull request and for every push to `main`. `install-dev.sh` downloads such a build, so a reviewer does not have to compile the code:
+
+```bash
+./install-dev.sh 663   # build of pull request 663
+./install-dev.sh main  # newest main build
+```
+
+The script requires the [GitHub CLI](https://github.com/cli/cli). These builds are unsigned and are for tests only. Use `install.sh` to install a release.
+
 ## Requirements for Acceptable Contributions
 
 - All code must be formatted with `gofmt`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,6 +40,31 @@ export PATH="$HOME/.local/bin:$PATH"
 
 2. Extract and move to a directory in your PATH
 
+## Development Builds
+
+`install-dev.sh` installs an unsigned build from a pull request or from `main`. Use it to test a change before it is released. Do not use it in production.
+
+The script requires the [GitHub CLI](https://github.com/cli/cli), because a workflow artifact needs an authenticated request.
+
+```bash
+# Newest main build
+curl -sSfL https://raw.githubusercontent.com/medizininformatik-initiative/aether/main/install-dev.sh | sh
+
+# Build of pull request 663
+curl -sSfL https://raw.githubusercontent.com/medizininformatik-initiative/aether/main/install-dev.sh | sh -s -- 663
+
+sudo mv aether /usr/local/bin/
+```
+
+With the repository checked out, call the script directly:
+
+```bash
+./install-dev.sh main
+./install-dev.sh 663
+```
+
+A build artifact expires after 14 days. Closing a pull request deletes its artifact immediately.
+
 ## Verify
 
 ```bash

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+# Usage: install-dev.sh [<pr-number>|main]
+#
+# Installs an unsigned development build from GitHub Actions.
+# Use install.sh instead to install a release.
+
+set -e
+
+repo="medizininformatik-initiative/aether"
+ref="${1:-main}"
+
+case $ref in
+  main) ;;
+  *[!0-9]*)
+    echo "Usage: install-dev.sh [<pr-number>|main]" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v gh > /dev/null; then
+  echo "Error: GitHub CLI (gh) is required to download workflow artifacts." >&2
+  echo "Install it from https://github.com/cli/cli" >&2
+  exit 1
+fi
+
+if ! gh auth status > /dev/null 2>&1; then
+  echo "Error: GitHub CLI is not authenticated. Run \`gh auth login\`." >&2
+  exit 1
+fi
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case $os in
+  mingw* | msys* | cygwin*) os="windows" ;;
+esac
+
+arch=$(uname -m)
+case $arch in
+  x86_64) arch="amd64" ;;
+  aarch64) arch="arm64" ;;
+esac
+
+binary_name="aether-$os-$arch"
+target="aether"
+if [ "$os" = "windows" ]; then
+  binary_name="$binary_name.exe"
+  target="aether.exe"
+fi
+
+artifact_exists() {
+  [ -n "$(gh api "/repos/$repo/actions/artifacts?name=$1" \
+    --jq '[.artifacts[] | select(.expired == false)] | .[0].id // empty')" ]
+}
+
+if [ "$ref" = "main" ]; then
+  source_description="main"
+  run_id=""
+  # The newest run gives no artifact if its build job failed or is still active.
+  for candidate in $(gh run list --repo "$repo" --workflow CI --branch main \
+    --event push --limit 10 --json databaseId --jq '.[].databaseId'); do
+    if artifact_exists "build-artifacts-$candidate"; then
+      run_id="$candidate"
+      break
+    fi
+  done
+  artifact_name="build-artifacts-$run_id"
+else
+  source_description="pull request $ref"
+  artifact_name="build-artifacts-pr-$ref"
+  # The artifact carries its run, so a run that is still in progress also works.
+  run_id=$(gh api "/repos/$repo/actions/artifacts?name=$artifact_name" \
+    --jq '[.artifacts[] | select(.expired == false)] | .[0].workflow_run.id // empty')
+fi
+
+if [ -z "$run_id" ]; then
+  echo "Error: no build artifact found for $source_description." >&2
+  echo "The build job is possibly still in progress or it failed." >&2
+  echo "An artifact also expires after 14 days, and closing a pull request deletes it." >&2
+  exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+echo "Warning: this is an unsigned development build. Do not use it in production."
+echo "Download $artifact_name from run $run_id ($source_description)..."
+
+gh run download "$run_id" --repo "$repo" --name "$artifact_name" --dir "$tmp_dir"
+
+if [ ! -f "$tmp_dir/$binary_name" ]; then
+  echo "Error: the artifact does not contain $binary_name." >&2
+  exit 1
+fi
+
+mv "$tmp_dir/$binary_name" "./$target"
+chmod +x "./$target"
+
+echo "Please use \`sudo mv ./$target /usr/local/bin/$target\` to move aether into PATH"


### PR DESCRIPTION
Closes #665

`install.sh` installs a release only. A tester who wants to try a pull request had to call `gh run download` by hand, find the artifact name and the run, pick the binary for their platform, and set the executable bit.

`install-dev.sh` does this in one step:

```bash
./install-dev.sh 663   # build of pull request 663
./install-dev.sh main  # newest main build
./install-dev.sh       # same as main
```

The curl-pipe form of `install.sh` works too: `curl -sSfL .../install-dev.sh | sh -s -- 663`.

## How the artifact is resolved

- **Pull request**: the artifact name is fixed (`build-artifacts-pr-<n>`), so the run comes from the artifact itself. A run that is still in progress therefore also works, because the build job uploads its artifact before the other jobs finish.
- **main**: the artifact name embeds the run ID, so the script walks the 10 newest CI runs of `main` and takes the first one with a live artifact. A filter on the conclusion of the run would be wrong here: `build` is one job among `lint`, `codeql`, `vuln` and `tests`, so a red unrelated job would hide a good build.

## Notes

- `gh` is a hard dependency. A workflow artifact is not reachable without an authenticated request. The script fails with a clear message if `gh` is absent or unauthenticated.
- No checksum and no attestation step. CI does not sign or attest these builds, so the script prints a warning that the build is unsigned.
- Windows is handled: `uname -s` reports `MINGW*`/`MSYS*`/`CYGWIN*`, and the binary gets the `.exe` suffix.
- The temporary directory is removed by a trap on `EXIT`, `INT` and `TERM`.

## Verification

There is no automated test. The repository has no test setup for shell scripts, and `install.sh` has none either; the maintainer chose to keep it that way for this change.

Verified by hand against the live repository, plus `sh -n` and `shellcheck -s sh`:

| Case | Result |
|---|---|
| `./install-dev.sh` (main) | downloads `build-artifacts-30902129041`, installs an ELF binary |
| `./install-dev.sh 655` (run in progress) | downloads `build-artifacts-pr-655` |
| `./install-dev.sh 999` (no artifact) | error message, exit 1 |
| `./install-dev.sh v1` (bad argument) | usage message, exit 1 |