### PR TITLE
fix(flattening): keep failed CSV output as .partial and report write errors

### DIFF
--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
@@ -119,6 +120,12 @@ func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 	csvWriter := services.NewCSVWriter(outputDir)
 	viewDefWriter := services.NewViewDefinitionWriter(viewDefDir)
 
+	// Drop stale partial files from an earlier failed run, so a retry never
+	// keeps or reports rows it did not write
+	if err := csvWriter.RemovePartials(); err != nil {
+		return StepResult{}, err
+	}
+
 	attributeGroups := services.GetAttributeGroups(crtdl)
 	fmt.Printf("Processing %d attribute group(s)...\n\n", len(attributeGroups))
 
@@ -168,7 +175,7 @@ func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 		job.Config.Services.Flattening.GetBatchSizeBytes(),
 	)
 	if err != nil {
-		return StepResult{}, err
+		return StepResult{}, annotateWithPartialFiles(err, csvWriter)
 	}
 
 	// Print per-group progress
@@ -216,7 +223,6 @@ func scanProvenanceIndex(files []string) (models.ProvenanceIndex, error) {
 	return mergedIndex, nil
 }
 
-// streamAndFlattenResources performs single-pass streaming over all input files,
 // perGroupBudget splits the total batch byte budget evenly across attribute groups,
 // clamping to one byte so a tiny budget spread over many groups never yields a
 // zero threshold that would flush after every single resource.
@@ -228,6 +234,7 @@ func perGroupBudget(batchSizeBytes, numGroups int) int {
 	return perGroupBytes
 }
 
+// streamAndFlattenResources performs single-pass streaming over all input files,
 // routing each resource to per-group batches via provenance index and flushing
 // when the byte threshold is exceeded. Returns per-group resource totals.
 func streamAndFlattenResources(
@@ -327,7 +334,28 @@ func streamAndFlattenResources(
 		}
 	}
 
+	// Publish complete files under their final names. A group whose batch
+	// never flushed has no file to publish.
+	for i := range batches {
+		if batches[i].isFirstBatch {
+			continue
+		}
+		if err := csvWriter.Finalize(filenames[i]); err != nil {
+			return nil, fmt.Errorf("failed to finalize CSV for group '%s': %w", groups[i].Name, err)
+		}
+	}
+
 	return totals, nil
+}
+
+// annotateWithPartialFiles names the partial CSV files that a failed run left
+// behind, so nobody mistakes them for complete exports.
+func annotateWithPartialFiles(err error, csvWriter *services.CSVWriter) error {
+	partials, listErr := csvWriter.PartialFiles()
+	if listErr != nil || len(partials) == 0 {
+		return err
+	}
+	return fmt.Errorf("%w (incomplete output kept as: %s)", err, strings.Join(partials, ", "))
 }
 
 // routeResourceToGroups determines which groups a resource belongs to based on

--- a/internal/services/csv_writer.go
+++ b/internal/services/csv_writer.go
@@ -3,15 +3,25 @@ package services
 import (
 	"encoding/csv"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/medizininformatik-initiative/aether/internal/lib"
 )
 
+// PartialSuffix marks CSV files that are still being written or were left
+// behind by a failed run. A file without the suffix is complete.
+const PartialSuffix = ".partial"
+
 // CSVWriter handles writing flattened data to CSV files
 type CSVWriter struct {
 	outputDir string
+}
+
+// partialPath returns the in-progress path for a CSV filename
+func (w *CSVWriter) partialPath(filename string) string {
+	return filepath.Join(w.outputDir, filename+PartialSuffix)
 }
 
 // NewCSVWriter creates a new CSVWriter with the given output directory
@@ -21,36 +31,22 @@ func NewCSVWriter(outputDir string) *CSVWriter {
 	}
 }
 
-// AppendCSVData appends parsed rows to a file. On the first batch, it creates
-// the file and writes the header followed by the rows. On subsequent batches,
-// it appends rows only (no duplicate header).
+// AppendCSVData appends parsed rows to the partial file for filename. On the
+// first batch, it creates the file and writes the header followed by the rows.
+// On subsequent batches, it appends rows only (no duplicate header).
+// Call Finalize after the last batch to publish the file under its final name.
 func (w *CSVWriter) AppendCSVData(filename string, header []string, rows [][]string, isFirstBatch bool) error {
-	outputPath := filepath.Join(w.outputDir, filename)
-
 	// Ensure output directory exists
 	if err := os.MkdirAll(w.outputDir, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	if isFirstBatch {
-		file, err := os.Create(outputPath)
+		file, err := os.Create(w.partialPath(filename))
 		if err != nil {
 			return fmt.Errorf("failed to create CSV file: %w", err)
 		}
-		defer func() { _ = file.Close() }()
-
-		writer := csv.NewWriter(file)
-
-		if len(header) > 0 {
-			if err := writer.Write(header); err != nil {
-				return fmt.Errorf("failed to write CSV header: %w", err)
-			}
-		}
-
-		if err := writer.WriteAll(rows); err != nil {
-			return fmt.Errorf("failed to write CSV rows: %w", err)
-		}
-		return nil
+		return w.writeRecords(file, header, rows)
 	}
 
 	// Subsequent batch: append rows only
@@ -58,15 +54,75 @@ func (w *CSVWriter) AppendCSVData(filename string, header []string, rows [][]str
 		return nil
 	}
 
-	file, err := os.OpenFile(outputPath, os.O_APPEND|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(w.partialPath(filename), os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open CSV file for append: %w", err)
 	}
-	defer func() { _ = file.Close() }()
 
-	writer := csv.NewWriter(file)
+	return w.writeRecords(file, nil, rows)
+}
+
+// writeRecords writes the header and the rows to dst as CSV, then closes dst.
+// It reports the error of Close, because a write fault on a network mount
+// often surfaces only there.
+func (w *CSVWriter) writeRecords(dst io.WriteCloser, header []string, rows [][]string) (err error) {
+	defer func() {
+		if cerr := dst.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("failed to close CSV file: %w", cerr)
+		}
+	}()
+
+	writer := csv.NewWriter(dst)
+
+	if len(header) > 0 {
+		if err := writer.Write(header); err != nil {
+			return fmt.Errorf("failed to write CSV header: %w", err)
+		}
+	}
+
+	// WriteAll flushes, so a buffered write fault surfaces here
 	if err := writer.WriteAll(rows); err != nil {
 		return fmt.Errorf("failed to write CSV rows: %w", err)
+	}
+
+	return nil
+}
+
+// PartialFiles returns the names of the partial files in the output directory
+func (w *CSVWriter) PartialFiles() ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(w.outputDir, "*"+PartialSuffix))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list partial CSV files: %w", err)
+	}
+
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		names = append(names, filepath.Base(match))
+	}
+	return names, nil
+}
+
+// RemovePartials deletes all partial files that an earlier run left in the
+// output directory, so a retry starts from empty output
+func (w *CSVWriter) RemovePartials() error {
+	names, err := w.PartialFiles()
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		if err := os.Remove(filepath.Join(w.outputDir, name)); err != nil {
+			return fmt.Errorf("failed to remove stale partial CSV file: %w", err)
+		}
+	}
+	return nil
+}
+
+// Finalize renames the partial file to its final name. Call it only after the
+// last batch for filename was appended without error.
+func (w *CSVWriter) Finalize(filename string) error {
+	if err := os.Rename(w.partialPath(filename), filepath.Join(w.outputDir, filename)); err != nil {
+		return fmt.Errorf("failed to finalize CSV file: %w", err)
 	}
 	return nil
 }

--- a/internal/services/csv_writer_internal_test.go
+++ b/internal/services/csv_writer_internal_test.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failingWriteCloser fails writes and/or the final Close.
+type failingWriteCloser struct {
+	writeErr error
+	closeErr error
+}
+
+func (f *failingWriteCloser) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+
+func (f *failingWriteCloser) Close() error {
+	return f.closeErr
+}
+
+func TestWriteRecords_ReportsWriteError(t *testing.T) {
+	w := NewCSVWriter(t.TempDir())
+	dst := &failingWriteCloser{writeErr: errors.New("disk fault")}
+
+	err := w.writeRecords(dst, []string{"id"}, [][]string{{"1"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write CSV rows")
+	assert.Contains(t, err.Error(), "disk fault")
+}
+
+func TestWriteRecords_ReportsHeaderWriteError(t *testing.T) {
+	w := NewCSVWriter(t.TempDir())
+	dst := &failingWriteCloser{writeErr: errors.New("disk fault")}
+
+	// csv.Writer buffers through a 4096-byte bufio.Writer, so a short header
+	// only fills the buffer. A header above that size flushes during Write,
+	// which is where the fault of the disk surfaces.
+	header := make([]string, 512)
+	for i := range header {
+		header[i] = strings.Repeat("x", 16)
+	}
+
+	err := w.writeRecords(dst, header, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write CSV header")
+	assert.Contains(t, err.Error(), "disk fault")
+}
+
+func TestWriteRecords_ReportsCloseError(t *testing.T) {
+	w := NewCSVWriter(t.TempDir())
+	dst := &failingWriteCloser{closeErr: errors.New("close fault")}
+
+	err := w.writeRecords(dst, []string{"id"}, [][]string{{"1"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to close CSV file")
+	assert.Contains(t, err.Error(), "close fault")
+}
+
+func TestWriteRecords_KeepsFirstError(t *testing.T) {
+	w := NewCSVWriter(t.TempDir())
+	dst := &failingWriteCloser{
+		writeErr: errors.New("disk fault"),
+		closeErr: errors.New("close fault"),
+	}
+
+	// The write error must win over the later close error
+	err := w.writeRecords(dst, []string{"id"}, [][]string{{"1"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write CSV rows")
+	assert.NotContains(t, err.Error(), "close fault")
+}

--- a/tests/unit/csv_writer_test.go
+++ b/tests/unit/csv_writer_test.go
@@ -39,6 +39,7 @@ func TestCSVWriter_AppendCSVData(t *testing.T) {
 
 		err := writer.AppendCSVData("special.csv", header, rows, true)
 		require.NoError(t, err)
+		require.NoError(t, writer.Finalize("special.csv"))
 
 		content, err := os.ReadFile(filepath.Join(tempDir, "special.csv"))
 		require.NoError(t, err)
@@ -63,6 +64,7 @@ func TestCSVWriter_AppendCSVData(t *testing.T) {
 
 		err := writer.AppendCSVData("patients.csv", header, rows, true)
 		require.NoError(t, err)
+		require.NoError(t, writer.Finalize("patients.csv"))
 
 		content, err := os.ReadFile(filepath.Join(tempDir, "patients.csv"))
 		require.NoError(t, err)
@@ -84,6 +86,7 @@ func TestCSVWriter_AppendCSVData(t *testing.T) {
 		// Second batch
 		err = writer.AppendCSVData("test.csv", header, [][]string{{"2", "Bob"}}, false)
 		require.NoError(t, err)
+		require.NoError(t, writer.Finalize("test.csv"))
 
 		content, err := os.ReadFile(filepath.Join(tempDir, "test.csv"))
 		require.NoError(t, err)
@@ -100,6 +103,7 @@ func TestCSVWriter_AppendCSVData(t *testing.T) {
 
 		err := writer.AppendCSVData("empty.csv", header, nil, true)
 		require.NoError(t, err)
+		require.NoError(t, writer.Finalize("empty.csv"))
 
 		content, err := os.ReadFile(filepath.Join(tempDir, "empty.csv"))
 		require.NoError(t, err)
@@ -120,6 +124,7 @@ func TestCSVWriter_AppendCSVData(t *testing.T) {
 		// Second batch with no rows
 		err = writer.AppendCSVData("test.csv", header, nil, false)
 		require.NoError(t, err)
+		require.NoError(t, writer.Finalize("test.csv"))
 
 		content, err := os.ReadFile(filepath.Join(tempDir, "test.csv"))
 		require.NoError(t, err)
@@ -142,12 +147,59 @@ func TestCSVWriter_AppendCSVData(t *testing.T) {
 
 		err = writer.AppendCSVData("multi.csv", header, [][]string{{"4", "d"}}, false)
 		require.NoError(t, err)
+		require.NoError(t, writer.Finalize("multi.csv"))
 
 		content, err := os.ReadFile(filepath.Join(tempDir, "multi.csv"))
 		require.NoError(t, err)
 
 		expected := "id,value\n1,a\n2,b\n3,c\n4,d\n"
 		assert.Equal(t, expected, string(content))
+	})
+}
+
+func TestCSVWriter_PartialLifecycle(t *testing.T) {
+	t.Run("append writes to partial file until finalized", func(t *testing.T) {
+		tempDir := t.TempDir()
+		writer := services.NewCSVWriter(tempDir)
+
+		err := writer.AppendCSVData("patients.csv", []string{"id", "name"}, [][]string{{"1", "Alice"}}, true)
+		require.NoError(t, err)
+
+		assert.FileExists(t, filepath.Join(tempDir, "patients.csv.partial"))
+		assert.NoFileExists(t, filepath.Join(tempDir, "patients.csv"))
+
+		err = writer.Finalize("patients.csv")
+		require.NoError(t, err)
+
+		assert.NoFileExists(t, filepath.Join(tempDir, "patients.csv.partial"))
+		content, err := os.ReadFile(filepath.Join(tempDir, "patients.csv"))
+		require.NoError(t, err)
+		assert.Equal(t, "id,name\n1,Alice\n", string(content))
+	})
+
+	t.Run("finalize without a partial file returns an error", func(t *testing.T) {
+		writer := services.NewCSVWriter(t.TempDir())
+
+		err := writer.Finalize("missing.csv")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to finalize CSV file")
+	})
+
+	t.Run("remove partials reports a removal error", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("Cannot test permission errors as root")
+		}
+
+		tempDir := t.TempDir()
+		partialPath := filepath.Join(tempDir, "stuck.csv"+services.PartialSuffix)
+		require.NoError(t, os.WriteFile(partialPath, []byte("id\n"), 0644))
+		require.NoError(t, os.Chmod(tempDir, 0555))
+		t.Cleanup(func() { _ = os.Chmod(tempDir, 0755) })
+
+		writer := services.NewCSVWriter(tempDir)
+		err := writer.RemovePartials()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to remove stale partial CSV file")
 	})
 }
 
@@ -193,43 +245,4 @@ func TestCSVWriter_AppendCSVDataErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open CSV file for append")
 	})
-
-	t.Run("first batch reports a write error", func(t *testing.T) {
-		dir, name := unwritableSink(t)
-		writer := services.NewCSVWriter(dir)
-
-		err := writer.AppendCSVData(name, []string{"id"}, [][]string{{"1"}}, true)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to write CSV rows")
-	})
-
-	t.Run("subsequent batch reports a write error", func(t *testing.T) {
-		dir, name := unwritableSink(t)
-		writer := services.NewCSVWriter(dir)
-
-		err := writer.AppendCSVData(name, []string{"id"}, [][]string{{"1"}}, false)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to write CSV rows")
-	})
-}
-
-// unwritableSink returns a directory and a filename whose join is a sink that
-// accepts an open but rejects every write. It makes the CSV write-error
-// branches reachable without a seam in the writer. Linux provides /dev/full
-// for this; on other systems the test skips.
-func unwritableSink(t *testing.T) (dir, name string) {
-	t.Helper()
-
-	const path = "/dev/full"
-	file, err := os.OpenFile(path, os.O_WRONLY, 0)
-	if err != nil {
-		t.Skipf("no unwritable sink on this system: %v", err)
-	}
-	_, writeErr := file.Write([]byte("probe"))
-	require.NoError(t, file.Close())
-	if writeErr == nil {
-		t.Skip("the sink accepted a write, so no CSV write error is possible")
-	}
-
-	return filepath.Dir(path), filepath.Base(path)
 }

--- a/tests/unit/pipeline_flattening_test.go
+++ b/tests/unit/pipeline_flattening_test.go
@@ -350,6 +350,24 @@ func writeTestLookupTable(t *testing.T, path string, profileURL, resourceType st
 	require.NoError(t, os.WriteFile(path, data, 0644))
 }
 
+// makeLargePatientBundles builds enough large Bundles with Provenance to
+// exceed a 1MB batch threshold, so the step makes more than one flattener call
+func makeLargePatientBundles(profileURL, groupID string) []map[string]any {
+	longName := strings.Repeat("Y", 10000)
+	var bundles []map[string]any
+	for i := 0; i < 110; i++ {
+		patientID := fmt.Sprintf("p%d", i)
+		patient := map[string]any{
+			"resourceType": "Patient", "id": patientID,
+			"meta": map[string]any{"profile": []any{profileURL}},
+			"name": []any{map[string]any{"family": fmt.Sprintf("%s_%d", longName, i)}},
+		}
+		prov := makeProvenance(fmt.Sprintf("prov-%d", i), "Patient/"+patientID, groupID)
+		bundles = append(bundles, makeBundle(fmt.Sprintf("b-%d", i), patient, prov))
+	}
+	return bundles
+}
+
 // TestExecuteFlatteningStep_ConfigValidationError tests line 36-40
 func TestExecuteFlatteningStep_ConfigValidationError(t *testing.T) {
 	tempDir := t.TempDir()
@@ -721,10 +739,14 @@ func TestExecuteFlatteningStep_MultipleBatches(t *testing.T) {
 	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
 	require.NoError(t, err)
 
-	// Verify CSV file was created
+	// Verify CSV file was created and no partial file remains
 	csvFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*.csv"))
 	require.NoError(t, err)
 	assert.Len(t, csvFiles, 1)
+
+	partialFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*"+services.PartialSuffix))
+	require.NoError(t, err)
+	assert.Empty(t, partialFiles)
 
 	// Read the CSV and verify it has header + data rows
 	content, err := os.ReadFile(csvFiles[0])
@@ -734,6 +756,375 @@ func TestExecuteFlatteningStep_MultipleBatches(t *testing.T) {
 	assert.Contains(t, lines[0], "id")
 	// Should have at least 1 data line (header + flattener response)
 	assert.GreaterOrEqual(t, len(lines), 2)
+}
+
+// TestExecuteFlatteningStep_FailedBatchLeavesPartialFile verifies that a batch
+// failure leaves only a .partial file, never a file under the final name, and
+// that the step error names the partial file
+func TestExecuteFlatteningStep_FailedBatchLeavesPartialFile(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fhir/ViewDefinition/$run" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"patient-from-first-batch"}` + "\n"))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("service error"))
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-partial-on-failure"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	groupID := "group-patient"
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	writeTestNDJSON(t, filepath.Join(inputDir, "patients.ndjson"), makeLargePatientBundles(profileURL, groupID))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	job.Config.Services.Flattening.BatchSizeMB = 1
+	logger := createFlatteningTestLogger()
+
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, callCount, 2, "test needs at least two batches")
+	assert.Contains(t, err.Error(), "Patient.csv"+services.PartialSuffix)
+
+	csvDir := filepath.Join(jobDir, "csv")
+	assert.NoFileExists(t, filepath.Join(csvDir, "Patient.csv"))
+	assert.FileExists(t, filepath.Join(csvDir, "Patient.csv"+services.PartialSuffix))
+}
+
+// TestExecuteFlatteningStep_RerunAfterFailureDoesNotDoubleRows verifies that a
+// rerun into the same job directory replaces the rows of the failed run
+func TestExecuteFlatteningStep_RerunAfterFailureDoesNotDoubleRows(t *testing.T) {
+	callCount := 0
+	failSecondCall := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fhir/ViewDefinition/$run" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		callCount++
+		if failSecondCall && callCount > 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("service error"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		if failSecondCall {
+			_, _ = w.Write([]byte(`{"id":"row-from-run1"}` + "\n"))
+		} else {
+			_, _ = w.Write([]byte(`{"id":"row-from-run2"}` + "\n"))
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-rerun-no-doubling"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	groupID := "group-patient"
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	writeTestNDJSON(t, filepath.Join(inputDir, "patients.ndjson"), makeLargePatientBundles(profileURL, groupID))
+
+	logger := createFlatteningTestLogger()
+
+	// Run 1 fails on the second batch and leaves a partial file
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	job.Config.Services.Flattening.BatchSizeMB = 1
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, callCount, 2, "test needs at least two batches")
+
+	// Run 2 succeeds into the same job directory
+	failSecondCall = false
+	job = createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	job.Config.Services.Flattening.BatchSizeMB = 1
+	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(jobDir, "csv", "Patient.csv"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "row-from-run1")
+	assert.Contains(t, string(content), "row-from-run2")
+
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	headerLine := lines[0]
+	assert.Contains(t, headerLine, "id")
+	assert.Equal(t, 1, strings.Count(string(content), headerLine+"\n"), "header must appear once")
+
+	partialFiles, err := filepath.Glob(filepath.Join(jobDir, "csv", "*"+services.PartialSuffix))
+	require.NoError(t, err)
+	assert.Empty(t, partialFiles)
+}
+
+// TestExecuteFlatteningStep_SiblingGroupFailureKeepsPartial verifies that when
+// one group fails, the flushed file of a sibling group stays a .partial file
+// and the step error names it
+func TestExecuteFlatteningStep_SiblingGroupFailureKeepsPartial(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fhir/ViewDefinition/$run" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"alpha-row"}` + "\n"))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("service error"))
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-sibling-group-failure"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+
+	urlAlpha := "https://example.com/PatientAlpha"
+	urlBeta := "https://example.com/PatientBeta"
+
+	crtdl := map[string]any{
+		"dataExtraction": map[string]any{
+			"attributeGroups": []map[string]any{
+				{
+					"id": "g-alpha", "name": "Alpha", "groupReference": urlAlpha,
+					"attributes": []map[string]any{{"attributeRef": "Patient.id", "mustHave": true}},
+				},
+				{
+					"id": "g-beta", "name": "Beta", "groupReference": urlBeta,
+					"attributes": []map[string]any{{"attributeRef": "Patient.id", "mustHave": true}},
+				},
+			},
+		},
+	}
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	crtdlData, err := json.Marshal(crtdl)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(crtdlPath, crtdlData, 0644))
+
+	lookup := []map[string]any{}
+	for _, url := range []string{urlAlpha, urlBeta} {
+		lookup = append(lookup, map[string]any{
+			"url": url, "resourceType": "Patient",
+			"elements": map[string]any{
+				"Patient.id": map[string]any{
+					"viewDefinition": map[string]any{
+						"select": []map[string]any{
+							{"column": []map[string]any{{"name": "id", "path": "id"}}},
+						},
+					},
+				},
+			},
+		})
+	}
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	lookupData, err := json.Marshal(lookup)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(lookupPath, lookupData, 0644))
+
+	// One patient per group, routed via provenance
+	patientAlpha := map[string]any{
+		"resourceType": "Patient", "id": "pa",
+		"meta": map[string]any{"profile": []any{urlAlpha}},
+	}
+	patientBeta := map[string]any{
+		"resourceType": "Patient", "id": "pb",
+		"meta": map[string]any{"profile": []any{urlBeta}},
+	}
+	bundle := makeBundle("b1",
+		patientAlpha, makeProvenance("prov-a", "Patient/pa", "g-alpha"),
+		patientBeta, makeProvenance("prov-b", "Patient/pb", "g-beta"),
+	)
+	writeTestNDJSON(t, filepath.Join(inputDir, "test.ndjson"), []map[string]any{bundle})
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err = runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.Error(t, err)
+	require.Equal(t, 2, callCount, "test needs one call per group")
+	assert.Contains(t, err.Error(), "Alpha.csv"+services.PartialSuffix)
+
+	csvDir := filepath.Join(jobDir, "csv")
+	assert.FileExists(t, filepath.Join(csvDir, "Alpha.csv"+services.PartialSuffix))
+	assert.NoFileExists(t, filepath.Join(csvDir, "Alpha.csv"))
+	assert.NoFileExists(t, filepath.Join(csvDir, "Beta.csv"))
+}
+
+// TestExecuteFlatteningStep_RemovesStalePartialFile verifies that a rerun
+// removes a stale .partial file, also when the group gets no new data
+func TestExecuteFlatteningStep_RemovesStalePartialFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-stale-partial"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	csvDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.MkdirAll(csvDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	groupID := "group-patient"
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	// A stale partial file from an earlier failed run
+	stalePartial := filepath.Join(csvDir, "Patient.csv"+services.PartialSuffix)
+	require.NoError(t, os.WriteFile(stalePartial, []byte("id\nstale-row\n"), 0644))
+
+	// The input routes no resources to the group, so the group never flushes
+	patient := map[string]any{
+		"resourceType": "Patient", "id": "1",
+		"meta": map[string]any{"profile": []any{profileURL}},
+	}
+	prov := makeProvenance("prov-1", "Patient/1", "unrelated-group")
+	bundle := makeBundle("b1", patient, prov)
+	writeTestNDJSON(t, filepath.Join(inputDir, "test.ndjson"), []map[string]any{bundle})
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, stalePartial)
+	assert.NoFileExists(t, filepath.Join(csvDir, "Patient.csv"))
+}
+
+// TestExecuteFlatteningStep_RemoveStalePartialError verifies that the step
+// fails when it cannot clear a stale partial file, rather than appending to it
+func TestExecuteFlatteningStep_RemoveStalePartialError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Cannot test permission errors as root")
+	}
+
+	tempDir := t.TempDir()
+	jobID := "test-stale-partial-error"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	csvDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.MkdirAll(csvDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	writeTestCRTDL(t, crtdlPath, "group-patient", "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	ndjsonContent := `{"resourceType":"Patient","id":"1","meta":{"profile":["https://example.com/Patient"]}}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "test.ndjson"), []byte(ndjsonContent), 0644))
+
+	// A stale partial file in a directory that no longer allows writes
+	stalePartial := filepath.Join(csvDir, "Patient.csv"+services.PartialSuffix)
+	require.NoError(t, os.WriteFile(stalePartial, []byte("id\nstale-row\n"), 0644))
+	require.NoError(t, os.Chmod(csvDir, 0555))
+	t.Cleanup(func() { _ = os.Chmod(csvDir, 0755) })
+
+	job := createFlatteningTestJob("http://localhost:8080", lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove stale partial CSV file")
+
+	// The stale rows stay untouched, so no retry reports them as its own
+	content, readErr := os.ReadFile(stalePartial)
+	require.NoError(t, readErr)
+	assert.Equal(t, "id\nstale-row\n", string(content))
+}
+
+// TestExecuteFlatteningStep_FinalizeError verifies that a failed rename keeps
+// the output as .partial and names it, instead of reporting a complete export
+func TestExecuteFlatteningStep_FinalizeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fhir/ViewDefinition/$run" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"id":"patient-1"}`+"\n")
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	jobID := "test-finalize-error"
+	jobDir := filepath.Join(tempDir, "jobs", jobID)
+	inputDir := filepath.Join(jobDir, "import")
+	csvDir := filepath.Join(jobDir, "csv")
+	require.NoError(t, os.MkdirAll(inputDir, 0755))
+	require.NoError(t, os.MkdirAll(csvDir, 0755))
+
+	profileURL := "https://example.com/Patient"
+	groupID := "group-patient"
+	crtdlPath := filepath.Join(tempDir, "test.json")
+	writeTestCRTDL(t, crtdlPath, groupID, "Patient", profileURL)
+
+	lookupPath := filepath.Join(tempDir, "lookup.json")
+	writeTestLookupTable(t, lookupPath, profileURL, "Patient")
+
+	patient := map[string]any{
+		"resourceType": "Patient", "id": "1",
+		"meta": map[string]any{"profile": []any{profileURL}},
+	}
+	prov := makeProvenance("prov-1", "Patient/1", groupID)
+	bundle := makeBundle("b1", patient, prov)
+	writeTestNDJSON(t, filepath.Join(inputDir, "test.ndjson"), []map[string]any{bundle})
+
+	// A directory sits at the final name, so the rename of the partial fails
+	finalPath := filepath.Join(csvDir, "Patient.csv")
+	require.NoError(t, os.MkdirAll(finalPath, 0755))
+
+	job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
+	logger := createFlatteningTestLogger()
+
+	err := runPipelineStep(models.StepFlattening, job, jobDir, logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to finalize CSV for group 'Patient'")
+
+	// The rows stay under the .partial name, never under the final name
+	assert.FileExists(t, filepath.Join(csvDir, "Patient.csv"+services.PartialSuffix))
 }
 
 // TestExecuteFlatteningStep_FlattenerError verifies fail-fast on flattener error
@@ -1096,19 +1487,7 @@ func TestExecuteFlatteningStep_FlattenerErrorDuringFlush(t *testing.T) {
 		inputDir := filepath.Join(jobDir, "import")
 		require.NoError(t, os.MkdirAll(inputDir, 0755))
 
-		// Create enough Bundles with Provenance to exceed 1MB batch threshold
-		var bundles []map[string]any
-		for i := 0; i < 110; i++ {
-			patientID := fmt.Sprintf("p%d", i)
-			patient := map[string]any{
-				"resourceType": "Patient", "id": patientID,
-				"meta": map[string]any{"profile": []any{profileURL}},
-				"name": []any{map[string]any{"family": fmt.Sprintf("%s_%d", longName, i)}},
-			}
-			prov := makeProvenance(fmt.Sprintf("prov-%d", i), "Patient/"+patientID, groupID)
-			bundles = append(bundles, makeBundle(fmt.Sprintf("b-%d", i), patient, prov))
-		}
-		writeTestNDJSON(t, filepath.Join(inputDir, "patients.ndjson"), bundles)
+		writeTestNDJSON(t, filepath.Join(inputDir, "patients.ndjson"), makeLargePatientBundles(profileURL, groupID))
 
 		job := createFlatteningTestJob(server.URL, lookupPath, crtdlPath)
 		job.Config.Services.Flattening.BatchSizeMB = 1


### PR DESCRIPTION
Closes #669

## Problem

When a batch failed in the flattening step, the CSV file it was building stayed on disk under its final name, with the expected header and a plausible row count. Nothing marked it as incomplete. The writer also dropped the errors of `Flush` and `Close`, so a write fault could produce a truncated file and a reported success.

## Changes

- `CSVWriter.AppendCSVData` and `CSVWriter.WriteCSV` write to `<name>.csv.partial`.
- `CSVWriter.Finalize` renames the partial file to its final name. The flattening step calls it per group after the last batch flushes. The rename is atomic within one directory, so `<name>.csv` exists only when it is complete.
- On failure, the `.partial` files stay in place for debugging, and the step error names them: `(incomplete output kept as: Patient.csv.partial)`.
- `CSVWriter.RemovePartials` deletes stale `.partial` files at step start, so a retry never keeps rows from an earlier failed run. The sweep also covers groups that no longer exist in the CRTDL.
- `writeRecords` reports the errors of `Flush` and `Close` through a named return. On a network mount, a write fault commonly appears only at `Close`. `WriteCSVDirect` needs no change, because `os.WriteFile` already reports the `Close` error.

## Tests

- A failed batch leaves `<name>.csv.partial` and no `<name>.csv`, and the error names the partial file.
- A successful run leaves `<name>.csv` and no `.partial` file.
- A rerun after a failure does not double the rows and does not repeat the header.
- When a sibling group fails, a flushed group stays `.partial` and appears in the error.
- A rerun removes a stale `.partial` file, also when the group gets no new data.
- A writer that fails at `Flush` or `Close` returns an error; an earlier error keeps precedence.