### PR TITLE
fix(flattening): drop the deprecated 'parent' warning in lookup tables

### DIFF
--- a/internal/pipeline/flattening.go
+++ b/internal/pipeline/flattening.go
@@ -73,7 +73,7 @@ func (flatteningStep) Run(ctx *StepContext) (StepResult, error) {
 	// Load lookup tables (LoadLookupTables normalizes and validates them)
 	lookupPath := job.Config.Services.Flattening.LookupPath
 	logger.Debug("Loading lookup tables", "path", lookupPath)
-	lookupTables, err := services.LoadLookupTables(lookupPath, logger)
+	lookupTables, err := services.LoadLookupTables(lookupPath)
 	if err != nil {
 		return StepResult{}, fmt.Errorf("failed to load lookup tables: %w", err)
 	}

--- a/internal/services/lookup_parser.go
+++ b/internal/services/lookup_parser.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 
-	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 )
 
@@ -14,8 +12,7 @@ import (
 // The file contains an array of LookupTable objects
 // The tables are normalized and validated; a file whose children lists form
 // a cycle is rejected here, so every loaded table set is safe for the builder.
-// A nil logger suppresses the deprecation warning for authored parent fields.
-func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, error) {
+func LoadLookupTables(path string) ([]models.LookupTable, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read lookup file: %w", err)
@@ -39,7 +36,7 @@ func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, er
 		}
 	}
 
-	if err := NormalizeLookupTables(tables, logger); err != nil {
+	if err := NormalizeLookupTables(tables); err != nil {
 		return nil, err
 	}
 
@@ -54,23 +51,15 @@ func LoadLookupTables(path string, logger *lib.Logger) ([]models.LookupTable, er
 // Authored parent values are ignored: each Parent is cleared and set to the
 // element whose Children list names it. A child that two elements claim, or
 // that one Children list names twice, is an error.
-// Authored parent fields are deprecated; when logger is non-nil, each profile
-// that sets them produces one warning.
-func NormalizeLookupTables(tables []models.LookupTable, logger *lib.Logger) error {
+// Authored parent fields are deprecated and dropped without a warning; the
+// field will be removed in a future flatten-lookup version.
+func NormalizeLookupTables(tables []models.LookupTable) error {
 	for _, table := range tables {
-		var authored []string
 		for elementID, element := range table.Elements {
 			if element.Parent != "" {
-				authored = append(authored, elementID)
 				element.Parent = ""
 				table.Elements[elementID] = element
 			}
-		}
-		if len(authored) > 0 && logger != nil {
-			sort.Strings(authored)
-			logger.Warn("lookup table sets deprecated 'parent' fields; the values are ignored and derived from 'children' lists instead, and the field will be removed in a future flatten-lookup version",
-				"profile", table.URL,
-				"elements", authored)
 		}
 
 		claimedBy := make(map[string]string)

--- a/tests/compat/flattening_lookup_compat_test.go
+++ b/tests/compat/flattening_lookup_compat_test.go
@@ -29,7 +29,7 @@ func TestReleasedFlatteningLookup(t *testing.T) {
 		t.Skipf("%s not set; set it to a flatteningLookup.json from a fhir-ontology-generator release", lookupPathEnv)
 	}
 
-	tables, err := services.LoadLookupTables(path, nil)
+	tables, err := services.LoadLookupTables(path)
 	require.NoError(t, err, "released lookup file must load")
 	require.NotEmpty(t, tables, "released lookup file must contain profiles")
 

--- a/tests/unit/lookup_parser_test.go
+++ b/tests/unit/lookup_parser_test.go
@@ -1,7 +1,6 @@
 package unit
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/medizininformatik-initiative/aether/internal/lib"
 	"github.com/medizininformatik-initiative/aether/internal/models"
 	"github.com/medizininformatik-initiative/aether/internal/services"
 )
@@ -35,7 +33,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath, nil)
+		tables, err := services.LoadLookupTables(lookupPath)
 		require.NoError(t, err)
 		assert.Len(t, tables, 1)
 		assert.Equal(t, "https://example.com/Patient", tables[0].URL)
@@ -61,7 +59,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath, nil)
+		tables, err := services.LoadLookupTables(lookupPath)
 		require.NoError(t, err)
 		assert.Len(t, tables, 2)
 	})
@@ -73,7 +71,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing 'url' field")
 	})
@@ -85,13 +83,13 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing 'resourceType' field")
 	})
 
 	t.Run("file not found", func(t *testing.T) {
-		_, err := services.LoadLookupTables("/nonexistent/path/lookup.json", nil)
+		_, err := services.LoadLookupTables("/nonexistent/path/lookup.json")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read lookup file")
 	})
@@ -102,7 +100,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte("not valid json"), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse lookup file")
 	})
@@ -123,7 +121,7 @@ func TestLoadLookupTables(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "circular")
 	})
@@ -225,7 +223,7 @@ func TestLoadLookupTablesMissingElements(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing 'elements' field")
 	})
@@ -256,7 +254,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath, nil)
+		tables, err := services.LoadLookupTables(lookupPath)
 		require.NoError(t, err)
 		child := tables[0].Elements["Encounter.extension:A.extension:B"]
 		assert.Equal(t, "Encounter.extension:A", child.Parent)
@@ -284,7 +282,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath, nil)
+		tables, err := services.LoadLookupTables(lookupPath)
 		require.NoError(t, err)
 		child := tables[0].Elements["Encounter.extension:A.extension:B"]
 		assert.Equal(t, "Encounter.extension:A", child.Parent)
@@ -311,7 +309,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		tables, err := services.LoadLookupTables(lookupPath, nil)
+		tables, err := services.LoadLookupTables(lookupPath)
 		require.NoError(t, err)
 		child := tables[0].Elements["Encounter.extension:A.extension:B"]
 		assert.Empty(t, child.Parent)
@@ -331,7 +329,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 			},
 		}
 
-		err := services.NormalizeLookupTables(tables, nil)
+		err := services.NormalizeLookupTables(tables)
 		require.NoError(t, err)
 		assert.Equal(t, "Encounter.extension:A", tables[0].Elements["Encounter.extension:A.extension:B"].Parent)
 		assert.NotContains(t, tables[0].Elements, "Encounter.extension:A.extension:Missing")
@@ -362,7 +360,7 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		// Map order decides which parent backfills first and which one the
 		// error names, so assert only the child ID.
@@ -390,75 +388,10 @@ func TestLoadLookupTablesNormalizesParentLinks(t *testing.T) {
 		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
 		require.NoError(t, err)
 
-		_, err = services.LoadLookupTables(lookupPath, nil)
+		_, err = services.LoadLookupTables(lookupPath)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Encounter.extension:A.extension:B")
 		assert.Contains(t, err.Error(), "listed more than once")
-	})
-}
-
-func TestLoadLookupTablesWarnsOnAuthoredParentFields(t *testing.T) {
-	t.Run("warns once per profile that sets deprecated parent fields", func(t *testing.T) {
-		tempDir := t.TempDir()
-		lookupPath := filepath.Join(tempDir, "lookup.json")
-		lookupJSON := `[
-			{
-				"url": "https://example.com/Encounter",
-				"resourceType": "Encounter",
-				"elements": {
-					"Encounter.extension:A": {
-						"children": ["Encounter.extension:A.extension:B"],
-						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
-					},
-					"Encounter.extension:A.extension:B": {
-						"parent": "Encounter.extension:A",
-						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
-					}
-				}
-			}
-		]`
-		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
-		require.NoError(t, err)
-
-		var logBuf bytes.Buffer
-		logger := lib.NewLoggerWithWriter(lib.LogLevelWarn, &logBuf)
-
-		_, err = services.LoadLookupTables(lookupPath, logger)
-		require.NoError(t, err)
-
-		logOutput := logBuf.String()
-		assert.Contains(t, logOutput, "deprecated")
-		assert.Contains(t, logOutput, "https://example.com/Encounter")
-		assert.Contains(t, logOutput, "Encounter.extension:A.extension:B")
-	})
-
-	t.Run("stays silent when no parent fields are set", func(t *testing.T) {
-		tempDir := t.TempDir()
-		lookupPath := filepath.Join(tempDir, "lookup.json")
-		lookupJSON := `[
-			{
-				"url": "https://example.com/Encounter",
-				"resourceType": "Encounter",
-				"elements": {
-					"Encounter.extension:A": {
-						"children": ["Encounter.extension:A.extension:B"],
-						"viewDefinition": {"forEachOrNull": "extension.where(url = 'A')"}
-					},
-					"Encounter.extension:A.extension:B": {
-						"viewDefinition": {"forEachOrNull": "extension.where(url = 'B')"}
-					}
-				}
-			}
-		]`
-		err := os.WriteFile(lookupPath, []byte(lookupJSON), 0644)
-		require.NoError(t, err)
-
-		var logBuf bytes.Buffer
-		logger := lib.NewLoggerWithWriter(lib.LogLevelWarn, &logBuf)
-
-		_, err = services.LoadLookupTables(lookupPath, logger)
-		require.NoError(t, err)
-		assert.Empty(t, logBuf.String())
 	})
 }
 

--- a/tests/unit/viewdefinition_builder_test.go
+++ b/tests/unit/viewdefinition_builder_test.go
@@ -1150,7 +1150,7 @@ func TestParentChildRefsFromChildrenListOnly(t *testing.T) {
 				},
 			}),
 		}
-		require.NoError(t, services.NormalizeLookupTables(lookupTables, nil))
+		require.NoError(t, services.NormalizeLookupTables(lookupTables))
 
 		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
 			"Encounter.extension:Aufnahmegrund",
@@ -1186,7 +1186,7 @@ func TestParentChildRefsFromChildrenListOnly(t *testing.T) {
 				},
 			}),
 		}
-		require.NoError(t, services.NormalizeLookupTables(lookupTables, nil))
+		require.NoError(t, services.NormalizeLookupTables(lookupTables))
 
 		group := newAttributeGroup("Encounter", "https://example.com/Encounter",
 			"Encounter.extension:Aufnahmegrund.extension:ErsteUndZweiteStelle",


### PR DESCRIPTION
## Summary

`NormalizeLookupTables` warned once per profile that sets the deprecated `parent` field. A lookup file with many profiles flooded the log with repeated warnings.

The warning is not actionable: the lookup file comes from the fhir-ontology-generator, and the authored values are ignored in every case. This change removes the warning completely.

The `logger` parameter of `NormalizeLookupTables` and `LoadLookupTables` served only that message, so it is removed too. Normalization behavior is unchanged: authored `parent` values are still cleared, and the parent links are still derived from the `children` lists.

## Changes

- `internal/services/lookup_parser.go`: drop the warning and the `logger` parameter of both functions.
- `internal/pipeline/flattening.go`: adjust the call site.
- Tests: delete the warning tests; adjust the call sites. The normalization tests in `TestLoadLookupTablesNormalizesParentLinks` continue to cover that authored values are cleared and derived.

Closes #672
