### PR TITLE
ci: run in-package tests under coverage

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -58,7 +58,7 @@ jobs:
           cache: true
 
       - name: Run tests with coverage
-        run: go test -coverpkg=./internal/... -coverprofile=coverage.txt ./tests/...
+        run: go test -coverpkg=./internal/... -coverprofile=coverage.txt ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test-fuzz:
 ## coverage: Run tests with coverage report
 coverage:
 	@echo "Running tests with coverage..."
-	$(GOTEST) -coverpkg=./internal/... -coverprofile=coverage.out ./tests/...
+	$(GOTEST) -coverpkg=./internal/... -coverprofile=coverage.out ./...
 	$(GOCMD) tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"
 


### PR DESCRIPTION
## Problem

The coverage command listed only `./tests/...`, so test files that live beside the code they test never ran. Their coverage counted for nothing, while `-coverpkg` kept the denominator at all of `./internal/...`.

## Change

Use `./...` in place of `./tests/...` in two places:

| File | Target |
|---|---|
| `.github/workflows/_tests.yaml` | the CI coverage gate |
| `Makefile` | `coverage` |

`./...` matches what `make test` already runs, and it cannot drift when a new test tree appears. `-coverpkg` still holds the denominator to `./internal/...`, so `cmd/` and `tests/` do not dilute the number.

## Effect

Nine in-package test files exist under `internal/` today. With the same denominator:

- old command (`./tests/...`): 92.4%
- new command (`./...`): 93.1%

## Not changed

`Makefile:113` and `Makefile:123` (`test-unit-coverage`, `test-integration-coverage`) still scope to one tree. No CI job and no document uses them, and the single-tree scope is deliberate.

Closes #674